### PR TITLE
Fix SSRF classification bypasses and harden publishing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,9 @@
-# Release-sensitive paths require Jeremy's review. Deliberately scoped — no
-# `*` rule and no Gemfile.lock rule — so Dependabot's bundler lockfile PRs
-# don't deadlock on code-owner review, and lib/ + test/ PRs are gated by the
-# >= 1 approving review rule plus the required CI check instead.
+# Release- and security-sensitive paths require Jeremy's review. Deliberately
+# scoped — no `*` rule and no Gemfile.lock rule — so Dependabot's bundler
+# lockfile PRs don't deadlock on code-owner review. Tests remain gated by the
+# >= 1 approving review rule plus the required CI check.
 /.github/            @jeremy
+/lib/                @jeremy
 /Rakefile            @jeremy
 /surfguard.gemspec   @jeremy
 /Gemfile             @jeremy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,19 +115,21 @@ jobs:
           name: rubygem
           path: surfguard-${{ steps.version.outputs.version }}.gem
           if-no-files-found: error
-      # The publish/confirm jobs run these scripts but never check out the
-      # repo; the scripts travel by artifact from this (trusted, unprivileged)
-      # checkout instead.
+      # The unprivileged confirm job runs these scripts without checking out
+      # the repo. The OIDC-capable publish job deliberately does not download
+      # or execute them.
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-scripts
-          path: script/release/*.rb
+          path: |
+            script/release/registry.rb
+            script/release/registry_confirm.rb
           if-no-files-found: error
 
   # The only job that can mint RubyGems credentials. Gated by the
   # release-rubygems environment (required reviewer + OIDC trusted publishing).
-  # No checkout: nothing repo-controlled executes here except the reviewed,
-  # artifact-delivered release scripts.
+  # No checkout and no build-produced executable code: only the .gem artifact
+  # enters this job. Registry reconciliation is workflow-owned shell below.
   publish:
     name: Publish to RubyGems
     if: github.event_name == 'push'
@@ -140,13 +142,25 @@ jobs:
       VERSION: ${{ needs.build.outputs.version }}
       GEM_SHA256: ${{ needs.build.outputs.gem_sha256 }}
     steps:
+      - name: Validate unprivileged build outputs against the release ref
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          if [[ ! "$VERSION" =~ ^[0-9]+(\.[A-Za-z0-9]+)*$ ]]; then
+            echo "::error::Build output is not a plausible gem version"
+            exit 1
+          fi
+          if [ "v${VERSION}" != "$REF_NAME" ]; then
+            echo "::error::Build output version ${VERSION} does not match release ref ${REF_NAME}"
+            exit 1
+          fi
+          if [[ ! "$GEM_SHA256" =~ ^[0-9a-f]{64}$ ]]; then
+            echo "::error::Build output is not a lowercase SHA-256 digest"
+            exit 1
+          fi
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: rubygem
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: release-scripts
-          path: script/release
       - name: Verify artifact identity (digest must match the build job's)
         run: |
           actual="$(sha256sum "surfguard-${VERSION}.gem" | awk '{ print $1 }')"
@@ -154,24 +168,96 @@ jobs:
             echo "::error::Artifact digest ${actual} does not match build output ${GEM_SHA256}"
             exit 1
           fi
+      - name: Reconcile with the registry (total state machine; fails closed)
+        id: reconcile
+        run: |
+          registry_url="https://rubygems.org/api/v2/rubygems/surfguard/versions/${VERSION}.json"
+          response_body="$(mktemp)"
+          trap 'rm -f "$response_body"' EXIT
+
+          attempt=1
+          while [ "$attempt" -le 5 ]; do
+            : > "$response_body"
+            status=""
+            retry_reason=""
+
+            if status="$(curl --disable --silent --show-error \
+              --connect-timeout 10 \
+              --max-time 40 \
+              --proto '=https' \
+              --output "$response_body" \
+              --write-out '%{http_code}' \
+              "$registry_url")"; then
+              case "$status" in
+                200)
+                  if ! published_version="$(jq --exit-status --raw-output \
+                    '.number | select(type == "string")' "$response_body")"; then
+                    echo "::error::RubyGems returned malformed version metadata"
+                    exit 1
+                  fi
+                  if ! published_sha="$(jq --exit-status --raw-output \
+                    '.sha | strings | select(test("^[0-9A-Fa-f]{64}$")) | ascii_downcase' \
+                    "$response_body")"; then
+                    echo "::error::RubyGems returned malformed digest metadata"
+                    exit 1
+                  fi
+                  if [ "$published_version" != "$VERSION" ]; then
+                    echo "::error::RubyGems returned metadata for a different version; expected ${VERSION}"
+                    exit 1
+                  fi
+                  if [ "$published_sha" != "$GEM_SHA256" ]; then
+                    echo "::error::surfguard ${VERSION} is already published with sha256 ${published_sha}; our artifact is ${GEM_SHA256}"
+                    exit 1
+                  fi
+                  decision="skip"
+                  break
+                  ;;
+                404)
+                  decision="push"
+                  break
+                  ;;
+                429|5??)
+                  retry_reason="HTTP ${status}"
+                  ;;
+                *)
+                  echo "::error::Unexpected HTTP ${status} from ${registry_url}"
+                  exit 1
+                  ;;
+              esac
+            else
+              retry_reason="network failure"
+            fi
+
+            if [ "$attempt" -ge 5 ]; then
+              echo "::error::RubyGems unavailable after ${attempt} attempts (${retry_reason})"
+              exit 1
+            fi
+            sleep "$((2 * attempt))"
+            attempt="$((attempt + 1))"
+          done
+
+          echo "decision=${decision}" >> "$GITHUB_OUTPUT"
+          echo "registry decision: ${decision}"
       - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
+        if: steps.reconcile.outputs.decision == 'push'
         with:
           ruby-version: ${{ env.RUBY_VERSION }}
           bundler-cache: false
       - name: Pin the packaging toolchain (same pins as build)
+        if: steps.reconcile.outputs.decision == 'push'
         run: gem update --system "$RUBYGEMS_VERSION"
-      - name: Reconcile with the registry (total state machine; fails closed)
-        id: reconcile
-        run: |
-          decision="$(ruby script/release/registry_check.rb surfguard "$VERSION" "$GEM_SHA256")"
-          echo "decision=${decision}" >> "$GITHUB_OUTPUT"
-          echo "registry decision: ${decision}"
       - name: Configure RubyGems trusted-publishing credentials (OIDC)
         if: steps.reconcile.outputs.decision == 'push'
         uses: rubygems/configure-rubygems-credentials@dc5a8d8553e6ee01fc26761a49e99e733d17954a # v2.1.0
-      - name: Push the gem
+      - name: Re-verify artifact identity and push the gem
         if: steps.reconcile.outputs.decision == 'push'
-        run: gem push "surfguard-${VERSION}.gem"
+        run: |
+          actual="$(sha256sum "surfguard-${VERSION}.gem" | awk '{ print $1 }')"
+          if [ "$actual" != "$GEM_SHA256" ]; then
+            echo "::error::Artifact digest ${actual} changed after reconciliation; expected ${GEM_SHA256}"
+            exit 1
+          fi
+          gem push "surfguard-${VERSION}.gem"
       - name: Scrub credentials (runs even when the push fails)
         if: always()
         run: |

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    surfguard (0.1.0)
+    surfguard (0.1.1)
 
 GEM
   remote: https://rubygems.org/
@@ -130,7 +130,7 @@ CHECKSUMS
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
   simplecov (1.1.0) sha256=30f12f31a659c377ef402d5463a50eaf9037035fe1fac3d263cb389682cae1b4
-  surfguard (0.1.0)
+  surfguard (0.1.1)
   tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b
   unicode-display_width (3.2.0) sha256=0cdd96b5681a5949cdbc2c55e7b420facae74c4aaf9a9815eee1087cb1853c42
   unicode-emoji (4.2.0) sha256=519e69150f75652e40bf736106cfbc8f0f73aa3fb6a65afe62fefa7f80b0f80f

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ One SSRF address policy for Ruby apps that fetch a URL someone else supplied.
 It consolidates several drifting in-house copies of this policy into one — copies that had grown
 four different ideas of what "internal" means, including one that decoded a NAT64 prefix whose length
 is not recoverable from the address. This gem is their union, decided once and tested against the
-full IPv4 × IPv6 range matrix.
+IPv4 × IPv6 range matrix it enforces.
 
 ## Installation
 
@@ -26,7 +26,7 @@ Surfguard.resolve_public_ips("feeds.example.com")
 # => ["93.184.216.34", "2606:2800:220:1:248:1893:25c8:1946"]   (IPv4 first, blocked removed)
 # Iterate THIS list on failover; do not resolve again inside a retry loop.
 
-# Non-pinning caller (hands the hostname straight to Net::HTTP, which resolves again):
+# Non-pinning preflight (hands the hostname to Net::HTTP, which resolves again):
 Surfguard.resolvable_public_ip?("https://feeds.example.com/atom")  # => true only if EVERY address is public
 Surfguard.enforce_public_ip(url)                                   # raises otherwise
 
@@ -36,6 +36,21 @@ Surfguard.resolve_public_ip(url)   # => "93.184.216.34" or nil
 # The classification core, if you already hold an address:
 Surfguard.blocked_address?(IPAddr.new("169.254.169.254"))  # => true
 ```
+
+The non-pinning helpers conservatively require every address in their lookup to be public. They do
+not bind the later connection to that answer, so a second lookup can still change underneath them.
+Pinning is required when attacker-controlled DNS or DNS rebinding is in scope.
+
+The direct address APIs accept endpoint addresses, not networks. A prefix shorter than `/32` or
+`/128` is refused rather than normalized into a host: `blocked_address?("10.0.0.1/8")` is `true`,
+and `resolve_public_ips("10.0.0.1/8")` is `[]`.
+
+### Caller responsibilities
+
+Surfguard classifies an address; it is not an HTTP client. The URL helpers do not restrict schemes,
+follow redirects, or make the request. Allow only the schemes your fetcher supports, and validate
+and pin every redirect target just as you did the original target. A pinning client must connect to
+the selected returned address while retaining the original hostname for HTTP Host and TLS identity.
 
 ## Refused vs. unresolvable
 
@@ -62,34 +77,53 @@ question it was asked and never raises; use `enforce_public_ip` or
 |---|---|
 | IPv4 private (10/8, 172.16/12, 192.168/16), loopback (127/8), link-local (169.254/16) | refuse |
 | CGNAT (100.64/10), benchmark (198.18/15), TEST-NETs, IETF (192.0.0/24), 6to4 relay anycast (192.88.99/24), multicast (224/4), reserved (240/4), "this" (0/8) | refuse |
-| IPv6 ULA (fc00::/7, incl. IMDSv6 `fd00:ec2::254`), loopback (::1), link-local (fe80::/10), site-local (fec0::/10), multicast (ff00::/8), unspecified (::), discard (100::/64), Teredo (2001::/32), docs (2001:db8::/32), benchmark (2001:2::/48) | refuse |
+| IPv6 ULA (fc00::/7, incl. IMDSv6 `fd00:ec2::254`), loopback (::1), link-local (fe80::/10), site-local (fec0::/10), multicast (ff00::/8), unspecified (::), discard/dummy (100::/64, 100:0:0:1::/64), documentation (2001:db8::/32, 3fff::/20), SRv6 SID (5f00::/16) | refuse |
+| IETF protocol assignments (2001::/23) | refuse by default, including Teredo, benchmark, PCP/TURN/DNS-SD anycast to nearby infrastructure, deprecated ORCHID, ORCHIDv2, DET, and unallocated space; allow only AMT (2001:3::/32) and AS112-v6 (2001:4:112::/48) |
 | IPv4-mapped `::ffff:0:0/96`, IPv4-compatible `::/96` | refuse outright |
 | **SIIT `::ffff:0:0:0/96`** | decode embedded IPv4 (low 32 bits), re-check |
 | NAT64 well-known `64:ff9b::/96` | decode embedded IPv4 (low 32 bits), re-check |
 | **RFC 8215 NAT64 local-use `64:ff9b:1::/48`** | **refuse outright** — the Pref64 length is not recoverable from the address (RFC 6052 §2.2), so a low-32-bit decode reads the wrong octets; and the block is never globally routed |
 | 6to4 `2002::/16` | refuse (a 6to4 address is just an IPv4 address in disguise) |
 
-## Two things worth knowing
+This is an SSRF address policy, not a label-only copy of the IANA special-purpose registry. It
+refuses internal, non-destination, non-global domain, and overlay-identifier ranges plus transition
+encodings that can conceal a blocked target. Actual globally reachable IP-layer services such as
+AMT and AS112 remain valid; ORCHID and DET identifiers do not, because they can be interpreted by a
+local overlay rather than routed as ordinary public IP destinations.
 
-**1. The resolver is part of the policy.** Surfguard resolves with `Resolv.getaddresses`, which
-honours `/etc/hosts` and search domains **and** returns every address. The obvious alternatives each
-drop something a guard can't afford to lose:
+## Three things worth knowing
+
+**1. Numeric parsing and name resolution are both part of the policy.** Before asking DNS,
+Surfguard asks the system numeric-host parser used by `Socket`/`Net::HTTP` whether the token is an
+address. This recognizes non-canonical decimal, hexadecimal, octal, and shortened IPv4 forms. A
+numeric token is classified directly and is never sent through DNS or a search domain.
+
+Names resolve with `Resolv.getaddresses`, which uses Ruby's usual hosts-plus-DNS chain, honours
+search domains, and returns every address. The obvious alternatives each drop something a guard
+can't afford to lose:
 
 - `Resolv.getaddress` honours `/etc/hosts` but returns only the **first** address — so an AAAA-only
   host deterministically takes the IPv6 path, and a multi-homed host is validated on one address
   while the connection may use another.
-- `Resolv::DNS.open` returns every address but **ignores** `/etc/hosts` and search domains — so it
-  validates a different set than `Net::HTTP` (which resolves through `getaddrinfo`) will actually
-  connect to. Demonstrable: `Resolv.getaddresses("localhost")` → `["::1","127.0.0.1"]` while
-  `Resolv::DNS.open`'s `each_address("localhost")` → `["::","0.0.0.0"]`.
+- `Resolv::DNS.open` returns every DNS address but **ignores** `/etc/hosts` and the other parts of
+  the default resolver chain.
 
-`getaddresses` is both complete (every address) and faithful (the same chain the connection layer
-uses).
+Ruby `Resolv` is not a universal substitute for the system `getaddrinfo` name-service chain. A host
+with custom NSS sources such as mDNS or LDAP can produce a different answer at connection time.
+Pinning a returned address avoids that second name lookup; non-pinning deployments need a resolver
+configuration in which Ruby's hosts-plus-DNS answers match the connection layer, or an independent
+egress control. Resolver-chain equivalence does not eliminate the separate DNS-rebinding window.
 
 **2. A resolver-level "no AAAA" switch is not a mitigation.** Disabling AAAA at the system resolver
 (for example Kamal's `dns-opt: no-aaaa`) is a glibc `getaddrinfo` option. Surfguard resolves through
 pure-Ruby `Resolv`, which requests AAAA regardless, so IPv6 answers still reach it. Don't treat that
 deploy setting as if it narrowed Surfguard's input.
+
+**3. Custom DNS64 prefixes need their own enforcement.** Surfguard can decode and re-check the
+fixed NAT64 well-known prefix `64:ff9b::/96`, and it refuses the RFC 8215 local-use block outright.
+It cannot infer the embedded IPv4 address in an arbitrary network-specific Pref64 from the
+synthesized IPv6 address alone. A deployment using DNS64 with another Pref64 must enforce the same
+blocked-address policy at its DNS64/NAT64 or egress layer.
 
 ## Testing
 
@@ -107,5 +141,5 @@ issue tracker.
 ## Status
 
 Extracted and consolidated from several in-house SSRF guards, tested against the full
-IPv4 × IPv6 special-use matrix. Resolve-and-classify only; callers pin. See the
+policy matrix. Resolve-and-classify only; callers pin. See the
 [releases page](https://github.com/basecamp/surfguard/releases) for versions and changes.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -15,11 +15,13 @@ test -> build -> publish -> confirm -> attest -> github-release
   re-downloads the artifact and asserts that digest before acting.
 - **publish** — the only job that can mint RubyGems credentials, gated by the
   `release-rubygems` environment (required reviewer: Jeremy) and OIDC trusted
-  publishing. No checkout. Before pushing it reconciles with the registry via
-  `script/release/registry_check.rb` — a total state machine: version absent →
-  push; already published with exactly our bytes → skip (idempotent re-run);
-  anything else → fail closed. Credentials are scrubbed unconditionally
-  (`if: always()`), even when the push fails.
+  publishing. No checkout and no artifact-delivered executable code: only the
+  `.gem` enters this job. Before pushing it reconciles with the registry using
+  workflow-owned `curl`/`jq` — a total state machine: version absent → push;
+  already published with exactly our bytes → skip (idempotent re-run);
+  anything else → fail closed. It verifies the gem digest again immediately
+  before `gem push`. Credentials are scrubbed unconditionally (`if: always()`),
+  even when the push fails.
 - **confirm** — deliberately credential-free (`permissions: {}`): polls the
   registry until it reports exactly our version with exactly our digest, then
   downloads the canonical bytes from RubyGems and asserts their digest equals
@@ -35,8 +37,8 @@ Rehearse before every first-of-its-kind release.
 
 ## Cutting a release
 
-1. For a version bump (not needed for v0.1.0, which ships the current
-   version): `rake "bump[X.Y.Z]"` on a branch, review, PR, merge. `bump`
+1. For a version bump: `rake "bump[X.Y.Z]"` on a clean branch, review, PR,
+   merge. `bump`
    rewrites `lib/surfguard/version.rb` and refreshes `Gemfile.lock`; it
    commits nothing itself.
 2. **First release only:** verify/create the RubyGems pending trusted
@@ -115,8 +117,10 @@ Repository-level controls **cannot defend against malicious repository
 administrators**: admins can edit the controls themselves. With 19 effective
 admins on this repo, that residual exposure is real. The setup below narrows
 *routine* release authority to Jeremy; it does not and cannot make admins
-powerless. Mitigations are organizational: reduce admin membership on this
-repo and/or impose independently managed org-level governance (org rulesets).
+powerless. Before announcing Surfguard as a public security control, re-audit
+effective admin membership, reduce it, and/or impose independently managed
+org-level governance (org rulesets). That risk cannot be eliminated by another
+repository-owned workflow or ruleset.
 
 ## One-time setup
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,8 +23,13 @@ Anything that lets a blocked address through, for example:
 - An address in a blocked range that Surfguard classifies as public.
 - A resolution path (encoding, embedding, transition mechanism) that reaches a blocked address
   despite validation.
-- A discrepancy between what Surfguard validates and what a caller following the documented
-  pinning contract would connect to.
+- A parser or resolver discrepancy that lets a caller following a documented API contract connect
+  to a different address than Surfguard classified.
+
+Surfguard does not perform the fetch itself. Scheme restrictions, redirect handling, connection
+pinning, custom DNS64 prefixes, and nonstandard NSS sources have caller or deployment requirements
+documented in the README. Those boundaries by themselves are not classification bugs, but a bypass
+when the documented contract is followed qualifies.
 
 Non-security bugs and questions belong in the
 [regular issue tracker](https://github.com/basecamp/surfguard/issues).

--- a/lib/surfguard.rb
+++ b/lib/surfguard.rb
@@ -2,6 +2,7 @@
 
 require "ipaddr"
 require "resolv"
+require "socket"
 require "uri"
 
 require_relative "surfguard/version"
@@ -15,13 +16,16 @@ require_relative "surfguard/version"
 # Two policy decisions the copies drifted on, settled here and explained where
 # they live in the code:
 #
-#   * Resolver (see .resolve_public_ips): resolve with Resolv.getaddresses, which
-#     honours /etc/hosts and search domains AND returns every address. One copy
-#     used Resolv.getaddress (honours hosts, but only the FIRST address, so an
-#     AAAA-only host deterministically selected the IPv6 path); another used
-#     Resolv::DNS.open (all addresses, but ignores /etc/hosts, so it validated a
-#     different set than Net::HTTP would actually connect to). getaddresses is
-#     both complete and faithful to what the connection layer resolves.
+#   * Resolver (see .resolve_public_ips): first use getaddrinfo's numeric-only
+#     parser so legacy decimal, hex, octal, and short IPv4 forms mean exactly
+#     what they do to Net::HTTP; never send those tokens to DNS. Names resolve
+#     with Resolv.getaddresses, which honours /etc/hosts and search domains AND
+#     returns every address. One copy used Resolv.getaddress (honours hosts, but
+#     only the FIRST address, so an AAAA-only host deterministically selected the
+#     IPv6 path); another used Resolv::DNS.open (all addresses, but ignores
+#     /etc/hosts, so it validated a different set than Net::HTTP would connect
+#     to). getaddresses is complete for Ruby's hosts-plus-DNS chain; system
+#     getaddrinfo may additionally consult NSS sources such as mDNS or LDAP.
 #
 #   * `no-aaaa` in Kamal `dns-opt` is NOT a mitigation. It is a glibc
 #     getaddrinfo option; every guard here resolves through pure-Ruby Resolv,
@@ -38,6 +42,12 @@ require_relative "surfguard/version"
 # resolved address is public.
 module Surfguard
   class Violation < StandardError; end
+
+  # Internal signal for something IPAddr can parse, but which is a network
+  # rather than a host. Keep it separate from a lookup failure: callers must
+  # refuse these inputs without asking DNS to reinterpret them as names.
+  class InvalidHost < ArgumentError; end
+  private_constant :InvalidHost
 
   # The host answered with no address at all. Deliberately NOT a Violation:
   # nothing was refused here, the lookup simply came back empty, which is
@@ -78,12 +88,29 @@ module Surfguard
   DISALLOWED_IPV6 = [
     IPAddr.new("::/128"),           # Unspecified (RFC 4291)
     IPAddr.new("100::/64"),         # Discard-only (RFC 6666)
+    IPAddr.new("100:0:0:1::/64"),   # Dummy IPv6 destination (RFC 9780)
     IPAddr.new("2001::/32"),        # Teredo (RFC 4380)
     IPAddr.new("2001:2::/48"),      # Benchmark testing (RFC 5180)
     IPAddr.new("2001:db8::/32"),    # Documentation (RFC 3849)
     IPAddr.new("2002::/16"),        # 6to4 (RFC 3056)
+    IPAddr.new("3fff::/20"),        # Documentation (RFC 9637)
+    IPAddr.new("5f00::/16"),        # SRv6 SIDs, confined to SR domains (RFC 9602)
     IPAddr.new("fec0::/10"),        # Deprecated site-local (RFC 3879)
     IPAddr.new("ff00::/8")          # Multicast (RFC 4291)
+  ].freeze
+
+  # The IANA parent assignment is non-source, non-destination, non-forwardable,
+  # and non-global unless a more-specific allocation says otherwise. Refuse it
+  # by default so unallocated/future-special space cannot become an internal
+  # fetch path. These are the current, narrowly scoped IP-layer services whose
+  # registrations explicitly permit globally reachable destinations without
+  # selecting nearby infrastructure. PCP, TURN, and DNS-SD SRP anycast remain
+  # refused because they deliberately target on-path or local services. ORCHID,
+  # ORCHIDv2, and DET are overlay identifiers, not ordinary IP-layer locators.
+  IETF_PROTOCOL_ASSIGNMENTS = IPAddr.new("2001::/23")
+  GLOBALLY_REACHABLE_IETF_ASSIGNMENTS = [
+    IPAddr.new("2001:3::/32"),       # AMT (RFC 7450)
+    IPAddr.new("2001:4:112::/48")    # AS112-v6 (RFC 7535)
   ].freeze
 
   # NAT64 embeds an IPv4 target that must be re-checked as IPv4. The well-known
@@ -123,6 +150,8 @@ module Surfguard
              .partition(&:ipv4?)
              .flatten
              .map(&:to_s)
+  rescue InvalidHost
+    []
   end
 
   # True only if the URL's host resolves to at least one address and NONE are
@@ -171,6 +200,7 @@ module Surfguard
   # it cannot parse is blocked.
   def blocked_address?(ip)
     ipaddr = ip.is_a?(IPAddr) ? ip : IPAddr.new(ip.to_s)
+    return true unless host_address?(ipaddr)
 
     # DNS never legitimately returns an IPv4 address embedded these two ways, so
     # refuse them regardless of the address they wrap.
@@ -191,15 +221,19 @@ module Surfguard
 
   private
 
-  # An IP-literal host skips DNS so a public literal URL resolves directly and an
-  # internal literal is still caught by blocked_address?. Otherwise resolve via
-  # Resolv.getaddresses — the Hosts+DNS chain, matching what the connection layer
-  # will use, and returning every address. Returns [IPAddr].
+  # A numeric host skips DNS so a public literal URL resolves directly and an
+  # internal literal is still caught by blocked_address?. Socket's numeric-only
+  # parser comes first because it accepts every legacy IPv4 spelling the
+  # connection layer does (decimal, hex, octal, and shortened forms), while
+  # IPAddr does not. Otherwise resolve via Resolv.getaddresses, returning every
+  # address from Ruby's hosts-plus-DNS chain. System getaddrinfo may consult
+  # additional NSS sources; pinning an address returned here avoids that second
+  # resolution. Returns [IPAddr].
   def resolve(host)
-    literal = ip_literal(host)
+    literals = numeric_literals(host)
 
-    if literal
-      [ literal ]
+    if literals
+      literals
     else
       Resolv.getaddresses(host).map { |a| IPAddr.new(a) }
     end
@@ -207,13 +241,51 @@ module Surfguard
     []
   end
 
-  # nil for anything that isn't already an address. Kept separate so the DNS
-  # call above sits in the method body, where the ResolvError rescue can reach
-  # it — inside a sibling rescue clause it could not.
+  # Every address Socket's numeric-only parser finds. AI_NUMERICHOST guarantees
+  # this call never falls through to DNS. Its success is authoritative: these
+  # tokens must not be reinterpreted as names by Resolv, because Net::HTTP's
+  # getaddrinfo call will reinterpret them as the numeric addresses returned
+  # here. IPAddr remains as a fallback for syntax it alone accepts, notably a
+  # full-width /32 or /128 host prefix. nil means the token is a name.
+  def numeric_literals(host)
+    Socket.getaddrinfo(
+      host, nil, Socket::AF_UNSPEC, Socket::SOCK_STREAM, 0, Socket::AI_NUMERICHOST
+    ).map { |address| IPAddr.new(address[3]) }.uniq
+  rescue SocketError
+    literal = ip_literal(host)
+    return [ literal ] if literal
+
+    # An ordinary name may proceed to Resolv after AI_NUMERICHOST says it is
+    # not numeric. A token shaped like a legacy IPv4 spelling may not: if the
+    # system numeric parser itself failed abnormally, asking DNS would recreate
+    # the parser/resolver identity gap this method exists to close.
+    raise InvalidHost, "numeric-looking host #{host.inspect} could not be classified" if numeric_host_candidate?(host)
+
+    nil
+  end
+
+  def numeric_host_candidate?(host)
+    text = host.to_s
+    return true if text.include?(":") # Invalid IPv6 syntax is never a DNS name.
+
+    parts = text.split(".", -1)
+    (1..4).cover?(parts.length) &&
+      parts.all? { |part| part.match?(/\A(?:0[xX][0-9A-Fa-f]+|[0-9]+)\z/) }
+  end
+
+  # nil for anything IPAddr cannot parse. A shortened prefix is not a host and
+  # is rejected rather than normalized to its network address or sent to DNS.
   def ip_literal(host)
-    IPAddr.new(host)
+    ipaddr = IPAddr.new(host)
+    raise InvalidHost, "#{host.inspect} is a network, not a host" unless host_address?(ipaddr)
+
+    ipaddr
   rescue IPAddr::InvalidAddressError
     nil
+  end
+
+  def host_address?(ipaddr)
+    ipaddr.prefix == (ipaddr.ipv4? ? 32 : 128)
   end
 
   def host_of(url)
@@ -232,7 +304,10 @@ module Surfguard
   end
 
   def disallowed_ipv6?(ipaddr)
+    return false if GLOBALLY_REACHABLE_IETF_ASSIGNMENTS.any? { |range| range.include?(ipaddr) }
+
     ipaddr.private? || ipaddr.loopback? || ipaddr.link_local? ||
+      IETF_PROTOCOL_ASSIGNMENTS.include?(ipaddr) ||
       DISALLOWED_IPV6.any? { |range| range.include?(ipaddr) }
   end
 

--- a/lib/surfguard/version.rb
+++ b/lib/surfguard/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Surfguard
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end

--- a/surfguard.gemspec
+++ b/surfguard.gemspec
@@ -31,6 +31,6 @@ Gem::Specification.new do |spec|
   spec.files = Dir["lib/**/*.rb", "README.md", "LICENSE", "SECURITY.md"]
   spec.require_paths = [ "lib" ]
 
