### PR TITLE
Refuse malformed numeric hosts before resolution

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    surfguard (0.1.2)
+    surfguard (0.1.3)
 
 GEM
   remote: https://rubygems.org/
@@ -130,7 +130,7 @@ CHECKSUMS
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
   simplecov (1.1.0) sha256=30f12f31a659c377ef402d5463a50eaf9037035fe1fac3d263cb389682cae1b4
-  surfguard (0.1.2)
+  surfguard (0.1.3)
   tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b
   unicode-display_width (3.2.0) sha256=0cdd96b5681a5949cdbc2c55e7b420facae74c4aaf9a9815eee1087cb1853c42
   unicode-emoji (4.2.0) sha256=519e69150f75652e40bf736106cfbc8f0f73aa3fb6a65afe62fefa7f80b0f80f

--- a/README.md
+++ b/README.md
@@ -97,7 +97,9 @@ local overlay rather than routed as ordinary public IP destinations.
 **1. Numeric parsing and name resolution are both part of the policy.** Before asking DNS,
 Surfguard asks the system numeric-host parser used by `Socket`/`Net::HTTP` whether the token is an
 address. This recognizes non-canonical decimal, hexadecimal, octal, and shortened IPv4 forms. A
-numeric token is classified directly and is never sent through DNS or a search domain.
+numeric token is classified directly and is never sent through DNS or a search domain. Malformed
+IPv4-shaped variants with empty dot labels or invalid zone/prefix suffixes are refused rather than
+reinterpreted as DNS names.
 
 Names resolve with `Resolv.getaddresses`, which uses Ruby's usual hosts-plus-DNS chain, honours
 search domains, and returns every address. The obvious alternatives each drop something a guard

--- a/lib/surfguard.rb
+++ b/lib/surfguard.rb
@@ -289,15 +289,19 @@ module Surfguard
     text = host.to_s
     return false if text.include?(":") # IPv6 literals and zones go to AI_NUMERICHOST.
 
-    address, separator, remainder = text.partition(/[%\/]/)
-    address = remainder if address.empty?
-    labels = address.split(".", -1)
-    malformed = !separator.empty? || labels.any?(&:empty?)
-    return false unless malformed && legacy_ipv4_shape?(address)
+    # Isolate the address: drop every leading separator, then keep only what
+    # precedes the next one. Removing a single separator would let a second one
+    # ("//127.0.0.1", "%127.0.0.1%lo") hide the legacy IPv4 shape, so the token
+    # would reach the platform parser and, failing there, be handed to DNS as a
+    # name — the parser/resolver identity gap this check exists to close.
+    core = text.sub(%r{\A[%/]+}, "")[%r{\A[^%/]*}]
+    labels = core.split(".", -1)
+    malformed = core != text || labels.any?(&:empty?)
+    return false unless malformed && legacy_ipv4_shape?(core)
 
     # Full-width host prefixes are documented inputs and IPAddr parses them
     # unambiguously. Shorter or otherwise invalid prefixes remain malformed.
-    return false if separator == "/" && full_width_host_literal?(text)
+    return false if full_width_host_literal?(text)
 
     true
   end

--- a/lib/surfguard.rb
+++ b/lib/surfguard.rb
@@ -137,6 +137,11 @@ module Surfguard
   # the NAT64 well-known prefix it is a fixed /96, so decode the low 32 bits.
   IPV4_TRANSLATABLE = IPAddr.new("::ffff:0:0:0/96") # RFC 2765
 
+  # IPv4-compatible IPv6 is deprecated and must never be a DNS fetch target.
+  # Classify the prefix directly instead of calling IPAddr#ipv4_compat?, which
+  # has been obsolete since Ruby 2.5 and is expected to disappear in ipaddr 2.x.
+  IPV4_COMPATIBLE = IPAddr.new("::/96")
+
   # Every PUBLIC address the host resolves to, IPv4 ahead of IPv6, DNS order
   # preserved within each family so a provider's round-robin still spreads load.
   # Empty when the host resolves but every address is blocked; raises
@@ -206,7 +211,7 @@ module Surfguard
 
     # DNS never legitimately returns an IPv4 address embedded these two ways, so
     # refuse them regardless of the address they wrap.
-    if ipaddr.ipv4_mapped? || ipaddr.ipv4_compat?
+    if ipaddr.ipv4_mapped? || IPV4_COMPATIBLE.include?(ipaddr)
       true
     elsif ipaddr.ipv4?
       disallowed_ipv4?(ipaddr)
@@ -250,6 +255,13 @@ module Surfguard
   # here. IPAddr remains as a fallback for syntax it alone accepts, notably a
   # full-width /32 or /128 host prefix. nil means the token is a name.
   def numeric_literals(host)
