### PR TITLE
surfguard 0.1.0 is published: drop the pre-release hedging

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,6 @@ full IPv4 × IPv6 range matrix.
 
 ## Installation
 
-Not yet published to RubyGems — `v0.1.0` will be the first packaged release. Until it ships,
-install from source:
-
-```ruby
-gem "surfguard", github: "basecamp/surfguard"
-```
-
-Once `v0.1.0` is published:
-
 ```ruby
 gem "surfguard"
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,8 +31,7 @@ Non-security bugs and questions belong in the
 
 ## Supported versions
 
-No packaged release exists yet, so `main` is the supported version. Once releases ship, it
-becomes the latest released version. Fixes ship as a new release, not backports.
+The latest released version. Fixes ship as a new release, not backports.
 
 ## What to expect
 


### PR DESCRIPTION
Now that v0.1.0 is live on RubyGems, flip the two spots that were deliberately written for the unpublished state:

- **README**: Installation drops the "not yet published — install from source" caveat and is just `gem "surfguard"`.
- **SECURITY.md**: supported version goes from `main` to the latest released version.

Verified against the published release: RubyGems, the GitHub Release asset, and the attestation subject all carry digest `1f4cd4d…`, and `gh attestation verify` passes constrained by `--signer-workflow release.yml --source-ref refs/tags/v0.1.0` (and fails on a wrong ref, confirming the constraint binds).