### PR TITLE
Tell "the host didn't answer" apart from "we refuse that address"

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Surfguard.resolve_public_ips("feeds.example.com")
 
 # Non-pinning caller (hands the hostname straight to Net::HTTP, which resolves again):
 Surfguard.resolvable_public_ip?("https://feeds.example.com/atom")  # => true only if EVERY address is public
-Surfguard.enforce_public_ip(url)                                   # raises Surfguard::Violation otherwise
+Surfguard.enforce_public_ip(url)                                   # raises otherwise
 
 # Single-address compatibility shim:
 Surfguard.resolve_public_ip(url)   # => "93.184.216.34" or nil
@@ -28,6 +28,25 @@ Surfguard.resolve_public_ip(url)   # => "93.184.216.34" or nil
 # The classification core, if you already hold an address:
 Surfguard.blocked_address?(IPAddr.new("169.254.169.254"))  # => true
 ```
+
+## Refused vs. unresolvable
+
+"We refuse that address" and "the host didn't answer" are different answers, and
+collapsing them bites callers that treat a refusal as permanent. A webhook that
+deactivates a customer's endpoint on `Violation` would retire it on one bad DNS
+minute if a failed lookup arrived the same way.
+
+| | resolves to something public | resolves, all blocked | resolves to nothing | malformed URL |
+|---|---|---|---|---|
+| `resolve_public_ips` (takes a host) | the public addresses | `[]` | raises `Unresolvable` | — |
+| `resolve_public_ip` | first public address | `nil` | raises `Unresolvable` | `nil` |
+| `enforce_public_ip` | returns | raises `Violation` | raises `Unresolvable` | raises `Violation` |
+| `resolvable_public_ip?` | `true` | `false` | `false` | `false` |
+
+`Unresolvable` is **not** a subclass of `Violation` — that's the whole point.
+Rescue both where you don't care which it was. Note the predicate answers the
+question it was asked and never raises; use `enforce_public_ip` or
+`resolve_public_ip` when you need to tell the cases apart.
 
 ## The policy
 

--- a/lib/surfguard.rb
+++ b/lib/surfguard.rb
@@ -39,6 +39,14 @@ require_relative "surfguard/version"
 module Surfguard
   class Violation < StandardError; end
 
+  # The host answered with no address at all. Deliberately NOT a Violation:
+  # nothing was refused here, the lookup simply came back empty, which is
+  # usually a transient upstream failure. A caller that gives up permanently on
+  # a Violation -- a webhook deactivating a customer's endpoint, say -- must not
+  # give up the same way on this, or one bad DNS minute retires the endpoint for
+  # good. Callers that don't care can rescue both.
+  class Unresolvable < StandardError; end
+
   extend self
 
   # IPv4 special-use ranges that must never be a fetch target (RFC 5735/6890,
@@ -102,20 +110,27 @@ module Surfguard
 
   # Every PUBLIC address the host resolves to, IPv4 ahead of IPv6, DNS order
   # preserved within each family so a provider's round-robin still spreads load.
-  # Empty when nothing usable resolves — the caller's signal to refuse. A caller
-  # that fails over MUST iterate this list and pin each address; resolving again
-  # reopens the rebinding window. Accepts a hostname or an IP-literal host.
+  # Empty when the host resolves but every address is blocked; raises
+  # Unresolvable when it resolves to nothing at all, so the caller can tell a
+  # refusal from a lookup failure. A caller that fails over MUST iterate this
+  # list and pin each address; resolving again reopens the rebinding window.
+  # Accepts a hostname or an IP-literal host.
   def resolve_public_ips(host)
-    resolve(host).reject { |ip| blocked_address?(ip) }
-                 .partition(&:ipv4?)
-                 .flatten
-                 .map(&:to_s)
+    addresses = resolve(host)
+    raise Unresolvable, "No address for #{host}" if addresses.empty?
+
+    addresses.reject { |ip| blocked_address?(ip) }
+             .partition(&:ipv4?)
+             .flatten
+             .map(&:to_s)
   end
 
   # True only if the URL's host resolves to at least one address and NONE are
   # blocked. For non-pinning callers (they hand the hostname straight to
   # Net::HTTP, which resolves again), so anything short of "every address is
-  # public" is unsafe. Returns false on an unresolvable or malformed host.
+  # public" is unsafe. A predicate answers the question it was asked and doesn't
+  # raise: false covers unresolvable and malformed alike. Reach for
+  # .enforce_public_ip or .resolve_public_ip when you need to tell those apart.
   def resolvable_public_ip?(url)
     addresses = resolve(host_of(url))
     addresses.any? && addresses.none? { |ip| blocked_address?(ip) }
@@ -123,19 +138,29 @@ module Surfguard
     false
   end
 
-  # Raise Surfguard::Violation unless the URL's host is safe (see
-  # .resolvable_public_ip?). For call sites that want a hard stop, not a boolean.
+  # Raise unless the URL's host is safe, for call sites that want a hard stop
+  # rather than a boolean: Unresolvable when it answers with nothing, Violation
+  # when it answers with something we refuse. A malformed URL is a Violation --
+  # there was never a lookup to fail.
   def enforce_public_ip(url)
-    raise Violation, "Refusing to fetch private/internal address for #{url}" unless resolvable_public_ip?(url)
+    addresses = resolve(host_of(url))
+    raise Unresolvable, "No address for #{url}" if addresses.empty?
+    raise Violation, "Refusing to fetch private/internal address for #{url}" if addresses.any? { |ip| blocked_address?(ip) }
+  rescue URI::InvalidURIError, IPAddr::InvalidAddressError, ArgumentError
+    raise Violation, "Refusing to fetch malformed address for #{url}"
   end
 
   # The single-address compatibility shim for callers migrating from an older
-  # first-address-only guard. Returns the first public address as a String, or nil
-  # if the host is unresolvable, malformed, or resolves to anything blocked. Prefer
-  # .resolve_public_ips for new code.
+  # first-address-only guard. Returns the first public address as a String, nil
+  # if the host is malformed or resolves to anything blocked, and raises
+  # Unresolvable if it resolves to nothing -- which is where an older guard
+  # built on Resolv.getaddress raised Resolv::ResolvError, so callers that
+  # distinguished a lookup failure keep doing so. Prefer .resolve_public_ips.
   def resolve_public_ip(url)
     addresses = resolve(host_of(url))
-    return nil if addresses.empty? || addresses.any? { |ip| blocked_address?(ip) }
+    raise Unresolvable, "No address for #{url}" if addresses.empty?
+    return nil if addresses.any? { |ip| blocked_address?(ip) }
+
     addresses.first.to_s
   rescue URI::InvalidURIError, IPAddr::InvalidAddressError, ArgumentError
     nil
@@ -171,16 +196,33 @@ module Surfguard
   # Resolv.getaddresses — the Hosts+DNS chain, matching what the connection layer
   # will use, and returning every address. Returns [IPAddr].
   def resolve(host)
-    [ IPAddr.new(host) ]
-  rescue IPAddr::InvalidAddressError
-    Resolv.getaddresses(host).map { |a| IPAddr.new(a) }
+    literal = ip_literal(host)
+
+    if literal
+      [ literal ]
+    else
+      Resolv.getaddresses(host).map { |a| IPAddr.new(a) }
+    end
   rescue Resolv::ResolvError, Resolv::ResolvTimeout
     []
   end
 
+  # nil for anything that isn't already an address. Kept separate so the DNS
+  # call above sits in the method body, where the ResolvError rescue can reach
+  # it — inside a sibling rescue clause it could not.
+  def ip_literal(host)
+    IPAddr.new(host)
+  rescue IPAddr::InvalidAddressError
+    nil
+  end
+
   def host_of(url)
-    # URI#host keeps IPv6 brackets ([::1]); IPAddr.new does not want them.
-    host = URI.parse(url).host or raise URI::InvalidURIError, "no host in #{url.inspect}"
+    # URI#host is "" for "http://" and nil when there's no authority at all.
+    # Neither is a name to look up, so both are malformed rather than a lookup
+    # that failed. URI#host keeps IPv6 brackets ([::1]); IPAddr.new won't take them.
+    host = URI.parse(url).host
+    raise URI::InvalidURIError, "no host in #{url.inspect}" if host.nil? || host.empty?
+
     host.delete_prefix("[").delete_suffix("]")
   end
 

--- a/test/surfguard_test.rb
+++ b/test/surfguard_test.rb
@@ -156,4 +156,67 @@ class SurfguardTest < Minitest::Test
     refute Surfguard.resolvable_public_ip?("http://")
     assert_nil Surfguard.resolve_public_ip("::::not a url")
   end
+
+  # --- unresolvable is not a refusal ------------------------------------------
+
+  def test_unresolvable_is_not_a_violation
+    # The distinction is the point: a caller that stops retrying on Violation
+    # must not stop on a lookup that merely came back empty.
+    refute_includes Surfguard::Unresolvable.ancestors, Surfguard::Violation
+  end
+
+  def test_resolve_public_ip_raises_unresolvable_when_nothing_resolves
+    stub_getaddresses({}) do
+      assert_raises(Surfguard::Unresolvable) do
+        Surfguard.resolve_public_ip("https://nope.example")
+      end
+    end
+  end
+
+  def test_resolve_public_ip_returns_nil_when_resolved_but_blocked
+    # Blocked is nil, not Unresolvable — the host answered, we refused it.
+    stub_getaddresses("bad.example" => %w[169.254.169.254]) do
+      assert_nil Surfguard.resolve_public_ip("https://bad.example")
+    end
+  end
+
+  def test_resolve_public_ips_raises_unresolvable_when_nothing_resolves
+    stub_getaddresses({}) do
+      assert_raises(Surfguard::Unresolvable) do
+        Surfguard.resolve_public_ips("nope.example")
+      end
+    end
+  end
+
+  def test_resolve_public_ips_returns_empty_when_resolved_but_all_blocked
+    stub_getaddresses("bad.example" => %w[10.0.0.1 169.254.169.254]) do
+      assert_empty Surfguard.resolve_public_ips("bad.example")
+    end
+  end
+
+  def test_enforce_raises_unresolvable_rather_than_violation
+    stub_getaddresses({}) do
+      assert_raises(Surfguard::Unresolvable) do
+        Surfguard.enforce_public_ip("https://nope.example")
+      end
+    end
+  end
+
+  def test_enforce_raises_violation_on_malformed_url
+    assert_raises(Surfguard::Violation) do
+      Surfguard.enforce_public_ip("http://")
+    end
+  end
+
+  def test_resolver_errors_resolve_to_nothing
+    # Resolv.getaddresses runs in the method body, not inside another rescue
+    # clause, so the ResolvError rescue actually covers it.
+    original = Resolv.method(:getaddresses)
+    Resolv.define_singleton_method(:getaddresses) { |_host| raise Resolv::ResolvError }
+    assert_raises(Surfguard::Unresolvable) do
+      Surfguard.resolve_public_ips("boom.example")
+    end
+  ensure
+    Resolv.define_singleton_method(:getaddresses, original)
+  end
 end


### PR DESCRIPTION
"The host didn't answer" and "we refuse that address" arrived as the same `nil`, empty list, or `false`. That reads fine until a caller treats a refusal as permanent — a webhook that deactivates a customer's endpoint when the guard refuses it would retire that endpoint on one bad DNS minute, because a lookup returning nothing was indistinguishable from a lookup returning the metadata address.

A refusal is a statement about the address. An empty lookup is a statement about the moment. So a host that resolves to nothing now raises `Unresolvable`, **deliberately not a subclass of `Violation`** — callers that don't care can rescue both, and the ones that do can finally choose.

| | resolves to something public | resolves, all blocked | resolves to nothing | malformed URL |
|---|---|---|---|---|
| `resolve_public_ips` (takes a host) | the public addresses | `[]` | raises `Unresolvable` | — |
| `resolve_public_ip` | first public address | `nil` | raises `Unresolvable` | `nil` |
| `enforce_public_ip` | returns | raises `Violation` | raises `Unresolvable` | raises `Violation` |
| `resolvable_public_ip?` | `true` | `false` | `false` | `false` |

`resolvable_public_ip?` still answers `false` either way — a predicate answers the question it was asked and doesn't raise.

This is also where a guard built on `Resolv.getaddress` used to raise `Resolv::ResolvError`, so callers migrating from one keep a distinction they already had rather than silently losing it.

## Two bugs the tests turned up

**The resolver's `ResolvError` rescue was dead code.** `Resolv.getaddresses` sat inside the `rescue IPAddr::InvalidAddressError` clause that detects an IP literal, and sibling rescue clauses don't catch each other — so the `rescue Resolv::ResolvError, Resolv::ResolvTimeout` below it could never fire. Only reachable through a resolver configured to raise timeout errors, so nothing was breaking today, but it read as protection it wasn't providing. The literal check moves into its own method and the DNS call moves back into the body where the rescue reaches it.

**A blank host resolved to nothing instead of being refused.** `URI#host` is `""` for `"http://"`, not `nil`, so it slipped past `host_of` and came back as a failed lookup. There was never a name to look up — that's malformed, and it now says so.

## Compatibility

Breaking for anyone relying on `resolve_public_ip`/`resolve_public_ips` returning `nil`/`[]` for an unresolvable host, or on `enforce_public_ip` raising `Violation` for one. Rescuing `Unresolvable` alongside `Violation` restores the old behavior exactly.

63 tests green on the existing suite plus the new cases.
