### PR TITLE
Add a security policy: report privately via GHSA, not the issue tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,11 @@ ruby -Ilib test/surfguard_test.rb
 # 55 runs, 59 assertions — the full BLOCKED/ALLOWED matrix, checked as execution.
 ```
 
+## Security
+
+Surfguard is a security control, so classification bugs are vulnerabilities. Report them privately
+via [SECURITY.md](SECURITY.md) — not the public issue tracker.
+
 ## Status
 
 `0.1.0` — extracted and consolidated from several in-house SSRF guards, tested against the full

--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ ruby -Ilib test/surfguard_test.rb
 ## Security
 
 Surfguard is a security control, so classification bugs are vulnerabilities. Report them privately
-via [SECURITY.md](SECURITY.md) — not the public issue tracker.
+per the [security policy](https://github.com/basecamp/surfguard/security/policy) — not the public
+issue tracker.
 
 ## Status
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,39 @@
+# Security Policy
+
+Surfguard is a security control — an SSRF address guard — so classification bugs are security
+vulnerabilities, not ordinary defects. Please report them privately.
+
+## Reporting a vulnerability
+
+Report privately via GitHub's vulnerability reporting:
+[**Report a vulnerability**](https://github.com/basecamp/surfguard/security/advisories/new)
+(the repo's **Security** tab → **Report a vulnerability**).
+
+Open-source reports aren't bounty-eligible, but we also accept them via
+[hackerone.com/basecamp](https://hackerone.com/basecamp) if you'd like the report on your
+HackerOne record — see the
+[37signals security response policy](https://37signals.com/policies/security/response/).
+
+**Do not open a public issue for security bugs.**
+
+## What qualifies
+
+Anything that lets a blocked address through, for example:
+
+- An address in a blocked range that Surfguard classifies as public.
+- A resolution path (encoding, embedding, transition mechanism) that reaches a blocked address
+  despite validation.
+- A discrepancy between what Surfguard validates and what a caller following the documented
+  pinning contract would connect to.
+
+Non-security bugs and questions belong in the
+[regular issue tracker](https://github.com/basecamp/surfguard/issues).
+
+## Supported versions
+
+The latest released version. Fixes ship as a new release, not backports.
+
+## What to expect
+
+We'll acknowledge your report, work with you on a fix, and coordinate disclosure through a
+GitHub Security Advisory. Reporters are credited in the advisory unless they prefer otherwise.


### PR DESCRIPTION
Surfguard is an SSRF guard, so classification bugs are vulnerabilities — the kind of report this repo should route privately, and today nothing tells a researcher how.

This adds a SECURITY.md:

- **Reporting**: GitHub private vulnerability reporting (already enabled on this repo), with a direct link to the advisory form. HackerOne (https://hackerone.com/basecamp) accepted as an alternative for researchers who want the report on their H1 record — no bounty, per the [37signals response policy](https://37signals.com/policies/security/response/).
- **What qualifies**: a blocked-range address classified as public, a resolution path that lets a blocked address through, or a validate-vs-connect discrepancy under the documented pinning contract. Non-security bugs → issue tracker.
- **Supported versions**: latest release only.
- **Expectations**: acknowledgment, GHSA-coordinated fix and disclosure, reporter credit.

The README gains a short "Security" section linking the policy by absolute URL, so it works from GitHub and from the packaged gem (which ships README.md but not SECURITY.md). Gemspec untouched — SECURITY.md is a repo artifact, not gem payload.

Pairs with basecamp/.github#17, which adds the org-wide default; this repo-specific policy takes precedence for surfguard.