+    # Refuse malformed IPv4-shaped text before consulting the platform parser.
+    # Some connection layers may accept decorations that others reject; none
+    # may turn them into a public DNS name after Surfguard classified them.
+    if malformed_numeric_host_candidate?(host)
+      raise InvalidHost, "malformed numeric-looking host #{host.inspect}"
+    end
+
     Socket.getaddrinfo(
       host, nil, Socket::AF_UNSPEC, Socket::SOCK_STREAM, 0, Socket::AI_NUMERICHOST
     ).map { |address| IPAddr.new(address[3]) }.uniq
@@ -270,9 +282,36 @@ module Surfguard
     text = host.to_s
     return true if text.include?(":") # Invalid IPv6 syntax is never a DNS name.
 
-    parts = text.split(".", -1)
+    legacy_ipv4_shape?(text)
+  end
+
+  def malformed_numeric_host_candidate?(host)
+    text = host.to_s
+    return false if text.include?(":") # IPv6 literals and zones go to AI_NUMERICHOST.
+
+    address, separator, remainder = text.partition(/[%\/]/)
+    address = remainder if address.empty?
+    labels = address.split(".", -1)
+    malformed = !separator.empty? || labels.any?(&:empty?)
+    return false unless malformed && legacy_ipv4_shape?(address)
+
+    # Full-width host prefixes are documented inputs and IPAddr parses them
+    # unambiguously. Shorter or otherwise invalid prefixes remain malformed.
+    return false if separator == "/" && full_width_host_literal?(text)
+
+    true
+  end
+
+  def legacy_ipv4_shape?(text)
+    parts = text.split(".", -1).reject(&:empty?)
     (1..4).cover?(parts.length) &&
       parts.all? { |part| part.match?(/\A(?:0[xX][0-9A-Fa-f]+|[0-9]+)\z/) }
+  end
+
+  def full_width_host_literal?(text)
+    host_address?(IPAddr.new(text))
+  rescue IPAddr::InvalidAddressError
+    false
   end
 
   # nil for anything IPAddr cannot parse. A shortened prefix is not a host and

--- a/lib/surfguard/version.rb
+++ b/lib/surfguard/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Surfguard
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end

--- a/test/surfguard_test.rb
+++ b/test/surfguard_test.rb
@@ -84,6 +84,35 @@ class SurfguardTest < Minitest::Test
     "hex link-local"              => "0xa9fea9fe"
   }.freeze
 
