### PR TITLE
Block the Azure WireServer address

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    surfguard (0.1.1)
+    surfguard (0.1.2)
 
 GEM
   remote: https://rubygems.org/
@@ -130,7 +130,7 @@ CHECKSUMS
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
   simplecov (1.1.0) sha256=30f12f31a659c377ef402d5463a50eaf9037035fe1fac3d263cb389682cae1b4
-  surfguard (0.1.1)
+  surfguard (0.1.2)
   tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b
   unicode-display_width (3.2.0) sha256=0cdd96b5681a5949cdbc2c55e7b420facae74c4aaf9a9815eee1087cb1853c42
   unicode-emoji (4.2.0) sha256=519e69150f75652e40bf736106cfbc8f0f73aa3fb6a65afe62fefa7f80b0f80f

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ question it was asked and never raises; use `enforce_public_ip` or
 |---|---|
 | IPv4 private (10/8, 172.16/12, 192.168/16), loopback (127/8), link-local (169.254/16) | refuse |
 | CGNAT (100.64/10), benchmark (198.18/15), TEST-NETs, IETF (192.0.0/24), 6to4 relay anycast (192.88.99/24), multicast (224/4), reserved (240/4), "this" (0/8) | refuse |
+| Azure WireServer `168.63.129.16/32` | refuse — a fixed Azure platform/fabric alias, not an RFC special-use range |
 | IPv6 ULA (fc00::/7, incl. IMDSv6 `fd00:ec2::254`), loopback (::1), link-local (fe80::/10), site-local (fec0::/10), multicast (ff00::/8), unspecified (::), discard/dummy (100::/64, 100:0:0:1::/64), documentation (2001:db8::/32, 3fff::/20), SRv6 SID (5f00::/16) | refuse |
 | IETF protocol assignments (2001::/23) | refuse by default, including Teredo, benchmark, PCP/TURN/DNS-SD anycast to nearby infrastructure, deprecated ORCHID, ORCHIDv2, DET, and unallocated space; allow only AMT (2001:3::/32) and AS112-v6 (2001:4:112::/48) |
 | IPv4-mapped `::ffff:0:0/96`, IPv4-compatible `::/96` | refuse outright |

--- a/lib/surfguard.rb
+++ b/lib/surfguard.rb
@@ -59,15 +59,17 @@ module Surfguard
 
   extend self
 