-  # Standard library only: ipaddr, resolv, uri. No runtime dependencies on
+  # Standard library only: ipaddr, resolv, socket, uri. No runtime dependencies on
   # purpose — this must drop into apps on wildly different gem sets.
 end

--- a/test/release/publish_reconciliation_workflow_test.rb
+++ b/test/release/publish_reconciliation_workflow_test.rb
@@ -1,0 +1,280 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+require "json"
+require "open3"
+require "rbconfig"
+require "tmpdir"
+require "yaml"
+
+# Executes the publish job's workflow-owned registry reconciliation verbatim.
+# A minimal PATH makes accidentally reaching the network impossible through the
+# named curl command, while scripted curl and sleep executables make every
+# state-machine transition deterministic and fast.
+class PublishReconciliationWorkflowTest < Minitest::Test
+  STEP_ID = "reconcile"
+  STEP_NAME = "Reconcile with the registry (total state machine; fails closed)"
+  WORKFLOW_PATH = File.expand_path("../../.github/workflows/release.yml", __dir__)
+
+  VERSION = "0.1.0"
+  GEM_SHA256 = ("a" * 64).freeze
+  OTHER_SHA256 = ("b" * 64).freeze
+  REGISTRY_URL = "https://rubygems.org/api/v2/rubygems/surfguard/versions/0.1.0.json"
+
+  RunResult = Struct.new(:stdout, :stderr, :status, :github_output, :curl_calls, :sleeps,
+    keyword_init: true)
+
+  def self.load_reconciliation_script
+    workflow = YAML.safe_load(File.read(WORKFLOW_PATH), aliases: false)
+    steps = workflow.fetch("jobs").fetch("publish").fetch("steps")
+    matches = steps.select do |step|
+      step.is_a?(Hash) && step["id"] == STEP_ID && step["name"] == STEP_NAME
+    end
+
+    raise "expected exactly one #{STEP_ID.inspect} / #{STEP_NAME.inspect} workflow step" unless matches.one?
+
+    matches.first.fetch("run").freeze
+  end
+  private_class_method :load_reconciliation_script
+
+  RECONCILIATION_SCRIPT = load_reconciliation_script
+
+  def test_404_means_push
+    result = run_reconciliation([ response(404) ])
+
+    assert_success(result)
+    assert_equal "decision=push\n", result.github_output
+    assert_equal 1, result.curl_calls
+    assert_empty result.sleeps
+  end
+
+  def test_matching_200_means_skip_and_normalizes_digest_case
+    result = run_reconciliation([
+      response(200, metadata(sha: GEM_SHA256.upcase))
+    ])
+
+    assert_success(result)
+    assert_equal "decision=skip\n", result.github_output
+    assert_equal 1, result.curl_calls
+  end
+
+  def test_conflicting_digest_fails_closed
+    result = run_reconciliation([
+      response(200, metadata(sha: OTHER_SHA256))
+    ])
+
+    assert_failure(result, /already published with sha256 #{OTHER_SHA256}/)
+    assert_equal 1, result.curl_calls
+  end
+
+  def test_malformed_json_fails_closed
+    result = run_reconciliation([ response(200, "not JSON") ])
+
+    assert_failure(result, /RubyGems returned malformed version metadata/)
+    assert_equal 1, result.curl_calls
+  end
+
+  def test_malformed_json_shape_fails_closed
+    result = run_reconciliation([ response(200, JSON.generate([ VERSION, GEM_SHA256 ])) ])
+
+    assert_failure(result, /RubyGems returned malformed version metadata/)
+    assert_equal 1, result.curl_calls
+  end
+
+  def test_metadata_for_a_different_version_fails_closed
+    result = run_reconciliation([
+      response(200, metadata(version: "9.9.9"))
+    ])
+
+    assert_failure(result, /metadata for a different version; expected #{VERSION}/)
+    assert_equal 1, result.curl_calls
+  end
+
+  def test_unexpected_status_fails_without_retrying
+    result = run_reconciliation([ response(403) ])
+
+    assert_failure(result, /Unexpected HTTP 403/)
+    assert_equal 1, result.curl_calls
+    assert_empty result.sleeps
+  end
+
+  def test_retryable_statuses_back_off_then_succeed
+    result = run_reconciliation([
+      response(429),
+      response(503),
+      response(404)
+    ])
+
+    assert_success(result)
+    assert_equal "decision=push\n", result.github_output
+    assert_equal 3, result.curl_calls
+    assert_equal [ 2, 4 ], result.sleeps
+  end
+
+  def test_persistent_retryable_status_fails_after_five_attempts
+    result = run_reconciliation(Array.new(5) { response(503) })
+
+    assert_failure(result, /RubyGems unavailable after 5 attempts \(HTTP 503\)/)
+    assert_equal 5, result.curl_calls
+    assert_equal [ 2, 4, 6, 8 ], result.sleeps
+  end
+
+  def test_persistent_network_failure_fails_after_five_attempts
+    result = run_reconciliation(Array.new(5) { network_failure })
+
+    assert_failure(result, /RubyGems unavailable after 5 attempts \(network failure\)/)
+    assert_equal 5, result.curl_calls
+    assert_equal [ 2, 4, 6, 8 ], result.sleeps
+  end
+
+  private
+
+  def run_reconciliation(fixtures)
+    Dir.mktmpdir("surfguard-reconcile-test") do |directory|
+      bin_directory = File.join(directory, "bin")
+      Dir.mkdir(bin_directory)
+      install_real_commands(bin_directory)
+      install_fake_curl(bin_directory)
+      install_fake_sleep(bin_directory)
+
+      fixtures_path = File.join(directory, "curl-fixtures")
+      curl_index_path = File.join(directory, "curl-index")
+      sleep_log_path = File.join(directory, "sleep-log")
+      github_output_path = File.join(directory, "github-output")
+      File.binwrite(fixtures_path, Marshal.dump(fixtures))
+      File.write(curl_index_path, "0")
+      File.write(sleep_log_path, "")
+      File.write(github_output_path, "")
+
+      stdout, stderr, status = Open3.capture3(
+        isolated_environment(
+          directory: directory,
+          bin_directory: bin_directory,
+          fixtures_path: fixtures_path,
+          curl_index_path: curl_index_path,
+          sleep_log_path: sleep_log_path,
+          github_output_path: github_output_path
+        ),
+        executable("bash"), "--noprofile", "--norc", "-e", "-o", "pipefail", "-c",
+        RECONCILIATION_SCRIPT,
+        chdir: directory,
+        unsetenv_others: true
+      )
+
+      RunResult.new(
+        stdout: stdout,
+        stderr: stderr,
+        status: status,
+        github_output: File.read(github_output_path),
+        curl_calls: Integer(File.read(curl_index_path)),
+        sleeps: File.readlines(sleep_log_path, chomp: true).map(&:to_i)
+      )
+    end
+  end
+
+  def isolated_environment(directory:, bin_directory:, fixtures_path:, curl_index_path:,
+    sleep_log_path:, github_output_path:)
+    {
+      "PATH" => bin_directory,
+      "HOME" => directory,
+      "TMPDIR" => directory,
+      "VERSION" => VERSION,
+      "GEM_SHA256" => GEM_SHA256,
+      "GITHUB_OUTPUT" => github_output_path,
+      "CURL_FIXTURES" => fixtures_path,
+      "CURL_INDEX" => curl_index_path,
+      "SLEEP_LOG" => sleep_log_path,
+      "EXPECTED_REGISTRY_URL" => REGISTRY_URL,
+      # Defense in depth if a future edit bypasses the fake curl by using an
+      # absolute path: external HTTP(S) still cannot leave through a proxy.
+      "HTTP_PROXY" => "http://127.0.0.1:1",
+      "HTTPS_PROXY" => "http://127.0.0.1:1",
+      "ALL_PROXY" => "http://127.0.0.1:1"
+    }
+  end
+
+  def install_real_commands(bin_directory)
+    %w[jq mktemp rm].each do |command|
+      File.symlink(executable(command), File.join(bin_directory, command))
+    end
+  end
+
+  def install_fake_curl(bin_directory)
+    write_executable(File.join(bin_directory, "curl"), <<~RUBY)
+      #!#{RbConfig.ruby}
+      fixtures = Marshal.load(File.binread(ENV.fetch("CURL_FIXTURES")))
+      index_path = ENV.fetch("CURL_INDEX")
+      index = Integer(File.read(index_path))
+      fixture = fixtures.fetch(index)
+      File.write(index_path, (index + 1).to_s)
+
+      output_index = ARGV.index("--output")
+      abort "fake curl requires --output" unless output_index
+      abort "unexpected registry URL" unless ARGV.last == ENV.fetch("EXPECTED_REGISTRY_URL")
+
+      File.binwrite(ARGV.fetch(output_index + 1), fixture.fetch(:body, ""))
+      $stderr.write(fixture.fetch(:stderr, ""))
+      $stdout.write(fixture.fetch(:status, "").to_s)
+      exit fixture.fetch(:exit_status, 0)
+    RUBY
+  end
+
+  def install_fake_sleep(bin_directory)
+    write_executable(File.join(bin_directory, "sleep"), <<~RUBY)
+      #!#{RbConfig.ruby}
+      abort "fake sleep requires one argument" unless ARGV.length == 1
+      File.open(ENV.fetch("SLEEP_LOG"), "a") { |file| file.puts(ARGV.first) }
+    RUBY
+  end
+
+  def write_executable(path, contents)
+    File.write(path, contents)
+    File.chmod(0o700, path)
+  end
+
+  def executable(command)
+    ENV.fetch("PATH").split(File::PATH_SEPARATOR).each do |directory|
+      path = File.join(directory, command)
+      return File.realpath(path) if File.file?(path) && File.executable?(path)
+    end
+
+    raise "required executable not found: #{command}"
+  end
+
+  def response(status, body = "")
+    { status: status.to_s, body: body }
+  end
+
+  def network_failure
+    {
+      status: "000",
+      stderr: "curl: simulated network failure\n",
+      exit_status: 7
+    }
+  end
+
+  def metadata(version: VERSION, sha: GEM_SHA256)
+    JSON.generate("number" => version, "sha" => sha)
+  end
+
+  def assert_success(result)
+    assert result.status.success?, failure_diagnostics(result)
+  end
+
+  def assert_failure(result, message_pattern)
+    refute result.status.success?, "expected workflow step to fail"
+    assert_empty result.github_output
+    assert_match message_pattern, result.stdout
+  end
+
+  def failure_diagnostics(result)
+    <<~MESSAGE
+      workflow step unexpectedly failed (#{result.status.exitstatus})
+      stdout:
+      #{result.stdout}
+      stderr:
+      #{result.stderr}
+    MESSAGE
+  end
+end

--- a/test/surfguard_test.rb
+++ b/test/surfguard_test.rb
@@ -33,8 +33,18 @@ class SurfguardTest < Minitest::Test
     "IPv6 site-local (deprecated)"       => "fec0::1",
     "IPv6 multicast"                     => "ff02::1",
     "IPv6 discard-only"                  => "100::1",
+    "IPv6 dummy destination"             => "100:0:0:1::1",
     "IPv6 Teredo"                        => "2001:0:a9fe:a9fe::",
+    "IPv6 PCP anycast"                   => "2001:1::1",
+    "IPv6 TURN anycast"                  => "2001:1::2",
+    "IPv6 DNS-SD SRP anycast"            => "2001:1::3",
+    "IPv6 unallocated IETF assignment"   => "2001:1::4",
+    "IPv6 deprecated ORCHID"             => "2001:10::1",
+    "IPv6 ORCHIDv2"                      => "2001:20::1",
+    "IPv6 DET overlay identifier"        => "2001:30::1",
     "IPv6 documentation"                 => "2001:db8::1",
+    "IPv6 expanded documentation"        => "3fff::1",
+    "IPv6 SRv6 SID"                      => "5f00::1",
     # IPv4-in-IPv6 encapsulations
     "IPv4-mapped link-local"             => "::ffff:169.254.169.254",
     "IPv4-compatible link-local"         => "::169.254.169.254",
@@ -54,9 +64,34 @@ class SurfguardTest < Minitest::Test
     "octet above link-local"               => "169.255.0.0",
     "below carrier-grade NAT"              => "100.63.255.255",
     "above carrier-grade NAT"              => "100.128.0.0",
+    "AMT service"                           => "2001:3::1",
+    "AS112 service"                         => "2001:4:112::1",
+    "direct AS112 service"                  => "2620:4f:8000::1",
     "NAT64 WKP wrapping a public IPv4"     => "64:ff9b::5db8:d822", # 93.184.216.34
     "SIIT wrapping a public IPv4"          => "::ffff:0:5db8:d822"
   }.freeze
+
+  LEGACY_NUMERIC_BLOCKED = {
+    "single-integer loopback"     => "2130706433",
+    "short loopback"              => "127.1",
+    "hex loopback"                => "0x7f000001",
+    "octal dotted loopback"       => "0177.0.0.1",
+    "single zero"                 => "0",
+    "octal zero"                  => "00",
+    "hex zero"                    => "0x0",
+    "single-integer link-local"   => "2852039166",
+    "hex link-local"              => "0xa9fea9fe"
+  }.freeze
+
+  NON_HOST_PREFIXES = %w[
+    0.0.0.0/0
+    ::/0
+    ::1/127
+    127.0.0.1/0
+    ::1/64
+    169.254.169.254/8
+    10.0.0.1/6
+  ].freeze
 
   BLOCKED.each do |label, address|
     define_method("test_blocks_#{label.gsub(/\W+/, '_')}") do
@@ -77,12 +112,40 @@ class SurfguardTest < Minitest::Test
     refute Surfguard::NAT64_LOCAL_USE.include?(IPAddr.new("64:ff9b::1"))
   end
 
+  def test_expanded_documentation_prefix_boundaries
+    assert Surfguard.blocked_address?("3fff::")
+    assert Surfguard.blocked_address?("3fff:fff:ffff:ffff:ffff:ffff:ffff:ffff")
+    refute Surfguard.blocked_address?("3ffe:ffff:ffff:ffff:ffff:ffff:ffff:ffff")
+    refute Surfguard.blocked_address?("3fff:1000::")
+  end
+
+  def test_globally_reachable_ietf_assignment_carve_outs_are_narrow
+    assert Surfguard.blocked_address?("2001:1::4")
+    assert Surfguard.blocked_address?("2001:2:ffff:ffff:ffff:ffff:ffff:ffff")
+    refute Surfguard.blocked_address?("2001:3:ffff:ffff:ffff:ffff:ffff:ffff")
+    assert Surfguard.blocked_address?("2001:4:111:ffff:ffff:ffff:ffff:ffff")
+    refute Surfguard.blocked_address?("2001:4:112:ffff:ffff:ffff:ffff:ffff")
+    assert Surfguard.blocked_address?("2001:4:113::")
+  end
+
   def test_siit_and_mapped_prefixes_do_not_overlap
     refute Surfguard::IPV4_TRANSLATABLE.include?(IPAddr.new("::ffff:169.254.169.254"))
   end
 
   def test_blocks_an_unparseable_address
     assert Surfguard.blocked_address?("not-an-ip")
+  end
+
+  NON_HOST_PREFIXES.each do |address|
+    define_method("test_blocks_non_host_prefix_#{address.gsub(/\W+/, '_')}") do
+      assert Surfguard.blocked_address?(address)
+      assert Surfguard.blocked_address?(IPAddr.new(address))
+    end
+  end
+
+  def test_allows_full_width_host_prefixes
+    refute Surfguard.blocked_address?("93.184.216.34/32")
+    refute Surfguard.blocked_address?("2606:2800:220:1:248:1893:25c8:1946/128")
   end
 
   # --- resolution (stub the resolver; never hit the network) ------------------
@@ -135,6 +198,84 @@ class SurfguardTest < Minitest::Test
     # No stub: an internal literal is caught without any resolver call.
     refute Surfguard.resolvable_public_ip?("http://169.254.169.254/latest/meta-data/")
     assert Surfguard.resolvable_public_ip?("http://93.184.216.34/")
+  end
+
+  LEGACY_NUMERIC_BLOCKED.each do |label, host|
+    define_method("test_legacy_numeric_#{label.gsub(/\W+/, '_')}_skips_dns_and_is_refused") do
+      original = Resolv.method(:getaddresses)
+      dns_queries = []
+      Resolv.define_singleton_method(:getaddresses) do |resolved_host|
+        dns_queries << resolved_host
+        [ "93.184.216.34" ] # Model a public wildcard/search-domain answer.
+      end
+
+      assert_empty Surfguard.resolve_public_ips(host)
+      refute Surfguard.resolvable_public_ip?("http://#{host}/")
+      assert_raises(Surfguard::Violation) do
+        Surfguard.enforce_public_ip("http://#{host}/")
+      end
+      assert_empty dns_queries
+    ensure
+      Resolv.define_singleton_method(:getaddresses, original)
+    end
+  end
+
+  def test_legacy_numeric_public_address_is_classified_and_skips_dns
+    original = Resolv.method(:getaddresses)
+    dns_queries = []
+    Resolv.define_singleton_method(:getaddresses) do |host|
+      dns_queries << host
+      [ "169.254.169.254" ]
+    end
+
+    assert_equal [ "93.184.216.34" ], Surfguard.resolve_public_ips("1572395042")
+    assert Surfguard.resolvable_public_ip?("http://1572395042/")
+    assert_empty dns_queries
+  ensure
+    Resolv.define_singleton_method(:getaddresses, original)
+  end
+
+  def test_numeric_parser_fault_cannot_send_numeric_looking_tokens_to_dns
+    original_getaddrinfo = Socket.method(:getaddrinfo)
+    original_getaddresses = Resolv.method(:getaddresses)
+    dns_queries = []
+    Socket.define_singleton_method(:getaddrinfo) { |*| raise SocketError, "simulated parser fault" }
+    Resolv.define_singleton_method(:getaddresses) do |host|
+      dns_queries << host
+      [ "93.184.216.34" ]
+    end
+
+    LEGACY_NUMERIC_BLOCKED.each_value do |host|
+      assert_empty Surfguard.resolve_public_ips(host)
+    end
+    assert_empty Surfguard.resolve_public_ips("not:a:valid:ipv6")
+    assert_equal [ "93.184.216.34" ], Surfguard.resolve_public_ips("example.com")
+    assert_equal [ "example.com" ], dns_queries
+  ensure
+    Socket.define_singleton_method(:getaddrinfo, original_getaddrinfo)
+    Resolv.define_singleton_method(:getaddresses, original_getaddresses)
+  end
+
+  def test_non_host_prefixes_are_rejected_without_dns
+    original = Resolv.method(:getaddresses)
+    dns_queries = []
+    Resolv.define_singleton_method(:getaddresses) do |host|
+      dns_queries << host
+      [ "93.184.216.34" ]
+    end
+
+    NON_HOST_PREFIXES.each do |host|
+      assert_empty Surfguard.resolve_public_ips(host)
+    end
+    assert_empty dns_queries
+  ensure
+    Resolv.define_singleton_method(:getaddresses, original)
+  end
+
+  def test_full_width_host_prefixes_remain_valid_literals
+    assert_equal [ "93.184.216.34" ], Surfguard.resolve_public_ips("93.184.216.34/32")
+    assert_equal [ "2606:2800:220:1:248:1893:25c8:1946" ],
+      Surfguard.resolve_public_ips("2606:2800:220:1:248:1893:25c8:1946/128")
   end
 
   def test_bracketed_ipv6_literal_host


### PR DESCRIPTION
## Summary

- classify numeric host tokens with the connection-layer numeric parser before DNS, reject network-prefix inputs, and update the IPv6 special-purpose policy
- remove artifact-delivered Ruby from the OIDC publish job, reconcile registry state in workflow-owned shell, rehash immediately before push, and protect `/lib/` with CODEOWNERS
- document resolver and pinning boundaries and prepare the immutable fixed release as 0.1.1

## Verification

- `COVERAGE=1 bundle exec rake test` — 180 tests, 528 assertions, 100% line and branch coverage
- full suite on Ruby 3.1.6, 3.2.9, 3.3.11, 3.4.10, and 4.0.6
- `bundle exec rubocop`
- `actionlint -color`
- authenticated `zizmor --persona=pedantic .`
- built and package-verified `surfguard-0.1.1.gem`

## Release note

v0.1.0 is already published and immutable. This PR bumps to 0.1.1; publish 0.1.1 promptly after merge. The advisory or yank decision for v0.1.0 remains separate.