+  MALFORMED_NUMERIC_HOSTS = %w[
+    127.0.0.1.
+    127.1.
+    2130706433.
+    0x7f000001.
+    168.63.129.16.
+    93.184.216.34.
+    .127.0.0.1
+    127..1
+    127.0.0.1%0
+    127.0.0.1..
+    127...1
+    .1
+    1..
+    01.02.03.04.
+    0X7F000001.
+    0x7f.0.0.1.
+    0x7f..1
+    127.0.0.1%lo
+    127.0.0.1%25lo
+    127.0.0.1/33
+    127.0.0.1/-1
+    127.0.0.1/foo
+    127.1/8
+    2130706433/32
+    %127.0.0.1
+    /127.0.0.1
+  ].freeze
+
   NON_HOST_PREFIXES = %w[
     0.0.0.0/0
     ::/0
@@ -137,6 +166,16 @@ class SurfguardTest < Minitest::Test
 
   def test_siit_and_mapped_prefixes_do_not_overlap
     refute Surfguard::IPV4_TRANSLATABLE.include?(IPAddr.new("::ffff:169.254.169.254"))
+  end
+
+  def test_ipv4_compatible_classification_does_not_depend_on_obsolete_ipaddr_api
+    ipaddr_without_compat = Class.new(IPAddr) do
+      undef_method :ipv4_compat?
+    end
+
+    assert Surfguard.blocked_address?(ipaddr_without_compat.new("::93.184.216.34"))
+    assert Surfguard.blocked_address?(ipaddr_without_compat.new("::ffff:93.184.216.34"))
+    refute Surfguard.blocked_address?(ipaddr_without_compat.new("::ffff:0:5db8:d822"))
   end
 
   def test_blocks_an_unparseable_address
@@ -283,6 +322,67 @@ class SurfguardTest < Minitest::Test
   ensure
     Socket.define_singleton_method(:getaddrinfo, original_getaddrinfo)
     Resolv.define_singleton_method(:getaddresses, original_getaddresses)
+  end
+
+  def test_malformed_numeric_hosts_are_refused_without_dns
+    original = Resolv.method(:getaddresses)
+    dns_queries = []
+    Resolv.define_singleton_method(:getaddresses) do |host|
+      dns_queries << host
+      [ "93.184.216.34" ] # Model a public wildcard/search-domain answer.
+    end
+
+    MALFORMED_NUMERIC_HOSTS.each do |host|
+      assert_empty Surfguard.resolve_public_ips(host), host
+    end
+    assert_empty dns_queries
+  ensure
+    Resolv.define_singleton_method(:getaddresses, original)
+  end
+
+  def test_malformed_numeric_hosts_are_refused_before_a_loose_platform_parser
+    original_getaddrinfo = Socket.method(:getaddrinfo)
+    original_getaddresses = Resolv.method(:getaddresses)
+    numeric_queries = []
+    dns_queries = []
+    Socket.define_singleton_method(:getaddrinfo) do |host, *|
+      numeric_queries << host
+      [ [ "AF_INET", nil, nil, "93.184.216.34" ] ]
+    end
+    Resolv.define_singleton_method(:getaddresses) do |host|
+      dns_queries << host
+      [ "93.184.216.34" ]
+    end
+
+    url = "http://93.184.216.34./"
+    assert_empty Surfguard.resolve_public_ips("93.184.216.34.")
+    assert_nil Surfguard.resolve_public_ip(url)
+    refute Surfguard.resolvable_public_ip?(url)
+    assert_raises(Surfguard::Violation) { Surfguard.enforce_public_ip(url) }
+    assert_empty numeric_queries
+    assert_empty dns_queries
+  ensure
+    Socket.define_singleton_method(:getaddrinfo, original_getaddrinfo)
+    Resolv.define_singleton_method(:getaddresses, original_getaddresses)
+  end
+
+  def test_numeric_label_hostnames_still_reach_dns
+    names = %w[
+      123.example
+      123.example.
+      0xfoo.example
+      0x7f000001.example
+      127.example
+      127.0.0.1.example
+      1.2.3.4.5
+      example.com.
+    ]
+
+    stub_getaddresses(names.to_h { |name| [ name, [ "93.184.216.34" ] ] }) do
+      names.each do |name|
+        assert_equal [ "93.184.216.34" ], Surfguard.resolve_public_ips(name), name
+      end
+    end
   end
 
   def test_non_host_prefixes_are_rejected_without_dns

--- a/test/surfguard_test.rb
+++ b/test/surfguard_test.rb
@@ -111,6 +111,12 @@ class SurfguardTest < Minitest::Test
     2130706433/32
     %127.0.0.1
     /127.0.0.1
+    //127.0.0.1
+    %%127.0.0.1
+    /%127.0.0.1
+    %127.0.0.1%lo
+    /127.0.0.1/32
+    //127.0.0.1/
   ].freeze
 
   NON_HOST_PREFIXES = %w[
@@ -170,7 +176,10 @@ class SurfguardTest < Minitest::Test
 
   def test_ipv4_compatible_classification_does_not_depend_on_obsolete_ipaddr_api
     ipaddr_without_compat = Class.new(IPAddr) do
-      undef_method :ipv4_compat?
+      # Guarded: undef_method raises NameError when nothing is inherited, so an
+      # unguarded call would fail this test on the very ipaddr version whose
+      # removal of ipv4_compat? it exists to cover.
+      undef_method :ipv4_compat? if method_defined?(:ipv4_compat?)
     end
 
     assert Surfguard.blocked_address?(ipaddr_without_compat.new("::93.184.216.34"))


### PR DESCRIPTION
## Summary

- reject malformed IPv4-shaped tokens before consulting the platform numeric parser or DNS, including empty dot labels and invalid zone/prefix suffixes
- preserve legitimate absolute and numeric-leading DNS names, canonical legacy numeric forms, and full-width `/32` and `/128` host literals
- replace the obsolete `IPAddr#ipv4_compat?` dependency with direct `::/96` classification
- document the resolver invariant and prepare 0.1.3 because v0.1.2 is already published and immutable

## Assessment

The supplied tokens reached `Resolv` on 0.1.2 and could accept a wildcard/search-domain answer. glibc and musl both reject them at connection time, so no Linux SSRF bypass was reproduced; Windows behavior remains unverified. This closes the parser-identity class by policy rather than relying on platform strictness.

The IPAddr issue is compatibility hardening: supported Rubies still provide `ipv4_compat?`, but the API is obsolete and planned for removal in ipaddr 2.x. The patch avoids rescuing broad `NoMethodError`.

## Verification

- supplied eight-token matrix plus adjacent malformed dots, zones, prefixes, public payloads, and 59 generated variants under a deliberately loose simulated platform parser
- 188 tests, 615 assertions; 100% line and branch coverage
- full bare suite on Ruby 3.1.6, 3.2.9, 3.3.11, 3.4.10, and 4.0.6
- `bundle exec rubocop`
- `actionlint -color`
- authenticated `zizmor --persona=pedantic .`
- exact Ruby 3.4.10 / RubyGems 4.0.18 package build and isolated verification for `surfguard-0.1.3.gem`
- independent adversarial review found no actionable defect

## Release note

Hardening fix: refuse malformed IPv4-shaped hosts before numeric parsing or DNS, and remove reliance on the obsolete `IPAddr#ipv4_compat?` API. Upgrade to 0.1.3 for the strict parser/resolver identity invariant.