-  # IPv4 special-use ranges that must never be a fetch target (RFC 5735/6890,
-  # plus CGNAT and benchmarking). RFC1918 / loopback / link-local are also
-  # covered by the IPAddr predicates in #disallowed_ipv4?; they are restated here
-  # so the policy is complete and auditable in one place.
+  # IPv4 special-use ranges and exact platform aliases that must never be a
+  # fetch target (RFC 5735/6890, plus CGNAT and benchmarking). RFC1918 /
+  # loopback / link-local are also covered by the IPAddr predicates in
+  # #disallowed_ipv4?; they are restated here so the policy is complete and
+  # auditable in one place.
   DISALLOWED_IPV4 = [
     IPAddr.new("0.0.0.0/8"),        # "This" network (RFC 1122)
     IPAddr.new("10.0.0.0/8"),       # Private (RFC 1918)
     IPAddr.new("100.64.0.0/10"),    # Carrier-grade NAT (RFC 6598)
     IPAddr.new("127.0.0.0/8"),      # Loopback (RFC 1122)
+    IPAddr.new("168.63.129.16/32"), # Azure host-node WireServer virtual IP
     IPAddr.new("169.254.0.0/16"),   # Link-local (RFC 3927) — includes the cloud metadata endpoint
     IPAddr.new("172.16.0.0/12"),    # Private (RFC 1918)
     IPAddr.new("192.0.0.0/24"),     # IETF protocol assignments (RFC 6890)

--- a/lib/surfguard/version.rb
+++ b/lib/surfguard/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Surfguard
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end

--- a/test/surfguard_test.rb
+++ b/test/surfguard_test.rb
@@ -17,6 +17,7 @@ class SurfguardTest < Minitest::Test
     "private 192.168/16"                 => "192.168.1.1",
     "carrier-grade NAT"                  => "100.64.0.1",
     "this network"                       => "0.0.0.0",
+    "Azure wire server"                  => "168.63.129.16",
     "IETF protocol assignments"          => "192.0.0.1",
     "6to4 relay anycast"                 => "192.88.99.1",
     "benchmarking"                       => "198.18.0.1",
@@ -119,6 +120,12 @@ class SurfguardTest < Minitest::Test
     refute Surfguard.blocked_address?("3fff:1000::")
   end
 
+  def test_azure_wire_server_deny_is_one_exact_address
+    refute Surfguard.blocked_address?("168.63.129.15")
+    assert Surfguard.blocked_address?("168.63.129.16")
+    refute Surfguard.blocked_address?("168.63.129.17")
+  end
+
   def test_globally_reachable_ietf_assignment_carve_outs_are_narrow
     assert Surfguard.blocked_address?("2001:1::4")
     assert Surfguard.blocked_address?("2001:2:ffff:ffff:ffff:ffff:ffff:ffff")
@@ -198,6 +205,28 @@ class SurfguardTest < Minitest::Test
     # No stub: an internal literal is caught without any resolver call.
     refute Surfguard.resolvable_public_ip?("http://169.254.169.254/latest/meta-data/")
     assert Surfguard.resolvable_public_ip?("http://93.184.216.34/")
+  end
+
+  def test_azure_wire_server_literal_is_refused_by_every_resolution_api
+    url = "http://168.63.129.16/machine/?comp=goalstate"
+
+    assert_empty Surfguard.resolve_public_ips("168.63.129.16")
+    assert_nil Surfguard.resolve_public_ip(url)
+    refute Surfguard.resolvable_public_ip?(url)
+    assert_raises(Surfguard::Violation) do
+      Surfguard.enforce_public_ip(url)
+    end
+  end
+
+  def test_azure_wire_server_in_a_dns_answer_is_filtered_and_refused_unpinned
+    stub_getaddresses("azure.example" => %w[93.184.216.34 168.63.129.16]) do
+      assert_equal [ "93.184.216.34" ], Surfguard.resolve_public_ips("azure.example")
+      assert_nil Surfguard.resolve_public_ip("https://azure.example")
+      refute Surfguard.resolvable_public_ip?("https://azure.example")
+      assert_raises(Surfguard::Violation) do
+        Surfguard.enforce_public_ip("https://azure.example")
+      end
+    end
   end
 
   LEGACY_NUMERIC_BLOCKED.each do |label, host|


### PR DESCRIPTION
## Summary

- block `168.63.129.16/32`, Azure WireServer's fixed host-node virtual IP, across classification, pinning, and non-pinning APIs
- keep the deny rule exact: adjacent public addresses remain allowed, while literal and mixed-DNS paths are regression-tested
- document that this is an Azure platform/fabric alias rather than an RFC special-use range
- bump the fixed release to 0.1.2 because v0.1.1 is already published and immutable

## Assessment

Microsoft documents `168.63.129.16` as a fixed host-node WireServer address used across Azure regions and clouds for platform communication. It is distinct from IMDS at `169.254.169.254`, but is still an internal platform endpoint and must not be treated as a public fetch target.

Affected versions: 0.1.1 and earlier when used on Azure. Patched version: 0.1.2.

## Verification

- 184 tests, 541 assertions; 100% line and branch coverage
- full suite on Ruby 3.1.6, 3.2.9, 3.3.11, 3.4.10, and 4.0.6
- `bundle exec rubocop`
- `actionlint -color`
- authenticated `zizmor --persona=pedantic .`
- hermetic Ruby 3.4.10 / RubyGems 4.0.18 build and package verification for `surfguard-0.1.2.gem`
- independent policy, patch, and release-state reviews found no remaining actionable issue

## Release note

Security fix: block Azure WireServer at `168.63.129.16`, a fixed Azure platform/fabric alias outside the RFC special-use ranges. On Azure, Surfguard 0.1.1 and earlier could classify this host-only service address as public. Upgrade to 0.1.2.

Primary reference: https://learn.microsoft.com/en-us/azure/virtual-network/what-is-ip-address-168-63-129-16