### PR TITLE
Harden address classification with reviewed IANA policies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [ main ]
   pull_request:
   workflow_dispatch:
+  schedule:
+    - cron: "17 9 * * 1"
 
 # Least privilege: no default grants; every job declares exactly what it needs.
 permissions: {}
@@ -20,12 +22,13 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    timeout-minutes: 15
     # head tracks unreleased Ruby — surface breakage early without blocking a merge.
     continue-on-error: ${{ matrix.ruby == 'head' }}
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ "3.1", "3.2", "3.3", "3.4", "4.0", "head" ]
+        ruby: [ "3.4.5", "3.4", "4.0", "head" ]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -36,6 +39,8 @@ jobs:
           # Bare Ruby on purpose: prove the gem and its suite need nothing
           # beyond the standard library (rake/minitest ship with Ruby).
           bundler-cache: false
+      - name: Reject vulnerable effective resolv versions
+        run: ruby script/check_resolv_version.rb
       - run: rake test
 
   lint:
@@ -43,6 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -51,11 +57,13 @@ jobs:
         with:
           ruby-version: "3.4"
           bundler-cache: true
+      - run: bundle exec ruby script/check_resolv_version.rb
       - run: bundle exec rubocop
       # Coverage thresholds plus the release-script fixture tests (test/release/).
       - run: bundle exec rake test
         env:
           COVERAGE: "1"
+      - run: ruby script/generate_iana_data.rb --check
       # dependency-review only screens vulnerable/licensed deps — it does not
       # reject a benign new runtime dependency. Enforce the invariant here so
       # a spec.add_dependency fails the PR, not the eventual release build.
@@ -73,6 +81,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -113,6 +122,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -123,17 +133,103 @@ jobs:
           fail-on-scopes: development, runtime, unknown
           show-openssf-scorecard: false
 
+  platforms:
+    name: "Core suite (${{ matrix.os }})"
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ macos-latest, windows-latest ]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
+        with:
+          ruby-version: "3.4.5"
+          bundler-cache: false
+      - run: ruby script/check_resolv_version.rb
+      - run: ruby -Itest -e 'Dir["test/surfguard*_test.rb"].sort.each { |file| require File.expand_path(file) }'
+      - run: ruby script/generate_iana_data.rb --check
+
+  musl:
+    name: Core suite (pinned musl)
+    runs-on: ubuntu-latest
+    container: ruby:3.4.5-alpine3.22@sha256:e284f39a2103a564dca9771a81bfecb455b04cd3be4149b133ed7e508ef1b65f
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - run: ruby script/check_resolv_version.rb
+      - run: ruby -Itest -e 'Dir["test/surfguard*_test.rb"].sort.each { |file| require File.expand_path(file) }'
+      - run: ruby script/generate_iana_data.rb --check
+
+  iana-drift:
+    name: IANA semantic drift
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
+        with:
+          ruby-version: "3.4.5"
+          bundler-cache: false
+      - run: ruby script/generate_iana_data.rb --check
+      - run: ruby script/check_iana_drift.rb
+
+  codeql:
+    name: CodeQL
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      # Repository default setup owns SARIF uploads. This independently runs
+      # the same pinned analyzer as a required CI fan-in job without creating
+      # an incompatible second code-scanning configuration.
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: github/codeql-action/init@f3712979fa5f215279b101dd0a2e3bdfb4353324 # v3
+        with:
+          languages: ruby
+      - uses: github/codeql-action/analyze@f3712979fa5f215279b101dd0a2e3bdfb4353324 # v3
+        with:
+          upload: never
+          upload-database: false
+
   # Stable fan-in for branch protection: require exactly one check ("CI")
   # regardless of how the matrix or job list evolves.
   ci:
     name: CI
     if: always()
-    needs: [ test, lint, lint-actions, dependency-review ]
+    timeout-minutes: 15
+    needs: [ test, lint, lint-actions, dependency-review, platforms, musl, iana-drift, codeql ]
     runs-on: ubuntu-latest
     permissions: {}
     steps:
       - name: Fail if any required job failed or was cancelled
         if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1
+      - name: Permit only the event-gated drift job to be skipped
+        if: needs.iana-drift.result == 'skipped' && github.event_name != 'push' && github.event_name != 'pull_request'
+        run: exit 1
+      - name: Permit dependency review to skip only outside pull requests
+        if: needs.dependency-review.result == 'skipped' && github.event_name == 'pull_request'
+        run: exit 1
+      - name: Reject every other skipped required job
+        if: needs.test.result == 'skipped' || needs.lint.result == 'skipped' || needs.lint-actions.result == 'skipped' || needs.platforms.result == 'skipped' || needs.musl.result == 'skipped' || needs.codeql.result == 'skipped'
         run: exit 1
       - name: All green
         run: echo "All required jobs succeeded (or were legitimately skipped)."

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ inherit_gem:
   rubocop-37signals: rubocop.yml
 
 AllCops:
-  TargetRubyVersion: 3.1
+  TargetRubyVersion: 3.4
   SuggestExtensions: false
 
 # assert_not is ActiveSupport, not minitest. This suite runs on bare Ruby

--- a/README.md
+++ b/README.md
@@ -1,13 +1,6 @@
 # Surfguard
 
-[![CI](https://github.com/basecamp/surfguard/actions/workflows/ci.yml/badge.svg)](https://github.com/basecamp/surfguard/actions/workflows/ci.yml)
-
-One SSRF address policy for Ruby apps that fetch a URL someone else supplied.
-
-It consolidates several drifting in-house copies of this policy into one — copies that had grown
-four different ideas of what "internal" means, including one that decoded a NAT64 prefix whose length
-is not recoverable from the address. This gem is their union, decided once and tested against the
-IPv4 × IPv6 range matrix it enforces.
+Surfguard resolves and classifies addresses for Ruby applications that fetch a URL supplied by someone else. It is deliberately not an HTTP client: the caller owns scheme restrictions, redirects, connection pinning, response limits, retries, and request deadlines.
 
 ## Installation
 
@@ -15,134 +8,152 @@ IPv4 × IPv6 range matrix it enforces.
 gem "surfguard"
 ```
 
-## What it does
+Surfguard requires Ruby 3.4.5 or newer and has zero runtime dependencies.
 
-Resolve **and classify only**. It cannot stop DNS rebinding by itself — the caller owns the fetch
-and must **pin** the connection to an address this returned.
+## APIs and policies
 
 ```ruby
-# Pinning caller (preferred): validate, then pin each address you try.
-Surfguard.resolve_public_ips("feeds.example.com")
-# => ["93.184.216.34", "2606:2800:220:1:248:1893:25c8:1946"]   (IPv4 first, blocked removed)
-# Iterate THIS list on failover; do not resolve again inside a retry loop.
-
-# Non-pinning preflight (hands the hostname to Net::HTTP, which resolves again):
-Surfguard.resolvable_public_ip?("https://feeds.example.com/atom")  # => true only if EVERY address is public
-Surfguard.enforce_public_ip(url)                                   # raises otherwise
-
-# Single-address compatibility shim:
-Surfguard.resolve_public_ip(url)   # => "93.184.216.34" or nil
-
-# The classification core, if you already hold an address:
-Surfguard.blocked_address?(IPAddr.new("169.254.169.254"))  # => true
+Surfguard.resolve_public_ips(host, policy: :default)
+Surfguard.resolvable_public_ip?(url, policy: :default)
+Surfguard.enforce_public_ip(url, policy: :default)
+Surfguard.resolve_public_ip(url, policy: :default)
+Surfguard.blocked_address?(ip, policy: :default)
 ```
 
-The non-pinning helpers conservatively require every address in their lookup to be public. They do
-not bind the later connection to that answer, so a second lookup can still change underneath them.
-Pinning is required when attacker-controlled DNS or DNS rebinding is in scope.
+`:default` is reachability-oriented. IPv4 retains the documented SSRF deny ranges. IPv6 is admitted only when it is in a checked-in IANA `Status=ALLOCATED` unicast prefix, subject to the explicit special/transition denies. Public NAT64/SIIT translations and globally reachable AMT/AS112 services remain admitted. This is intentionally not the much broader `2000::/3`.
 
-The direct address APIs accept endpoint addresses, not networks. A prefix shorter than `/32` or
-`/128` is refused rather than normalized into a host: `blocked_address?("10.0.0.1/8")` is `true`,
-and `resolve_public_ips("10.0.0.1/8")` is `[]`.
+`:iana_special_use` additionally blocks every prefix in the checked-in IANA IPv4 and IPv6 special-purpose registries, including AMT, AS112, and the whole NAT64 well-known prefix. Use it for advertised or discovered infrastructure values. A target must never choose its own policy; trusted consumer code chooses it.
 
-### Caller responsibilities
+For CIMD and similar discovery, strict address policy is only one layer. Consumers must still enforce HTTPS, reject userinfo, revalidate and pin redirects, limit response bytes, and apply egress controls.
 
-Surfguard classifies an address; it is not an HTTP client. The URL helpers do not restrict schemes,
-follow redirects, or make the request. Allow only the schemes your fetcher supports, and validate
-and pin every redirect target just as you did the original target. A pinning client must connect to
-the selected returned address while retaining the original hostname for HTTP Host and TLS identity.
+The host API accepts `String` or `IPAddr`; URL APIs accept `String`. Network prefixes are not endpoints. Invalid encodings, NUL, non-ASCII host syntax, unstable coercion, malformed resolver answers, and oversized answer sets fail closed. Unknown policies raise `ArgumentError` from every API.
 
-## Refused vs. unresolvable
+| Condition | plural | predicate | enforce | single | classifier |
+|---|---|---|---|---|---|
+| malformed direct input | `[]` | `false` | malformed `Violation` | `nil` | `true` |
+| empty, operational, or malformed resolver result | `Unresolvable` | `false` | `Unresolvable` | `Unresolvable` | n/a |
+| mixed public and blocked answers | public subset | `false` | `Violation` | `nil` | n/a |
+| unexpected programmer failure | escapes | escapes | escapes | escapes | escapes |
 
-"We refuse that address" and "the host didn't answer" are different answers, and
-collapsing them bites callers that treat a refusal as permanent. A webhook that
-deactivates a customer's endpoint on `Violation` would retire it on one bad DNS
-minute if a failed lookup arrived the same way.
+Messages are fixed and contain no input: `Host could not be resolved`, `Refusing blocked address`, and `Refusing malformed address`.
 
-| | resolves to something public | resolves, all blocked | resolves to nothing | malformed URL |
-|---|---|---|---|---|
-| `resolve_public_ips` (takes a host) | the public addresses | `[]` | raises `Unresolvable` | — |
-| `resolve_public_ip` | first public address | `nil` | raises `Unresolvable` | `nil` |
-| `enforce_public_ip` | returns | raises `Violation` | raises `Unresolvable` | raises `Violation` |
-| `resolvable_public_ip?` | `true` | `false` | `false` | `false` |
+The plural result is IPv4-first while preserving resolver order within each family. The single result preserves resolver order exactly. Answers are deduplicated in order; more than 256 raw or unique answers invalidates the lookup.
 
-`Unresolvable` is **not** a subclass of `Violation` — that's the whole point.
-Rescue both where you don't care which it was. Note the predicate answers the
-question it was asked and never raises; use `enforce_public_ip` or
-`resolve_public_ip` when you need to tell the cases apart.
+Only the returned plural or single address can be pinned. The predicate and enforcement helpers are conservative preflights; they do not bind a later connection, so resolving the hostname again after either helper reopens DNS-rebinding and resolver-divergence risk.
 
-## The policy
+## Pinning with Net::HTTP
 
-| Range | Handling |
-|---|---|
-| IPv4 private (10/8, 172.16/12, 192.168/16), loopback (127/8), link-local (169.254/16) | refuse |
-| CGNAT (100.64/10), benchmark (198.18/15), TEST-NETs, IETF (192.0.0/24), 6to4 relay anycast (192.88.99/24), multicast (224/4), reserved (240/4), "this" (0/8) | refuse |
-| Azure WireServer `168.63.129.16/32` | refuse — a fixed Azure platform/fabric alias, not an RFC special-use range |
-| IPv6 ULA (fc00::/7, incl. IMDSv6 `fd00:ec2::254`), loopback (::1), link-local (fe80::/10), site-local (fec0::/10), multicast (ff00::/8), unspecified (::), discard/dummy (100::/64, 100:0:0:1::/64), documentation (2001:db8::/32, 3fff::/20), SRv6 SID (5f00::/16) | refuse |
-| IETF protocol assignments (2001::/23) | refuse by default, including Teredo, benchmark, PCP/TURN/DNS-SD anycast to nearby infrastructure, deprecated ORCHID, ORCHIDv2, DET, and unallocated space; allow only AMT (2001:3::/32) and AS112-v6 (2001:4:112::/48) |
-| IPv4-mapped `::ffff:0:0/96`, IPv4-compatible `::/96` | refuse outright |
-| **SIIT `::ffff:0:0:0/96`** | decode embedded IPv4 (low 32 bits), re-check |
-| NAT64 well-known `64:ff9b::/96` | decode embedded IPv4 (low 32 bits), re-check |
-| **RFC 8215 NAT64 local-use `64:ff9b:1::/48`** | **refuse outright** — the Pref64 length is not recoverable from the address (RFC 6052 §2.2), so a low-32-bit decode reads the wrong octets; and the block is never globally routed |
-| 6to4 `2002::/16` | refuse (a 6to4 address is just an IPv4 address in disguise) |
+This recipe disables environment proxies, retains the original hostname for HTTP Host, TLS SNI, and certificate verification, and pins the validated address. Retry only addresses already returned by the first lookup. Every redirect starts this process again with the redirect's own URL.
 
-This is an SSRF address policy, not a label-only copy of the IANA special-purpose registry. It
-refuses internal, non-destination, non-global domain, and overlay-identifier ranges plus transition
-encodings that can conceal a blocked target. Actual globally reachable IP-layer services such as
-AMT and AS112 remain valid; ORCHID and DET identifiers do not, because they can be interpreted by a
-local overlay rather than routed as ordinary public IP destinations.
+<!-- net-http-recipe:start -->
+```ruby
+require "net/http"
+require "openssl"
+require "surfguard"
+require "uri"
 
-## Three things worth knowing
+PINNED_MAX_REDIRECTS = 10
+PINNED_MAX_BYTES = 16 * 1024 * 1024
 
-**1. Numeric parsing and name resolution are both part of the policy.** Before asking DNS,
-Surfguard asks the system numeric-host parser used by `Socket`/`Net::HTTP` whether the token is an
-address. This recognizes non-canonical decimal, hexadecimal, octal, and shortened IPv4 forms. A
-numeric token is classified directly and is never sent through DNS or a search domain. Malformed
-IPv4-shaped variants with empty dot labels or invalid zone/prefix suffixes are refused rather than
-reinterpreted as DNS names.
+class PinnedResponseTooLarge < StandardError; end
+class PinnedRedirectError < StandardError; end
 
-Names resolve with `Resolv.getaddresses`, which uses Ruby's usual hosts-plus-DNS chain, honours
-search domains, and returns every address. The obvious alternatives each drop something a guard
-can't afford to lose:
+def checked_https_uri(value, base: nil)
+  uri = base ? URI.join(base, value) : URI(value)
+  raise ArgumentError, "HTTPS required", cause: nil unless uri.is_a?(URI::HTTPS)
+  raise ArgumentError, "userinfo forbidden", cause: nil if uri.userinfo
+  raise ArgumentError, "host required", cause: nil if uri.hostname.nil? || uri.hostname.empty?
 
-- `Resolv.getaddress` honours `/etc/hosts` but returns only the **first** address — so an AAAA-only
-  host deterministically takes the IPv6 path, and a multi-homed host is validated on one address
-  while the connection may use another.
-- `Resolv::DNS.open` returns every DNS address but **ignores** `/etc/hosts` and the other parts of
-  the default resolver chain.
+  uri
+rescue URI::InvalidURIError
+  raise ArgumentError, "malformed URL", cause: nil
+end
 
-Ruby `Resolv` is not a universal substitute for the system `getaddrinfo` name-service chain. A host
-with custom NSS sources such as mDNS or LDAP can produce a different answer at connection time.
-Pinning a returned address avoids that second name lookup; non-pinning deployments need a resolver
-configuration in which Ruby's hosts-plus-DNS answers match the connection layer, or an independent
-egress control. Resolver-chain equivalence does not eliminate the separate DNS-rebinding window.
+def pinned_get_hop(uri, policy:, max_bytes:)
+  hostname = uri.hostname # strips IPv6 URI brackets; preserves DNS identity
+  addresses = Surfguard.resolve_public_ips(hostname, policy: policy)
+  raise Surfguard::Violation, Surfguard::BLOCKED_MESSAGE, cause: nil if addresses.empty?
 
-**2. A resolver-level "no AAAA" switch is not a mitigation.** Disabling AAAA at the system resolver
-(for example Kamal's `dns-opt: no-aaaa`) is a glibc `getaddrinfo` option. Surfguard resolves through
-pure-Ruby `Resolv`, which requests AAAA regardless, so IPv6 answers still reach it. Don't treat that
-deploy setting as if it narrowed Surfguard's input.
+  addresses.each do |address|
+    http = Net::HTTP.new(hostname, uri.port, nil) # nil disables environment proxies
+    http.use_ssl = true
+    http.ipaddr = address                         # connect only to this validated address
+    http.verify_mode = OpenSSL::SSL::VERIFY_PEER
+    http.verify_hostname = true
+    http.open_timeout = 5
+    http.read_timeout = 15
+    http.write_timeout = 15
+    begin
+      body = String.new(encoding: Encoding::BINARY)
+      request = Net::HTTP::Get.new(uri.request_uri, "Accept-Encoding" => "identity")
+      response = http.request(request) do |candidate|
+        candidate.read_body do |chunk|
+          raise PinnedResponseTooLarge, "response body exceeds limit", cause: nil if
+            chunk.bytesize > max_bytes - body.bytesize
 
-**3. Custom DNS64 prefixes need their own enforcement.** Surfguard can decode and re-check the
-fixed NAT64 well-known prefix `64:ff9b::/96`, and it refuses the RFC 8215 local-use block outright.
-It cannot infer the embedded IPv4 address in an arbitrary network-specific Pref64 from the
-synthesized IPv6 address alone. A deployment using DNS64 with another Pref64 must enforce the same
-blocked-address policy at its DNS64/NAT64 or egress layer.
+          body << chunk
+        end
+      end
+      return [ response, body.freeze ]
+    rescue IOError, SystemCallError, Timeout::Error
+      # Try the next address from the original validated list. Never resolve again here.
+    end
+  end
+  raise Surfguard::Unresolvable, Surfguard::UNRESOLVABLE_MESSAGE, cause: nil
+end
 
-## Testing
+def pinned_get(url, policy: :default, max_redirects: 5, max_bytes: 1024 * 1024)
+  unless max_redirects.is_a?(Integer) && (0..PINNED_MAX_REDIRECTS).cover?(max_redirects)
+    raise ArgumentError, "invalid redirect limit", cause: nil
+  end
+  unless max_bytes.is_a?(Integer) && (1..PINNED_MAX_BYTES).cover?(max_bytes)
+    raise ArgumentError, "invalid response limit", cause: nil
+  end
 
-```bash
-ruby -Ilib test/surfguard_test.rb
-# The full BLOCKED/ALLOWED matrix, checked as execution. Bare Ruby, no gems needed.
+  uri = checked_https_uri(url)
+  redirects = 0
+  loop do
+    response, body = pinned_get_hop(uri, policy: policy, max_bytes: max_bytes)
+    return [ response, body ] unless response.is_a?(Net::HTTPRedirection)
+
+    raise PinnedRedirectError, "redirect limit exceeded", cause: nil if redirects >= max_redirects
+
+    location = response["location"]
+    raise PinnedRedirectError, "redirect location missing", cause: nil if location.nil? || location.empty?
+
+    uri = checked_https_uri(location, base: uri)
+    redirects += 1
+  end
+end
 ```
+<!-- net-http-recipe:end -->
+
+The recipe returns `[response, body]`. It streams and caps each response body, caps redirect count, rejects non-HTTPS or userinfo-bearing redirects, and performs a fresh validation and pin for every redirect target. It never follows a redirect on the previous connection. The hard ceilings prevent a caller from accidentally configuring either bound away; choose smaller trusted values when appropriate.
+
+Surfguard's synchronous resolver has no independent cancellation deadline. The caller must apply a request or worker deadline around the whole operation. Surfguard intentionally does not use `Timeout.timeout`, which can interrupt code at unsafe points.
+
+## Policy boundaries and residual topology risk
+
+Surfguard blocks private, loopback, link-local, CGNAT, documentation, benchmark, multicast, reserved, IETF protocol, deprecated transition, ULA, and other explicitly listed address space. It also blocks Azure WireServer `168.63.129.16`; other provider/platform aliases need equivalent consumer egress policy when they are not represented by a standard address range.
+
+Address labels cannot prove reachability. DNS rebinding is prevented only when the caller pins. Ruby `Resolv` can differ from NSS sources such as mDNS or LDAP; platform and version configuration can also change AAAA behavior. A glibc `no-aaaa` setting does not control pure-Ruby `Resolv`.
+
+Custom DNS64 prefixes cannot be decoded from an address without deployment configuration. ISATAP and 6rd can give deployment-specific meaning to otherwise public-looking IPv6 addresses. Publicly addressed space may be routed internally. Platform aliases can also live in globally addressed space. Surfguard does not add a hostname blocklist or attempt to infer those topologies. Enforce outbound firewall/egress ACLs so the fetch worker cannot reach internal services even when addressing is unusual.
+
+The default policy intentionally admits public NAT64/SIIT destinations and globally reachable AMT/AS112 services. The strict policy intentionally overblocks all registered special-purpose prefixes. Choose based on the trusted source of the target, not target-supplied data.
+
+Operator-named development fixtures are outside Surfguard policy. If a consumer needs one, make it an exact consumer-owned exception gated by trusted configuration and restricted to an approved scheme, literal loopback address, and exact port. Do not expose a general loopback mode or let request data activate it.
+
+Environment proxies can cause a validated URL to connect somewhere else; construct `Net::HTTP` with the explicit `nil` proxy argument as above. Restrict supported schemes, userinfo, redirects, response bytes, decompression, and request duration in the consumer. Egress ACLs remain the final boundary.
+
+## Registry data
+
+Runtime classification never fetches registry data. Normalized IANA snapshots, source URLs, registry update dates, and raw SHA-256 digests live under `script/iana`. Generated runtime constants are deeply frozen. Scheduled and release checks report drift and require a reviewed human update; they never rewrite policy automatically.
+
+## Dependency residual risk
+
+Ruby 3.4.5 is the minimum supported interpreter. CI rejects effective `resolv` versions `<0.2.3`, `>=0.3.0,<0.3.1`, and `>=0.4.0,<0.6.2`. Explicitly replacing the patched standard-library gem with an affected version is unsupported residual risk. Surfguard will not add a runtime dependency or runtime version guard for that operator override.
 
 ## Security
 
-Surfguard is a security control, so classification bugs are vulnerabilities. Report them privately
-per the [security policy](https://github.com/basecamp/surfguard/security/policy) — not the public
-issue tracker.
-
-## Status
-
-Extracted and consolidated from several in-house SSRF guards, tested against the full
-policy matrix. Resolve-and-classify only; callers pin. See the
-[releases page](https://github.com/basecamp/surfguard/releases) for versions and changes.
+Report classification vulnerabilities privately using the [security policy](https://github.com/basecamp/surfguard/security/policy). Do not open a public issue.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,6 +31,10 @@ pinning, custom DNS64 prefixes, and nonstandard NSS sources have caller or deplo
 documented in the README. Those boundaries by themselves are not classification bugs, but a bypass
 when the documented contract is followed qualifies.
 
+Synchronous name resolution has no independent cancellation deadline; callers own request and
+worker deadlines. Public-addressed internal routes, custom DNS64, ISATAP/6rd, provider aliases,
+proxy configuration, and resolver/NSS divergence remain deployment risks requiring egress controls.
+
 Non-security bugs and questions belong in the
 [regular issue tracker](https://github.com/basecamp/surfguard/issues).
 

--- a/lib/surfguard.rb
+++ b/lib/surfguard.rb
@@ -152,7 +152,7 @@ module Surfguard
     return true if NAT64_LOCAL_USE.include?(ipaddr)
 
     if NAT64_WELL_KNOWN.include?(ipaddr) || IPV4_TRANSLATABLE.include?(ipaddr)
-      return disallowed_ipv4?(embedded_ipv4(ipaddr))
+      return disallowed_ipv4?(embedded_ipv4(ipaddr), policy: policy)
     end
 
     disallowed_ipv6?(ipaddr)
@@ -378,8 +378,9 @@ module Surfguard
       ranges.any? { |range| range.include?(ip) }
     end
 
-    def disallowed_ipv4?(ip)
-      ip.private? || ip.loopback? || ip.link_local? ||
+    def disallowed_ipv4?(ip, policy: :default)
+      (policy == :iana_special_use && iana_special_use?(ip)) ||
+        ip.private? || ip.loopback? || ip.link_local? ||
         DISALLOWED_IPV4.any? { |range| range.include?(ip) }
     end
 

--- a/lib/surfguard.rb
+++ b/lib/surfguard.rb
@@ -7,358 +7,392 @@ require "uri"
 
 require_relative "surfguard/version"
 
-# One SSRF address policy for a Ruby app that fetches a URL someone else supplied.
-# It consolidates several drifting in-house copies of this policy — copies that had
-# grown four different ideas of what "internal" means, including one that decoded a
-# NAT64 prefix whose length is not recoverable from the address. This is their
-# union, decided once.
-#
-# Two policy decisions the copies drifted on, settled here and explained where
-# they live in the code:
-#
-#   * Resolver (see .resolve_public_ips): first use getaddrinfo's numeric-only
-#     parser so legacy decimal, hex, octal, and short IPv4 forms mean exactly
-#     what they do to Net::HTTP; never send those tokens to DNS. Names resolve
-#     with Resolv.getaddresses, which honours /etc/hosts and search domains AND
-#     returns every address. One copy used Resolv.getaddress (honours hosts, but
-#     only the FIRST address, so an AAAA-only host deterministically selected the
-#     IPv6 path); another used Resolv::DNS.open (all addresses, but ignores
-#     /etc/hosts, so it validated a different set than Net::HTTP would connect
-#     to). getaddresses is complete for Ruby's hosts-plus-DNS chain; system
-#     getaddrinfo may additionally consult NSS sources such as mDNS or LDAP.
-#
-#   * `no-aaaa` in Kamal `dns-opt` is NOT a mitigation. It is a glibc
-#     getaddrinfo option; every guard here resolves through pure-Ruby Resolv,
-#     which asks for AAAA regardless. IPv6 answers reach this code in production.
-#     Do not treat the deploy config as if it narrowed the input.
-#
-# THREAT MODEL / caller contract: this only resolves and classifies. It cannot
-# stop DNS rebinding on its own. A caller must PIN the connection to an address
-# this returned (Net::HTTP#ipaddr=), because a second lookup at connect time can
-# answer differently than the one that was validated. The plural API exists so
-# that a caller failing over between addresses iterates the validated list rather
-# than resolving again inside its retry loop. A non-pinning caller must instead
-# use .resolvable_public_ip?/.enforce_public_ip, which refuse unless EVERY
-# resolved address is public.
+# Resolve and classify addresses for callers that pin the selected address at
+# connection time. Surfguard deliberately does not perform HTTP requests.
 module Surfguard
   class Violation < StandardError; end
-
-  # Internal signal for something IPAddr can parse, but which is a network
-  # rather than a host. Keep it separate from a lookup failure: callers must
-  # refuse these inputs without asking DNS to reinterpret them as names.
-  class InvalidHost < ArgumentError; end
-  private_constant :InvalidHost
-
-  # The host answered with no address at all. Deliberately NOT a Violation:
-  # nothing was refused here, the lookup simply came back empty, which is
-  # usually a transient upstream failure. A caller that gives up permanently on
-  # a Violation -- a webhook deactivating a customer's endpoint, say -- must not
-  # give up the same way on this, or one bad DNS minute retires the endpoint for
-  # good. Callers that don't care can rescue both.
   class Unresolvable < StandardError; end
+
+  class InvalidInput < ArgumentError; end
+  class InvalidResolverResult < StandardError; end
+  private_constant :InvalidInput, :InvalidResolverResult
 
   extend self
 
-  # IPv4 special-use ranges and exact platform aliases that must never be a
-  # fetch target (RFC 5735/6890, plus CGNAT and benchmarking). RFC1918 /
-  # loopback / link-local are also covered by the IPAddr predicates in
-  # #disallowed_ipv4?; they are restated here so the policy is complete and
-  # auditable in one place.
-  DISALLOWED_IPV4 = [
-    IPAddr.new("0.0.0.0/8"),        # "This" network (RFC 1122)
-    IPAddr.new("10.0.0.0/8"),       # Private (RFC 1918)
-    IPAddr.new("100.64.0.0/10"),    # Carrier-grade NAT (RFC 6598)
-    IPAddr.new("127.0.0.0/8"),      # Loopback (RFC 1122)
-    IPAddr.new("168.63.129.16/32"), # Azure host-node WireServer virtual IP
-    IPAddr.new("169.254.0.0/16"),   # Link-local (RFC 3927) — includes the cloud metadata endpoint
-    IPAddr.new("172.16.0.0/12"),    # Private (RFC 1918)
-    IPAddr.new("192.0.0.0/24"),     # IETF protocol assignments (RFC 6890)
-    IPAddr.new("192.0.2.0/24"),     # TEST-NET-1 (RFC 5737)
-    IPAddr.new("192.88.99.0/24"),   # 6to4 relay anycast (RFC 7526)
-    IPAddr.new("192.168.0.0/16"),   # Private (RFC 1918)
-    IPAddr.new("198.18.0.0/15"),    # Benchmark testing (RFC 2544)
-    IPAddr.new("198.51.100.0/24"),  # TEST-NET-2 (RFC 5737)
-    IPAddr.new("203.0.113.0/24"),   # TEST-NET-3 (RFC 5737)
-    IPAddr.new("224.0.0.0/4"),      # Multicast (RFC 5771)
-    IPAddr.new("240.0.0.0/4")       # Reserved / future use (RFC 1112)
-  ].freeze
+  UNRESOLVABLE_MESSAGE = "Host could not be resolved"
+  BLOCKED_MESSAGE = "Refusing blocked address"
+  MALFORMED_MESSAGE = "Refusing malformed address"
+  MAX_HOST_BYTES = 255
+  MAX_ADDRESSES = 256
+  POLICIES = %i[default iana_special_use].freeze
 
-  # IPv6 special-use ranges beyond what private? (ULA fc00::/7, incl. the IMDSv6
-  # address fd00:ec2::254), loopback (::1) and link-local (fe80::/10) already
-  # cover. 6to4 and Teredo are deprecated transition mechanisms with no
-  # legitimate fetch target — 2002:7f00:1:: is just a 6to4 spelling of 127.0.0.1.
-  DISALLOWED_IPV6 = [
-    IPAddr.new("::/128"),           # Unspecified (RFC 4291)
-    IPAddr.new("100::/64"),         # Discard-only (RFC 6666)
-    IPAddr.new("100:0:0:1::/64"),   # Dummy IPv6 destination (RFC 9780)
-    IPAddr.new("2001::/32"),        # Teredo (RFC 4380)
-    IPAddr.new("2001:2::/48"),      # Benchmark testing (RFC 5180)
-    IPAddr.new("2001:db8::/32"),    # Documentation (RFC 3849)
-    IPAddr.new("2002::/16"),        # 6to4 (RFC 3056)
-    IPAddr.new("3fff::/20"),        # Documentation (RFC 9637)
-    IPAddr.new("5f00::/16"),        # SRv6 SIDs, confined to SR domains (RFC 9602)
-    IPAddr.new("fec0::/10"),        # Deprecated site-local (RFC 3879)
-    IPAddr.new("ff00::/8")          # Multicast (RFC 4291)
-  ].freeze
+  # iana-generator:begin IANA_ALLOCATED_IPV6_UNICAST
+  # Generated from IANA IPv6 Global Unicast Status=ALLOCATED rows.
+  # Source provenance is checked in under script/iana.
+  IANA_ALLOCATED_IPV6_UNICAST = %w[
+    2001::/23 2001:200::/23 2001:400::/23 2001:600::/23 2001:800::/22
+    2001:c00::/23 2001:e00::/23 2001:1200::/23 2001:1400::/22 2001:1800::/23
+    2001:1a00::/23 2001:1c00::/22 2001:2000::/19 2001:4000::/23 2001:4200::/23
+    2001:4400::/23 2001:4600::/23 2001:4800::/23 2001:4a00::/23 2001:4c00::/23
+    2001:5000::/20 2001:8000::/19 2001:a000::/20 2001:b000::/20 2002::/16
+    2003::/18 2400::/12 2410::/12 2600::/12 2610::/23 2620::/23 2630::/12
+    2800::/12 2a00::/12 2a10::/12 2c00::/12
+  ].map { |cidr| IPAddr.new(cidr).freeze }.freeze
+  # iana-generator:end IANA_ALLOCATED_IPV6_UNICAST
 
-  # The IANA parent assignment is non-source, non-destination, non-forwardable,
-  # and non-global unless a more-specific allocation says otherwise. Refuse it
-  # by default so unallocated/future-special space cannot become an internal
-  # fetch path. These are the current, narrowly scoped IP-layer services whose
-  # registrations explicitly permit globally reachable destinations without
-  # selecting nearby infrastructure. PCP, TURN, and DNS-SD SRP anycast remain
-  # refused because they deliberately target on-path or local services. ORCHID,
-  # ORCHIDv2, and DET are overlay identifiers, not ordinary IP-layer locators.
-  IETF_PROTOCOL_ASSIGNMENTS = IPAddr.new("2001::/23")
-  GLOBALLY_REACHABLE_IETF_ASSIGNMENTS = [
-    IPAddr.new("2001:3::/32"),       # AMT (RFC 7450)
-    IPAddr.new("2001:4:112::/48")    # AS112-v6 (RFC 7535)
-  ].freeze
+  DISALLOWED_IPV4 = %w[
+    0.0.0.0/8 10.0.0.0/8 100.64.0.0/10 127.0.0.0/8
+    168.63.129.16/32 169.254.0.0/16 172.16.0.0/12 192.0.0.0/24
+    192.0.2.0/24 192.88.99.0/24 192.168.0.0/16 198.18.0.0/15
+    198.51.100.0/24 203.0.113.0/24 224.0.0.0/4 240.0.0.0/4
+  ].map { |cidr| IPAddr.new(cidr).freeze }.freeze
 
-  # NAT64 embeds an IPv4 target that must be re-checked as IPv4. The well-known
-  # prefix is a fixed /96, so the embedded octets are always the low 32 bits:
-  # decode and re-check them, and NAT64 to a public address still resolves.
-  NAT64_WELL_KNOWN = IPAddr.new("64:ff9b::/96")   # RFC 6052
+  DISALLOWED_IPV6 = %w[
+    ::/128 100::/64 100:0:0:1::/64 2001::/32 2001:2::/48
+    2001:db8::/32 2002::/16 3fff::/20 5f00::/16 fec0::/10 ff00::/8
+  ].map { |cidr| IPAddr.new(cidr).freeze }.freeze
 
-  # The RFC 8215 local-use block is refused whole, not decoded. It can host a
-  # Pref64 of any length (/32…/96) whose embedded position is NOT recoverable
-  # from the address alone (RFC 6052 §2.2), so decoding the low 32 bits reads the
-  # wrong octets and can under-block. It is also never globally routed, so there
-  # is no legitimate feed behind it. This is the divergence some in-house copies
-  # got wrong by decoding both prefixes the same way.
-  NAT64_LOCAL_USE = IPAddr.new("64:ff9b:1::/48")  # RFC 8215
+  # iana-generator:begin IANA_SPECIAL_USE_IPV4
+  # Every prefix in the checked-in IANA IPv4 special-purpose snapshot.
+  IANA_SPECIAL_USE_IPV4 = %w[
+    0.0.0.0/8 0.0.0.0/32 10.0.0.0/8 100.64.0.0/10 127.0.0.0/8 169.254.0.0/16
+    172.16.0.0/12 192.0.0.0/24 192.0.0.0/29 192.0.0.8/32 192.0.0.9/32
+    192.0.0.10/32 192.0.0.170/32 192.0.0.171/32 192.0.2.0/24 192.31.196.0/24
+    192.52.193.0/24 192.88.99.0/24 192.88.99.2/32 192.168.0.0/16
+    192.175.48.0/24 198.18.0.0/15 198.51.100.0/24 203.0.113.0/24 240.0.0.0/4
+    255.255.255.255/32
+  ].map { |cidr| IPAddr.new(cidr).freeze }.freeze
+  # iana-generator:end IANA_SPECIAL_USE_IPV4
 
-  # SIIT's IPv4-translated form is the third way an IPv4 address rides inside an
-  # IPv6 one, and the only one Ruby has no predicate for: ipv4_mapped?,
-  # ipv4_compat?, private?, loopback? and link_local? are all false for
-  # ::ffff:0:169.254.169.254, so it would reach the metadata address straight
-  # through the branches below. Note the extra group — ::ffff:0:0:0/96 is NOT the
-  # familiar IPv4-mapped ::ffff:0:0/96, and the two ranges do not overlap. Like
-  # the NAT64 well-known prefix it is a fixed /96, so decode the low 32 bits.
-  IPV4_TRANSLATABLE = IPAddr.new("::ffff:0:0:0/96") # RFC 2765
+  # iana-generator:begin IANA_SPECIAL_USE_IPV6
+  # Every prefix in the checked-in IANA IPv6 special-purpose snapshot.
+  IANA_SPECIAL_USE_IPV6 = %w[
+    ::1/128 ::/128 ::ffff:0:0/96 64:ff9b::/96 64:ff9b:1::/48 100::/64
+    100:0:0:1::/64 2001::/23 2001::/32 2001:1::1/128 2001:1::2/128
+    2001:1::3/128 2001:2::/48 2001:3::/32 2001:4:112::/48 2001:10::/28
+    2001:20::/28 2001:30::/28 2001:db8::/32 2002::/16 2620:4f:8000::/48
+    3fff::/20 5f00::/16 fc00::/7 fe80::/10
+  ].map { |cidr| IPAddr.new(cidr).freeze }.freeze
+  # iana-generator:end IANA_SPECIAL_USE_IPV6
 
-  # IPv4-compatible IPv6 is deprecated and must never be a DNS fetch target.
-  # Classify the prefix directly instead of calling IPAddr#ipv4_compat?, which
-  # has been obsolete since Ruby 2.5 and is expected to disappear in ipaddr 2.x.
-  IPV4_COMPATIBLE = IPAddr.new("::/96")
+  IETF_PROTOCOL_ASSIGNMENTS = IPAddr.new("2001::/23").freeze
+  GLOBALLY_REACHABLE_IETF_ASSIGNMENTS = %w[
+    2001:3::/32 2001:4:112::/48
+  ].map { |cidr| IPAddr.new(cidr).freeze }.freeze
+  NAT64_WELL_KNOWN = IPAddr.new("64:ff9b::/96").freeze
+  NAT64_LOCAL_USE = IPAddr.new("64:ff9b:1::/48").freeze
+  IPV4_TRANSLATABLE = IPAddr.new("::ffff:0:0:0/96").freeze
+  IPV4_COMPATIBLE = IPAddr.new("::/96").freeze
 
-  # Every PUBLIC address the host resolves to, IPv4 ahead of IPv6, DNS order
-  # preserved within each family so a provider's round-robin still spreads load.
-  # Empty when the host resolves but every address is blocked; raises
-  # Unresolvable when it resolves to nothing at all, so the caller can tell a
-  # refusal from a lookup failure. A caller that fails over MUST iterate this
-  # list and pin each address; resolving again reopens the rebinding window.
-  # Accepts a hostname or an IP-literal host.
-  def resolve_public_ips(host)
-    addresses = resolve(host)
-    raise Unresolvable, "No address for #{host}" if addresses.empty?
+  POLICY_RANGES = {
+    default: {
+      allocated_ipv6: IANA_ALLOCATED_IPV6_UNICAST,
+      disallowed_ipv4: DISALLOWED_IPV4,
+      disallowed_ipv6: DISALLOWED_IPV6
+    }.freeze,
+    iana_special_use: {
+      ipv4: IANA_SPECIAL_USE_IPV4,
+      ipv6: IANA_SPECIAL_USE_IPV6
+    }.freeze
+  }.freeze
 
-    addresses.reject { |ip| blocked_address?(ip) }
-             .partition(&:ipv4?)
-             .flatten
-             .map(&:to_s)
-  rescue InvalidHost
-    []
+  # Return every admitted address, with IPv4 before IPv6 and resolver order
+  # retained within each family. Malformed direct input returns [].
+  def resolve_public_ips(host, policy: :default)
+    validate_policy!(policy)
+    addresses = resolve(normalize_host(host))
+    public_addresses = addresses.reject { |ip| blocked_address?(ip, policy: policy) }
+    ipv4, ipv6 = public_addresses.partition(&:ipv4?)
+    (ipv4 + ipv6).map { |ip| ip.to_s.freeze }.freeze
+  rescue InvalidInput
+    [].freeze
   end
 
-  # True only if the URL's host resolves to at least one address and NONE are
-  # blocked. For non-pinning callers (they hand the hostname straight to
-  # Net::HTTP, which resolves again), so anything short of "every address is
-  # public" is unsafe. A predicate answers the question it was asked and doesn't
-  # raise: false covers unresolvable and malformed alike. Reach for
-  # .enforce_public_ip or .resolve_public_ip when you need to tell those apart.
-  def resolvable_public_ip?(url)
-    addresses = resolve(host_of(url))
-    addresses.any? && addresses.none? { |ip| blocked_address?(ip) }
-  rescue URI::InvalidURIError, IPAddr::InvalidAddressError, ArgumentError
+  # True only when the URL resolves and every answer is admitted.
+  def resolvable_public_ip?(url, policy: :default)
+    validate_policy!(policy)
+    addresses = resolve(host_of(normalize_url(url)))
+    addresses.none? { |ip| blocked_address?(ip, policy: policy) }
+  rescue InvalidInput, Unresolvable
     false
   end
 
-  # Raise unless the URL's host is safe, for call sites that want a hard stop
-  # rather than a boolean: Unresolvable when it answers with nothing, Violation
-  # when it answers with something we refuse. A malformed URL is a Violation --
-  # there was never a lookup to fail.
-  def enforce_public_ip(url)
-    addresses = resolve(host_of(url))
-    raise Unresolvable, "No address for #{url}" if addresses.empty?
-    raise Violation, "Refusing to fetch private/internal address for #{url}" if addresses.any? { |ip| blocked_address?(ip) }
-  rescue URI::InvalidURIError, IPAddr::InvalidAddressError, ArgumentError
-    raise Violation, "Refusing to fetch malformed address for #{url}"
+  def enforce_public_ip(url, policy: :default)
+    validate_policy!(policy)
+    addresses = resolve(host_of(normalize_url(url)))
+    if addresses.any? { |ip| blocked_address?(ip, policy: policy) }
+      raise Violation, BLOCKED_MESSAGE, cause: nil
+    end
+
+    nil
+  rescue InvalidInput
+    raise Violation, MALFORMED_MESSAGE, cause: nil
   end
 
-  # The single-address compatibility shim for callers migrating from an older
-  # first-address-only guard. Returns the first public address as a String, nil
-  # if the host is malformed or resolves to anything blocked, and raises
-  # Unresolvable if it resolves to nothing -- which is where an older guard
-  # built on Resolv.getaddress raised Resolv::ResolvError, so callers that
-  # distinguished a lookup failure keep doing so. Prefer .resolve_public_ips.
-  def resolve_public_ip(url)
-    addresses = resolve(host_of(url))
-    raise Unresolvable, "No address for #{url}" if addresses.empty?
-    return nil if addresses.any? { |ip| blocked_address?(ip) }
+  # Preserve resolver order here; unlike the plural API this method does not
+  # reorder address families.
+  def resolve_public_ip(url, policy: :default)
+    validate_policy!(policy)
+    addresses = resolve(host_of(normalize_url(url)))
+    return nil if addresses.any? { |ip| blocked_address?(ip, policy: policy) }
 
-    addresses.first.to_s
-  rescue URI::InvalidURIError, IPAddr::InvalidAddressError, ArgumentError
+    addresses.first.to_s.freeze
+  rescue InvalidInput
     nil
   end
 
-  # The classification core. True if this address must never be a fetch target.
-  # Accepts an IPAddr or anything IPAddr.new understands. Errs closed: an address
-  # it cannot parse is blocked.
-  def blocked_address?(ip)
-    ipaddr = ip.is_a?(IPAddr) ? ip : IPAddr.new(ip.to_s)
-    return true unless host_address?(ipaddr)
+  # Classify one endpoint. Malformed inputs and networks fail closed.
+  def blocked_address?(ip, policy: :default)
+    validate_policy!(policy)
+    ipaddr = normalize_ip(ip)
 
-    # DNS never legitimately returns an IPv4 address embedded these two ways, so
-    # refuse them regardless of the address they wrap.
-    if ipaddr.ipv4_mapped? || IPV4_COMPATIBLE.include?(ipaddr)
-      true
-    elsif ipaddr.ipv4?
-      disallowed_ipv4?(ipaddr)
-    elsif NAT64_LOCAL_USE.include?(ipaddr)
-      true
-    elsif NAT64_WELL_KNOWN.include?(ipaddr) || IPV4_TRANSLATABLE.include?(ipaddr)
-      disallowed_ipv4?(embedded_ipv4(ipaddr))
-    else
-      disallowed_ipv6?(ipaddr)
+    return true if policy == :iana_special_use && iana_special_use?(ipaddr)
+    return true if ipaddr.ipv4_mapped? || IPV4_COMPATIBLE.include?(ipaddr)
+    return disallowed_ipv4?(ipaddr) if ipaddr.ipv4?
+    return true if NAT64_LOCAL_USE.include?(ipaddr)
+
+    if NAT64_WELL_KNOWN.include?(ipaddr) || IPV4_TRANSLATABLE.include?(ipaddr)
+      return disallowed_ipv4?(embedded_ipv4(ipaddr))
     end
-  rescue IPAddr::InvalidAddressError
+
+    disallowed_ipv6?(ipaddr)
+  rescue InvalidInput
     true
   end
 
   private
+    def validate_policy!(policy)
+      return policy if POLICIES.include?(policy)
 
-  # A numeric host skips DNS so a public literal URL resolves directly and an
-  # internal literal is still caught by blocked_address?. Socket's numeric-only
-  # parser comes first because it accepts every legacy IPv4 spelling the
-  # connection layer does (decimal, hex, octal, and shortened forms), while
-  # IPAddr does not. Otherwise resolve via Resolv.getaddresses, returning every
-  # address from Ruby's hosts-plus-DNS chain. System getaddrinfo may consult
-  # additional NSS sources; pinning an address returned here avoids that second
-  # resolution. Returns [IPAddr].
-  def resolve(host)
-    literals = numeric_literals(host)
-
-    if literals
-      literals
-    else
-      Resolv.getaddresses(host).map { |a| IPAddr.new(a) }
-    end
-  rescue Resolv::ResolvError, Resolv::ResolvTimeout
-    []
-  end
-
-  # Every address Socket's numeric-only parser finds. AI_NUMERICHOST guarantees
-  # this call never falls through to DNS. Its success is authoritative: these
-  # tokens must not be reinterpreted as names by Resolv, because Net::HTTP's
-  # getaddrinfo call will reinterpret them as the numeric addresses returned
-  # here. IPAddr remains as a fallback for syntax it alone accepts, notably a
-  # full-width /32 or /128 host prefix. nil means the token is a name.
-  def numeric_literals(host)
-    # Refuse malformed IPv4-shaped text before consulting the platform parser.
-    # Some connection layers may accept decorations that others reject; none
-    # may turn them into a public DNS name after Surfguard classified them.
-    if malformed_numeric_host_candidate?(host)
-      raise InvalidHost, "malformed numeric-looking host #{host.inspect}"
+      raise ArgumentError, "unknown policy", cause: nil
     end
 
-    Socket.getaddrinfo(
-      host, nil, Socket::AF_UNSPEC, Socket::SOCK_STREAM, 0, Socket::AI_NUMERICHOST
-    ).map { |address| IPAddr.new(address[3]) }.uniq
-  rescue SocketError
-    literal = ip_literal(host)
-    return [ literal ] if literal
+    def normalize_url(url)
+      raise InvalidInput, cause: nil unless String === url
 
-    # An ordinary name may proceed to Resolv after AI_NUMERICHOST says it is
-    # not numeric. A token shaped like a legacy IPv4 spelling may not: if the
-    # system numeric parser itself failed abnormally, asking DNS would recreate
-    # the parser/resolver identity gap this method exists to close.
-    raise InvalidHost, "numeric-looking host #{host.inspect} could not be classified" if numeric_host_candidate?(host)
+      owned_string(url)
+    end
 
-    nil
-  end
+    def normalize_host(host)
+      if IPAddr === host
+        ip = copy_ipaddr(host)
+        raise InvalidInput, cause: nil unless host_address?(ip)
 
-  def numeric_host_candidate?(host)
-    text = host.to_s
-    return true if text.include?(":") # Invalid IPv6 syntax is never a DNS name.
+        ip
+      elsif String === host
+        text = owned_string(host)
+        raise InvalidInput, cause: nil if text.empty? || text.bytesize > MAX_HOST_BYTES
+        raise InvalidInput, cause: nil if text.include?("%")
 
-    legacy_ipv4_shape?(text)
-  end
+        text
+      else
+        raise InvalidInput, cause: nil
+      end
+    end
 
-  def malformed_numeric_host_candidate?(host)
-    text = host.to_s
-    return false if text.include?(":") # IPv6 literals and zones go to AI_NUMERICHOST.
+    def normalize_ip(value)
+      ip = if IPAddr === value
+        copy_ipaddr(value)
+      elsif String === value
+        copy_ipaddr(IPAddr.new(owned_string(value)))
+      else
+        raise InvalidInput, cause: nil
+      end
+      raise InvalidInput, cause: nil unless host_address?(ip)
 
-    # Isolate the address: drop every leading separator, then keep only what
-    # precedes the next one. Removing a single separator would let a second one
-    # ("//127.0.0.1", "%127.0.0.1%lo") hide the legacy IPv4 shape, so the token
-    # would reach the platform parser and, failing there, be handed to DNS as a
-    # name — the parser/resolver identity gap this check exists to close.
-    core = text.sub(%r{\A[%/]+}, "")[%r{\A[^%/]*}]
-    labels = core.split(".", -1)
-    malformed = core != text || labels.any?(&:empty?)
-    return false unless malformed && legacy_ipv4_shape?(core)
+      ip.freeze
+    rescue IPAddr::Error
+      raise InvalidInput, cause: nil
+    end
 
-    # Full-width host prefixes are documented inputs and IPAddr parses them
-    # unambiguously. Shorter or otherwise invalid prefixes remain malformed.
-    return false if full_width_host_literal?(text)
+    def copy_ipaddr(ip)
+      family = IPAddr.instance_method(:family).bind_call(ip)
+      raise InvalidInput, cause: nil unless Integer === family
 
-    true
-  end
+      canonical_family = case family
+      when Socket::AF_INET
+        Socket::AF_INET
+      when Socket::AF_INET6
+        Socket::AF_INET6
+      else
+        raise InvalidInput, cause: nil
+      end
 
-  def legacy_ipv4_shape?(text)
-    parts = text.split(".", -1).reject(&:empty?)
-    (1..4).cover?(parts.length) &&
-      parts.all? { |part| part.match?(/\A(?:0[xX][0-9A-Fa-f]+|[0-9]+)\z/) }
-  end
+      integer = IPAddr.instance_method(:to_i).bind_call(ip)
+      raise InvalidInput, cause: nil unless Integer === integer
 
-  def full_width_host_literal?(text)
-    host_address?(IPAddr.new(text))
-  rescue IPAddr::InvalidAddressError
-    false
-  end
+      mask = Object.instance_method(:instance_variable_get).bind_call(ip, :@mask_addr)
+      raise InvalidInput, cause: nil unless Integer === mask
 
-  # nil for anything IPAddr cannot parse. A shortened prefix is not a host and
-  # is rejected rather than normalized to its network address or sent to DNS.
-  def ip_literal(host)
-    ipaddr = IPAddr.new(host)
-    raise InvalidHost, "#{host.inspect} is a network, not a host" unless host_address?(ipaddr)
+      prefix = IPAddr.instance_method(:prefix).bind_call(ip)
+      bits = canonical_family == Socket::AF_INET ? 32 : 128
+      raise InvalidInput, cause: nil unless (0..bits).cover?(prefix)
+      raise InvalidInput, cause: nil unless (0...(1 << bits)).cover?(integer)
+      raise InvalidInput, cause: nil unless mask == ((1 << prefix) - 1) << (bits - prefix)
 
-    ipaddr
-  rescue IPAddr::InvalidAddressError
-    nil
-  end
+      zone = Object.instance_method(:instance_variable_get).bind_call(ip, :@zone_id)
+      raise InvalidInput, cause: nil unless NilClass === zone
 
-  def host_address?(ipaddr)
-    ipaddr.prefix == (ipaddr.ipv4? ? 32 : 128)
-  end
+      IPAddr.new(integer, canonical_family).mask(prefix)
+    end
 
-  def host_of(url)
-    # URI#host is "" for "http://" and nil when there's no authority at all.
-    # Neither is a name to look up, so both are malformed rather than a lookup
-    # that failed. URI#host keeps IPv6 brackets ([::1]); IPAddr.new won't take them.
-    host = URI.parse(url).host
-    raise URI::InvalidURIError, "no host in #{url.inspect}" if host.nil? || host.empty?
+    def owned_string(value)
+      raise InvalidInput, cause: nil unless String === value
 
-    host.delete_prefix("[").delete_suffix("]")
-  end
+      text = String.new(value)
+      raise InvalidInput, cause: nil unless text.valid_encoding? && text.ascii_only?
+      raise InvalidInput, cause: nil if text.include?("\0")
 
-  def disallowed_ipv4?(ipaddr)
-    ipaddr.private? || ipaddr.loopback? || ipaddr.link_local? ||
-      DISALLOWED_IPV4.any? { |range| range.include?(ipaddr) }
-  end
+      text.freeze
+    end
 
-  def disallowed_ipv6?(ipaddr)
-    return false if GLOBALLY_REACHABLE_IETF_ASSIGNMENTS.any? { |range| range.include?(ipaddr) }
+    def resolve(host)
+      literals = if IPAddr === host
+        [ host ]
+      else
+        numeric_literals(host)
+      end
+      raw = literals || Resolv.getaddresses(host)
+      normalize_answers(raw)
+    rescue Resolv::ResolvError, Resolv::ResolvTimeout, InvalidResolverResult,
+      SocketError, SystemCallError, IOError
+      raise Unresolvable, UNRESOLVABLE_MESSAGE, cause: nil
+    end
 
-    ipaddr.private? || ipaddr.loopback? || ipaddr.link_local? ||
-      IETF_PROTOCOL_ASSIGNMENTS.include?(ipaddr) ||
-      DISALLOWED_IPV6.any? { |range| range.include?(ipaddr) }
-  end
+    def normalize_answers(raw)
+      raise InvalidResolverResult, cause: nil unless Array === raw
 
-  # RFC 6052 §2.2: a fixed /96 translation prefix carries the IPv4 target in the
-  # low 32 bits.
-  def embedded_ipv4(ipaddr)
-    IPAddr.new([ ipaddr.to_i & 0xffffffff ].pack("N").unpack("C4").join("."))
-  end
+      answers = []
+      seen = {}
+      raw_count = 0
+      Array.instance_method(:each).bind_call(raw) do |answer|
+        raw_count += 1
+        raise InvalidResolverResult, cause: nil if raw_count > MAX_ADDRESSES
+
+        ip = normalize_resolver_answer(answer)
+        key = [ ip.family, ip.to_i ]
+        next if seen[key]
+
+        seen[key] = true
+        answers << ip
+      end
+      raise Unresolvable, UNRESOLVABLE_MESSAGE, cause: nil if answers.empty?
+
+      answers.freeze
+    end
+
+    def normalize_resolver_answer(answer)
+      raise InvalidResolverResult, cause: nil unless String === answer || IPAddr === answer
+
+      normalize_ip(answer)
+    rescue InvalidInput
+      raise InvalidResolverResult, cause: nil
+    end
+
+    def numeric_literals(host)
+      raise InvalidInput, cause: nil unless valid_host_syntax?(host)
+      raise InvalidInput, cause: nil if malformed_numeric_host_candidate?(host)
+
+      raw = Socket.getaddrinfo(
+        host, nil, Socket::AF_UNSPEC, Socket::SOCK_STREAM, 0, Socket::AI_NUMERICHOST
+      )
+      raise InvalidResolverResult, cause: nil unless Array === raw
+
+      Array.instance_method(:map).bind_call(raw) do |answer|
+        raise InvalidResolverResult, cause: nil unless Array === answer
+
+        address = Array.instance_method(:[]).bind_call(answer, 3)
+        raise InvalidResolverResult, cause: nil unless String === address
+
+        address
+      end
+    rescue SocketError
+      literal = ip_literal(host)
+      return [ literal.freeze ] if literal
+
+      raise InvalidInput, cause: nil if numeric_host_candidate?(host)
+
+      nil
+    end
+
+    def valid_host_syntax?(host)
+      return true if host.include?(":") || legacy_ipv4_shape?(host) || full_width_host_literal?(host)
+
+      absolute = host.end_with?(".")
+      labels = (absolute ? host[0...-1] : host).split(".", -1)
+      return false if labels.empty? || labels.any?(&:empty?)
+
+      labels.all? do |label|
+        label.bytesize <= 63 && label.match?(/\A[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?\z/)
+      end
+    end
+
+    def numeric_host_candidate?(host)
+      host.include?(":") || legacy_ipv4_shape?(host)
+    end
+
+    def malformed_numeric_host_candidate?(host)
+      return false if host.include?(":")
+
+      core = host.sub(%r{\A[%/]+}, "")[%r{\A[^%/]*}]
+      labels = core.split(".", -1)
+      malformed = core != host || labels.any?(&:empty?)
+      malformed && legacy_ipv4_shape?(core) && !full_width_host_literal?(host)
+    end
+
+    def legacy_ipv4_shape?(text)
+      parts = text.split(".", -1).reject(&:empty?)
+      (1..4).cover?(parts.length) &&
+        parts.all? { |part| part.match?(/\A(?:0[xX][0-9A-Fa-f]+|[0-9]+)\z/) }
+    end
+
+    def full_width_host_literal?(text)
+      host_address?(IPAddr.new(text))
+    rescue IPAddr::InvalidAddressError
+      false
+    end
+
+    def ip_literal(host)
+      normalize_ip(host)
+    rescue InvalidInput
+      nil
+    end
+
+    def host_address?(ip)
+      ip.prefix == (ip.ipv4? ? 32 : 128)
+    end
+
+    def host_of(url)
+      uri = URI.parse(url)
+      host = uri.host
+      raise InvalidInput, cause: nil if host.nil? || host.empty?
+      raise InvalidInput, cause: nil if host.match?(/\A\[v[0-9A-F]+\./i)
+
+      normalize_host(host.delete_prefix("[").delete_suffix("]"))
+    rescue URI::InvalidURIError
+      raise InvalidInput, cause: nil
+    end
+
+    def iana_special_use?(ip)
+      ranges = ip.ipv4? ? IANA_SPECIAL_USE_IPV4 : IANA_SPECIAL_USE_IPV6
+      ranges.any? { |range| range.include?(ip) }
+    end
+
+    def disallowed_ipv4?(ip)
+      ip.private? || ip.loopback? || ip.link_local? ||
+        DISALLOWED_IPV4.any? { |range| range.include?(ip) }
+    end
+
+    def disallowed_ipv6?(ip)
+      return false if GLOBALLY_REACHABLE_IETF_ASSIGNMENTS.any? { |range| range.include?(ip) }
+      return true if ip.private? || ip.loopback? || ip.link_local?
+      return true if IETF_PROTOCOL_ASSIGNMENTS.include?(ip)
+      return true if DISALLOWED_IPV6.any? { |range| range.include?(ip) }
+
+      IANA_ALLOCATED_IPV6_UNICAST.none? { |range| range.include?(ip) }
+    end
+
+    def embedded_ipv4(ip)
+      IPAddr.new([ ip.to_i & 0xffffffff ].pack("N").unpack("C4").join("."))
+    end
 end

--- a/script/check_iana_drift.rb
+++ b/script/check_iana_drift.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+require "digest"
+require "net/http"
+require "uri"
+
+require_relative "iana/registry"
+
+module Surfguard
+  module Iana
+    class HttpFetcher
+      MAX_BYTES = 1 << 20
+
+      def call(url, accept:)
+        uri = URI(url)
+        unless uri.is_a?(URI::HTTPS) && uri.host == "www.iana.org" && uri.port == 443 &&
+            uri.userinfo.nil? && uri.query.nil? && uri.fragment.nil?
+          raise Error, "IANA source must use its code-owned exact HTTPS origin"
+        end
+
+        Net::HTTP.start(uri.host, uri.port, nil, nil, nil, nil, use_ssl: true,
+          open_timeout: 10, read_timeout: 20) do |http|
+          request = Net::HTTP::Get.new(uri)
+          request["Accept"] = accept
+          body = nil
+          http.request(request) do |response|
+            raise Error, "#{uri}: HTTP #{response.code}" unless response.is_a?(Net::HTTPSuccess)
+
+            declared = declared_length(response["content-length"], uri)
+            raise Error, "#{uri}: declared body exceeds #{MAX_BYTES} bytes" if declared && declared > MAX_BYTES
+
+            body = +""
+            response.read_body do |chunk|
+              body << chunk
+              raise Error, "#{uri}: body exceeds #{MAX_BYTES} bytes" if body.bytesize > MAX_BYTES
+            end
+            body.force_encoding(Encoding::UTF_8)
+          end
+          body
+        end
+      rescue URI::InvalidURIError => error
+        raise Error, "invalid code-owned IANA URL: #{error.message}"
+      end
+
+      private
+        def declared_length(value, uri)
+          return unless value
+
+          length = Integer(value, 10)
+          raise Error, "#{uri}: invalid declared body length" if length.negative?
+
+          length
+        rescue ArgumentError
+          raise Error, "#{uri}: invalid declared body length"
+        end
+    end
+
+    class DriftChecker
+      Result = Struct.new(:snapshot, :actual_digest, :prefix_count, :issues, keyword_init: true)
+
+      def self.run_if_main(program_name, file_name)
+        return unless program_name == file_name
+
+        exit new.run
+      end
+
+      def initialize(fetcher: HttpFetcher.new, snapshot_directory: File.join(__dir__, "iana"))
+        @fetcher = fetcher
+        @snapshot_directory = snapshot_directory
+      end
+
+      def run(out: $stdout, err: $stderr)
+        snapshots = Registry.load_snapshots(@snapshot_directory)
+        failed = false
+        SCHEMAS.each do |schema|
+          result = check(snapshots.fetch(schema.id))
+          if result.issues.empty?
+            out.puts "IANA drift check: #{schema.snapshot_file} ok " \
+              "(#{result.prefix_count} prefixes, #{result.actual_digest})"
+          else
+            failed = true
+            err.puts "IANA drift check: #{schema.snapshot_file} FAILED"
+            result.issues.each { |issue| err.puts "  - #{issue}" }
+          end
+        end
+        failed ? 1 : 0
+      rescue Error => error
+        err.puts "IANA drift check failed closed: #{error.message}"
+        1
+      end
+
+      def check(snapshot)
+        source = @fetcher.call(snapshot.schema.source_url, accept: "text/csv")
+        metadata = @fetcher.call(snapshot.schema.metadata_url, accept: "application/xml")
+        audit(snapshot, source: source, metadata: metadata)
+      end
+
+      def audit(snapshot, source:, metadata:)
+        issues = []
+        actual_digest = Digest::SHA256.hexdigest(source)
+        unless actual_digest == snapshot.source_sha256
+          issues << "raw source SHA-256 drift: expected #{snapshot.source_sha256}, got #{actual_digest}"
+        end
+
+        actual_prefixes = nil
+        begin
+          actual_prefixes = Registry.parse_registry(snapshot.schema, source)
+          semantic_issues(snapshot.prefixes, actual_prefixes).each { |issue| issues << issue }
+        rescue Error => error
+          issues << "semantic registry parse failed: #{error.message}"
+        end
+
+        begin
+          actual_updated = Registry.registry_updated(metadata, id: snapshot.schema.id)
+          unless actual_updated == snapshot.registry_updated
+            issues << "registry update date drift: expected #{snapshot.registry_updated}, got #{actual_updated}"
+          end
+        rescue Error => error
+          issues << "registry metadata parse failed: #{error.message}"
+        end
+
+        Result.new(
+          snapshot: snapshot,
+          actual_digest: actual_digest.freeze,
+          prefix_count: actual_prefixes&.length || 0,
+          issues: issues.freeze
+        ).freeze
+      end
+
+      private
+        def semantic_issues(expected, actual)
+          expected_by_tuple = expected.to_h { |record| [ record.tuple, record.cidr ] }
+          actual_by_tuple = actual.to_h { |record| [ record.tuple, record.cidr ] }
+          added = actual_by_tuple.keys - expected_by_tuple.keys
+          removed = expected_by_tuple.keys - actual_by_tuple.keys
+          return [] if added.empty? && removed.empty?
+
+          details = []
+          details << "added #{added.map { |tuple| actual_by_tuple.fetch(tuple) }.sort.inspect}" unless added.empty?
+          details << "removed #{removed.map { |tuple| expected_by_tuple.fetch(tuple) }.sort.inspect}" unless removed.empty?
+          [ "semantic policy drift: #{details.join('; ')}" ]
+        end
+    end
+  end
+end
+
+Surfguard::Iana::DriftChecker.run_if_main($PROGRAM_NAME, __FILE__)

--- a/script/check_resolv_version.rb
+++ b/script/check_resolv_version.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "resolv"
+require "rubygems"
+
+module SurfguardRelease
+  module ResolvVersionCheck
+    VULNERABLE_RANGES = [
+      [ nil, Gem::Version.new("0.2.3") ],
+      [ Gem::Version.new("0.3.0"), Gem::Version.new("0.3.1") ],
+      [ Gem::Version.new("0.4.0"), Gem::Version.new("0.6.2") ]
+    ].freeze
+
+    module_function
+
+    def vulnerable?(version)
+      parsed = Gem::Version.new(version.to_s)
+      VULNERABLE_RANGES.any? do |lower, upper|
+        (lower.nil? || parsed >= lower) && parsed < upper
+      end
+    end
+
+    def current_version(loaded_specs: Gem.loaded_specs, available_specs: Gem::Specification.find_all_by_name("resolv"))
+      specification = loaded_specs["resolv"] || available_specs.find(&:default_gem?)
+      raise "could not identify the effective resolv version" unless specification
+
+      Gem::Version.new(specification.version.to_s)
+    end
+
+    def main(version: current_version, output: $stdout, error: $stderr)
+      parsed = Gem::Version.new(version.to_s)
+      if vulnerable?(parsed)
+        error.puts "unsupported vulnerable resolv #{parsed}"
+        return 1
+      end
+
+      output.puts "resolv #{parsed}: supported"
+      0
+    end
+
+    def cli(program_name: $PROGRAM_NAME, file: __FILE__)
+      return unless program_name == file
+
+      exit main
+    end
+  end
+end
+
+SurfguardRelease::ResolvVersionCheck.cli

--- a/script/generate_iana_data.rb
+++ b/script/generate_iana_data.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require_relative "iana/generator"
+
+module Surfguard
+  module Iana
+    module GeneratorCLI
+      module_function
+
+      def run_if_main(program_name, file_name, argv)
+        return unless program_name == file_name
+
+        exit run(argv)
+      end
+
+      def run(argv, out: $stdout, err: $stderr)
+        case argv
+        when [ "--check" ]
+          Generator.check!
+          out.puts "IANA generated constants: ok"
+          0
+        when [ "--update" ]
+          changed = Generator.update!
+          if changed
+            out.puts "Updated generated IANA constants; review the diff"
+          else
+            out.puts "IANA generated constants already current"
+          end
+          0
+        else
+          err.puts "usage: script/generate_iana_data.rb --check|--update"
+          2
+        end
+      end
+    end
+  end
+end
+
+Surfguard::Iana::GeneratorCLI.run_if_main($PROGRAM_NAME, __FILE__, ARGV)

--- a/script/iana/generator.rb
+++ b/script/iana/generator.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+require "tempfile"
+
+require_relative "registry"
+
+module Surfguard
+  module Iana
+    module Generator
+      ROOT = File.expand_path("../..", __dir__)
+      SNAPSHOT_DIRECTORY = File.join(__dir__).freeze
+      DEFAULT_TARGET = File.join(ROOT, "lib/surfguard.rb").freeze
+      MAX_LINE = 80
+
+      REGIONS = {
+        "IANA_ALLOCATED_IPV6_UNICAST" => {
+          snapshot: "ipv6_allocated",
+          comments: [
+            "Generated from IANA IPv6 Global Unicast Status=ALLOCATED rows.",
+            "Source provenance is checked in under script/iana."
+          ]
+        }.freeze,
+        "IANA_SPECIAL_USE_IPV4" => {
+          snapshot: "ipv4_special_use",
+          comments: [
+            "Every prefix in the checked-in IANA IPv4 special-purpose snapshot."
+          ]
+        }.freeze,
+        "IANA_SPECIAL_USE_IPV6" => {
+          snapshot: "ipv6_special_use",
+          comments: [
+            "Every prefix in the checked-in IANA IPv6 special-purpose snapshot."
+          ]
+        }.freeze
+      }.freeze
+
+      module_function
+
+      def check!(target: DEFAULT_TARGET, snapshot_directory: SNAPSHOT_DIRECTORY)
+        source = File.binread(target)
+        expected = generated_source(source, snapshot_directory: snapshot_directory)
+        return true if source == expected
+
+        raise Error, "generated IANA constants differ; review snapshots, then run script/generate_iana_data.rb --update"
+      end
+
+      def update!(target: DEFAULT_TARGET, snapshot_directory: SNAPSHOT_DIRECTORY)
+        stat = File.lstat(target)
+        raise Error, "IANA generation target must be a regular non-symlink file" unless stat.file? && !stat.symlink?
+
+        source = File.binread(target)
+        generated = generated_source(source, snapshot_directory: snapshot_directory)
+        return false if source == generated
+
+        directory = File.dirname(File.expand_path(target))
+        Tempfile.create([ ".iana-generated", ".tmp" ], directory) do |temporary|
+          temporary.binmode
+          temporary.chmod(stat.mode & 0o777)
+          temporary.write(generated)
+          temporary.flush
+          temporary.fsync
+          temporary.close
+          File.rename(temporary.path, target)
+          fsync_directory(directory)
+        end
+        true
+      end
+
+      def generated_source(source, snapshot_directory: SNAPSHOT_DIRECTORY)
+        snapshots = Registry.load_snapshots(snapshot_directory)
+        newline = source_newline(source)
+        REGIONS.reduce(String.new(source)) do |result, (constant, settings)|
+          snapshot = snapshots.fetch(settings.fetch(:snapshot))
+          replacement = render_region(constant, settings.fetch(:comments), snapshot.prefixes, newline: newline)
+          replace_region(result, constant, replacement)
+        end
+      end
+
+      def render_region(constant, comments, prefixes, newline: "\n")
+        lines = [ marker(:begin, constant) ]
+        comments.each { |comment| lines << "  # #{comment}" }
+        lines << "  #{constant} = %w["
+        line = +"    "
+        prefixes.each do |record|
+          word = record.cidr
+          if line.length > 4 && line.length + word.length + 1 > MAX_LINE
+            lines << line.rstrip
+            line = +"    "
+          end
+          line << word << " "
+        end
+        lines << line.rstrip unless line.strip.empty?
+        lines << "  ].map { |cidr| IPAddr.new(cidr).freeze }.freeze"
+        lines << marker(:end, constant)
+        lines.join(newline)
+      end
+
+      def replace_region(source, constant, replacement)
+        opening = marker(:begin, constant)
+        closing = marker(:end, constant)
+        opening_count = source.scan(/^#{Regexp.escape(opening)}\r?$/).length
+        closing_count = source.scan(/^#{Regexp.escape(closing)}\r?$/).length
+        unless opening_count == 1 && closing_count == 1
+          raise Error, "expected exactly one generated region for #{constant}"
+        end
+
+        pattern = /^#{Regexp.escape(opening)}\r?\n.*?^#{Regexp.escape(closing)}(?=\r?$)/m
+        matches = source.scan(pattern)
+        raise Error, "expected exactly one generated region for #{constant}" unless matches.one?
+
+        source.sub(pattern, replacement)
+      end
+      private_class_method :replace_region
+
+      def source_newline(source)
+        crlf = source.scan("\r\n").length
+        bare_lf = source.scan(/(?<!\r)\n/).length
+        raise Error, "generation target mixes line endings" if crlf.positive? && bare_lf.positive?
+
+        crlf.positive? ? "\r\n" : "\n"
+      end
+      private_class_method :source_newline
+
+      def fsync_directory(directory, platform: RUBY_PLATFORM)
+        return if platform.match?(/mswin|mingw/)
+
+        File.open(directory, File::RDONLY, &:fsync)
+      rescue Errno::EISDIR, Errno::EINVAL, Errno::ENOTSUP
+        # Some otherwise atomic filesystems do not expose directory fsync.
+        nil
+      end
+      private_class_method :fsync_directory
+
+      def marker(position, constant)
+        "  # iana-generator:#{position} #{constant}"
+      end
+      private_class_method :marker
+    end
+  end
+end

--- a/script/iana/ipv4_special_use.json
+++ b/script/iana/ipv4_special_use.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": 1,
+  "registry": "ipv4_special_use",
+  "url": "https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry-1.csv",
+  "metadata_url": "https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xml",
+  "registry_updated": "2025-10-09",
+  "source_sha256": "e3e39e76d00b1677335db8e9a805c7b9480ea2f4dc9e33f0b93cd3a905128d73",
+  "selection": "all",
+  "semantic_sha256": "a5f33a00a9c52f4e407a9a2c32ae63943fb752abbc9b2388f540a72e35f24d58",
+  "prefixes": [
+    "0.0.0.0/8", "0.0.0.0/32", "10.0.0.0/8", "100.64.0.0/10", "127.0.0.0/8",
+    "169.254.0.0/16", "172.16.0.0/12", "192.0.0.0/24", "192.0.0.0/29",
+    "192.0.0.8/32", "192.0.0.9/32", "192.0.0.10/32", "192.0.0.170/32",
+    "192.0.0.171/32", "192.0.2.0/24", "192.31.196.0/24", "192.52.193.0/24",
+    "192.88.99.0/24", "192.88.99.2/32", "192.168.0.0/16", "192.175.48.0/24",
+    "198.18.0.0/15", "198.51.100.0/24", "203.0.113.0/24", "240.0.0.0/4",
+    "255.255.255.255/32"
+  ]
+}

--- a/script/iana/ipv6_allocated.json
+++ b/script/iana/ipv6_allocated.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "registry": "ipv6_allocated",
+  "url": "https://www.iana.org/assignments/ipv6-unicast-address-assignments/ipv6-unicast-address-assignments.csv",
+  "metadata_url": "https://www.iana.org/assignments/ipv6-unicast-address-assignments/ipv6-unicast-address-assignments.xml",
+  "registry_updated": "2025-10-10",
+  "source_sha256": "ebff425bb1acbbea29c4f28146930873faddd5ee57260e95b57ed9e04ea21dd8",
+  "selection": "status_allocated",
+  "semantic_sha256": "b511f06a77effdbad197631e735dc51a118b16937cf4530a25374aa4f7b7ef6e",
+  "prefixes": [
+    "2001::/23", "2001:200::/23", "2001:400::/23", "2001:600::/23",
+    "2001:800::/22", "2001:c00::/23", "2001:e00::/23", "2001:1200::/23",
+    "2001:1400::/22", "2001:1800::/23", "2001:1a00::/23", "2001:1c00::/22",
+    "2001:2000::/19", "2001:4000::/23", "2001:4200::/23", "2001:4400::/23",
+    "2001:4600::/23", "2001:4800::/23", "2001:4a00::/23", "2001:4c00::/23",
+    "2001:5000::/20", "2001:8000::/19", "2001:a000::/20", "2001:b000::/20",
+    "2002::/16", "2003::/18", "2400::/12", "2410::/12", "2600::/12",
+    "2610::/23", "2620::/23", "2630::/12", "2800::/12", "2a00::/12",
+    "2a10::/12", "2c00::/12"
+  ]
+}

--- a/script/iana/ipv6_special_use.json
+++ b/script/iana/ipv6_special_use.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "registry": "ipv6_special_use",
+  "url": "https://www.iana.org/assignments/iana-ipv6-special-registry/iana-ipv6-special-registry-1.csv",
+  "metadata_url": "https://www.iana.org/assignments/iana-ipv6-special-registry/iana-ipv6-special-registry.xml",
+  "registry_updated": "2025-10-09",
+  "source_sha256": "775feea0621dec8735a44fbf30f762e721e8f0a1b3ab7eb341961a88cfce2139",
+  "selection": "all",
+  "semantic_sha256": "85149a4791e13862ab90b37eed05f5be7a8abd3773c2f9a0dc86661a2d22e67f",
+  "prefixes": [
+    "::1/128", "::/128", "::ffff:0:0/96", "64:ff9b::/96", "64:ff9b:1::/48",
+    "100::/64", "100:0:0:1::/64", "2001::/23", "2001::/32", "2001:1::1/128",
+    "2001:1::2/128", "2001:1::3/128", "2001:2::/48", "2001:3::/32",
+    "2001:4:112::/48", "2001:10::/28", "2001:20::/28", "2001:30::/28",
+    "2001:db8::/32", "2002::/16", "2620:4f:8000::/48", "3fff::/20",
+    "5f00::/16", "fc00::/7", "fe80::/10"
+  ]
+}

--- a/script/iana/registry.rb
+++ b/script/iana/registry.rb
@@ -1,0 +1,678 @@
+# frozen_string_literal: true
+
+require "digest"
+require "ipaddr"
+require "json"
+require "socket"
+
+module Surfguard
+  module Iana
+    class Error < StandardError; end
+
+    IP_VERSION_BY_FAMILY = {
+      Socket::AF_INET => 4,
+      Socket::AF_INET6 => 6
+    }.freeze
+    IANA_XML_NAMESPACE = "http://www.iana.org/assignments"
+
+    Schema = Struct.new(
+      :id, :snapshot_file, :source_url, :metadata_url, :metadata_registry_id, :headers,
+      :prefix_header, :family, :selection, :statuses,
+      keyword_init: true
+    )
+    Prefix = Struct.new(:cidr, :family, :integer, :prefix, keyword_init: true) do
+      def tuple
+        [ IP_VERSION_BY_FAMILY.fetch(family), integer, prefix ].freeze
+      end
+    end
+    Snapshot = Struct.new(
+      :schema, :registry_updated, :source_sha256, :semantic_sha256, :prefixes,
+      keyword_init: true
+    )
+
+    SCHEMA_VERSION = 1
+    SNAPSHOT_KEYS = %w[
+      schema_version registry url metadata_url registry_updated source_sha256
+      selection semantic_sha256 prefixes
+    ].sort.freeze
+
+    IPV4_SPECIAL_HEADERS = [
+      "Address Block", "Name", "RFC", "Allocation Date", "Termination Date",
+      "Source", "Destination", "Forwardable", "Globally Reachable", "Reserved-by-Protocol"
+    ].freeze
+    IPV6_ALLOCATED_HEADERS = [ "Prefix", "Designation", "Date", "WHOIS", "RDAP", "Status", "Note" ].freeze
+
+    SCHEMAS = [
+      Schema.new(
+        id: "ipv4_special_use",
+        snapshot_file: "ipv4_special_use.json",
+        source_url: "https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry-1.csv",
+        metadata_url: "https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xml",
+        metadata_registry_id: "iana-ipv4-special-registry",
+        headers: IPV4_SPECIAL_HEADERS,
+        prefix_header: "Address Block",
+        family: Socket::AF_INET,
+        selection: :all,
+        statuses: nil
+      ),
+      Schema.new(
+        id: "ipv6_allocated",
+        snapshot_file: "ipv6_allocated.json",
+        source_url: "https://www.iana.org/assignments/ipv6-unicast-address-assignments/ipv6-unicast-address-assignments.csv",
+        metadata_url: "https://www.iana.org/assignments/ipv6-unicast-address-assignments/ipv6-unicast-address-assignments.xml",
+        metadata_registry_id: "ipv6-unicast-address-assignments",
+        headers: IPV6_ALLOCATED_HEADERS,
+        prefix_header: "Prefix",
+        family: Socket::AF_INET6,
+        selection: :status_allocated,
+        statuses: %w[ALLOCATED RESERVED].freeze
+      ),
+      Schema.new(
+        id: "ipv6_special_use",
+        snapshot_file: "ipv6_special_use.json",
+        source_url: "https://www.iana.org/assignments/iana-ipv6-special-registry/iana-ipv6-special-registry-1.csv",
+        metadata_url: "https://www.iana.org/assignments/iana-ipv6-special-registry/iana-ipv6-special-registry.xml",
+        metadata_registry_id: "iana-ipv6-special-registry",
+        headers: IPV4_SPECIAL_HEADERS,
+        prefix_header: "Address Block",
+        family: Socket::AF_INET6,
+        selection: :all,
+        statuses: nil
+      )
+    ].each do |schema|
+      schema.id.freeze
+      schema.snapshot_file.freeze
+      schema.source_url.freeze
+      schema.metadata_url.freeze
+      schema.metadata_registry_id.freeze
+      schema.headers.freeze
+      schema.freeze
+    end.freeze
+    SCHEMAS_BY_ID = SCHEMAS.to_h { |schema| [ schema.id, schema ] }.freeze
+
+    module Registry
+      module_function
+
+      def schema(id)
+        SCHEMAS_BY_ID.fetch(id.to_s) { raise Error, "unknown IANA registry schema #{id.inspect}" }
+      end
+
+      def load_snapshots(directory)
+        actual = Dir[File.join(directory, "*.json")].map { |path| File.basename(path) }.sort
+        expected = SCHEMAS.map(&:snapshot_file).sort
+        raise Error, "IANA snapshot files differ: expected #{expected.inspect}, got #{actual.inspect}" unless actual == expected
+
+        SCHEMAS.to_h do |entry|
+          path = File.join(directory, entry.snapshot_file)
+          [ entry.id, parse_snapshot(entry.id, File.binread(path)) ]
+        end.freeze
+      end
+
+      def parse_snapshot(id, bytes)
+        entry = schema(id)
+        text = utf8_string(bytes, "#{id}: snapshot is not valid UTF-8")
+        data = JSON.parse(text, allow_duplicate_key: true)
+        reject_duplicate_json_keys!(text, id)
+        raise Error, "#{id}: snapshot must be a JSON object" unless Hash === data
+        raise Error, "#{id}: snapshot fields differ" unless data.keys.sort == SNAPSHOT_KEYS
+        raise Error, "#{id}: unsupported snapshot schema" unless data["schema_version"] == SCHEMA_VERSION
+        raise Error, "#{id}: registry identity differs" unless data["registry"] == entry.id
+        raise Error, "#{id}: source URL differs from the code-owned schema" unless data["url"] == entry.source_url
+        unless data["metadata_url"] == entry.metadata_url
+          raise Error, "#{id}: metadata URL differs from the code-owned schema"
+        end
+        raise Error, "#{id}: selector differs from the code-owned schema" unless data["selection"] == entry.selection.to_s
+
+        updated = owned_string(data["registry_updated"], "#{id}: invalid registry update date")
+        raise Error, "#{id}: invalid registry update date" unless valid_iso_date?(updated)
+        source_sha = digest_string(data["source_sha256"], "#{id}: invalid source SHA-256")
+        semantic_sha = digest_string(data["semantic_sha256"], "#{id}: invalid semantic SHA-256")
+        prefixes = records_from_cidrs(entry, data["prefixes"], context: "#{id} snapshot")
+        actual_semantic_sha = semantic_digest(prefixes)
+        unless actual_semantic_sha == semantic_sha
+          raise Error, "#{id}: semantic SHA-256 does not match the normalized prefixes"
+        end
+
+        Snapshot.new(
+          schema: entry,
+          registry_updated: updated.freeze,
+          source_sha256: source_sha.freeze,
+          semantic_sha256: semantic_sha.freeze,
+          prefixes: prefixes
+        ).freeze
+      rescue JSON::ParserError => error
+        raise Error, "#{id}: malformed snapshot JSON: #{error.message}"
+      end
+
+      def parse_registry(entry, bytes)
+        bytes = utf8_string(bytes, "#{entry.id}: registry body is not valid UTF-8")
+
+        headers, rows = parse_csv(bytes, id: entry.id)
+        unless headers == entry.headers
+          raise Error, "#{entry.id}: registry headers differ: #{headers.inspect}"
+        end
+
+        cidrs = []
+        rows.each_with_index do |values, index|
+          unless values.length == headers.length
+            raise Error, "#{entry.id}: row #{index + 2} has #{values.length} fields; expected #{headers.length}"
+          end
+          row = headers.zip(values).to_h
+          if entry.selection == :status_allocated
+            status = row["Status"]
+            unless entry.statuses.include?(status)
+              raise Error, "#{entry.id}: row #{index + 2} has unknown status #{status.inspect}"
+            end
+            next unless status == "ALLOCATED"
+          elsif entry.selection != :all
+            raise Error, "#{entry.id}: unknown code-owned selector #{entry.selection.inspect}"
+          end
+
+          cidrs.concat(prefix_tokens(row[entry.prefix_header], entry.id, index + 2))
+        end
+        raise Error, "#{entry.id}: registry selection is empty" if cidrs.empty?
+
+        records_from_cidrs(entry, cidrs, context: "#{entry.id} registry")
+      end
+
+      def records_from_cidrs(entry, values, context:)
+        raise Error, "#{context}: prefixes must be an array" unless Array === values
+
+        seen = {}
+        values.map.with_index do |value, index|
+          cidr = owned_string(value, "#{context}: prefix #{index + 1} must be a string")
+          record = parse_cidr(entry, cidr, context: "#{context}: prefix #{index + 1}")
+          duplicate = seen[record.tuple]
+          raise Error, "#{context}: duplicate prefix #{cidr.inspect} (already #{duplicate.inspect})" if duplicate
+
+          seen[record.tuple] = cidr
+          record
+        end.freeze
+      end
+
+      def parse_cidr(entry, cidr, context:)
+        match = /\A([^\/]+)\/(0|[1-9]\d*)\z/.match(cidr)
+        raise Error, "#{context}: invalid CIDR #{cidr.inspect}" unless match
+
+        address_text = match[1]
+        prefix = Integer(match[2], 10)
+        address = IPAddr.new(address_text)
+        unless address.family == entry.family
+          raise Error, "#{context}: wrong address family for #{cidr.inspect}"
+        end
+        bits = IP_VERSION_BY_FAMILY.fetch(entry.family) == 4 ? 32 : 128
+        raise Error, "#{context}: invalid prefix length for #{cidr.inspect}" unless (0..bits).cover?(prefix)
+
+        mask = prefix.zero? ? 0 : (((1 << prefix) - 1) << (bits - prefix))
+        network_integer = address.to_i & mask
+        raise Error, "#{context}: host bits are set in #{cidr.inspect}" unless network_integer == address.to_i
+
+        canonical = "#{render_address(entry.family, network_integer)}/#{prefix}"
+        raise Error, "#{context}: non-canonical CIDR #{cidr.inspect}; expected #{canonical}" unless cidr == canonical
+
+        Prefix.new(cidr: cidr.freeze, family: entry.family, integer: network_integer, prefix: prefix).freeze
+      rescue IPAddr::InvalidAddressError, ArgumentError
+        raise Error, "#{context}: invalid CIDR #{cidr.inspect}"
+      end
+
+      def semantic_digest(records)
+        Digest::SHA256.hexdigest(JSON.generate(records.map(&:tuple)))
+      end
+
+      def registry_updated(bytes, id: "IANA metadata")
+        bytes = utf8_string(bytes, "#{id}: metadata body is not valid UTF-8")
+        expected_registry_id = SCHEMAS_BY_ID[id]&.metadata_registry_id
+        updated = parse_registry_metadata_xml(bytes, id, expected_registry_id)
+        raise Error, "#{id}: expected exactly one registry update date" unless updated.one?
+        date = updated.first
+        raise Error, "#{id}: invalid registry update date" unless valid_iso_date?(date)
+
+        String.new(date).freeze
+      end
+
+      def parse_csv(bytes, id: "IANA registry")
+        raise Error, "#{id}: registry CSV has no header row" if bytes.empty?
+
+        rows = []
+        row = []
+        field = +""
+        quoted = false
+        after_quote = false
+        index = 0
+        ended_with_record_separator = false
+
+        while index < bytes.length
+          character = bytes[index]
+          if quoted
+            if character == '"'
+              if bytes[index + 1] == '"'
+                field << '"'
+                index += 2
+              else
+                quoted = false
+                after_quote = true
+                index += 1
+              end
+            else
+              field << character
+              index += 1
+            end
+            next
+          end
+
+          if after_quote && character != "," && character != "\n" && character != "\r"
+            raise Error, "#{id}: malformed CSV after closing quote"
+          end
+
+          case character
+          when '"'
+            raise Error, "#{id}: quote appears inside an unquoted CSV field" unless field.empty? && !after_quote
+
+            quoted = true
+            index += 1
+          when ","
+            row << field
+            field = +""
+            after_quote = false
+            ended_with_record_separator = false
+            index += 1
+          when "\n", "\r"
+            if character == "\r"
+              raise Error, "#{id}: bare carriage return in CSV" unless bytes[index + 1] == "\n"
+              index += 1
+            end
+            row << field
+            rows << row
+            row = []
+            field = +""
+            after_quote = false
+            ended_with_record_separator = true
+            index += 1
+          else
+            field << character
+            ended_with_record_separator = false
+            index += 1
+          end
+        end
+        raise Error, "#{id}: unterminated quoted CSV field" if quoted
+
+        unless ended_with_record_separator
+          row << field
+          rows << row
+        end
+        [ rows.first.freeze, rows.drop(1).map(&:freeze).freeze ].freeze
+      end
+
+      def render_address(family, integer)
+        return [ integer ].pack("N").unpack("C4").join(".") if family == Socket::AF_INET
+
+        hextets = 8.times.map { |index| (integer >> ((7 - index) * 16)) & 0xffff }
+        best_start = nil
+        best_length = 0
+        index = 0
+        while index < hextets.length
+          unless hextets[index].zero?
+            index += 1
+            next
+          end
+
+          finish = index
+          finish += 1 while finish < hextets.length && hextets[finish].zero?
+          length = finish - index
+          if length >= 2 && length > best_length
+            best_start = index
+            best_length = length
+          end
+          index = finish
+        end
+
+        return hextets.map { |value| value.to_s(16) }.join(":") unless best_start
+
+        left = hextets[0...best_start].map { |value| value.to_s(16) }.join(":")
+        right = hextets[(best_start + best_length)..].map { |value| value.to_s(16) }.join(":")
+        return "::" if left.empty? && right.empty?
+        return "::#{right}" if left.empty?
+        return "#{left}::" if right.empty?
+
+        "#{left}::#{right}"
+      end
+
+      def prefix_tokens(value, id, row_number)
+        field = owned_string(value, "#{id}: row #{row_number} has no prefix field")
+        field.split(",", -1).map do |piece|
+          token = piece.strip
+          token = token.sub(/\s+\[\d+\]\z/, "").rstrip while token.match?(/\s+\[\d+\]\z/)
+          if token.empty? || token.include?("[") || token.include?("]")
+            raise Error, "#{id}: row #{row_number} has an unsupported prefix annotation"
+          end
+          token
+        end
+      end
+      private_class_method :prefix_tokens
+
+      def owned_string(value, message)
+        raise Error, message unless String === value
+
+        text = String.new(value)
+        raise Error, message unless text.valid_encoding?
+
+        text
+      end
+      private_class_method :owned_string
+
+      def digest_string(value, message)
+        text = owned_string(value, message)
+        raise Error, message unless text.match?(/\A[0-9a-f]{64}\z/)
+
+        text
+      end
+      private_class_method :digest_string
+
+      def utf8_string(value, message)
+        raise Error, message unless String === value
+
+        text = String.new(value)
+        text.force_encoding(Encoding::UTF_8) if text.encoding == Encoding::ASCII_8BIT
+        raise Error, message unless text.encoding == Encoding::UTF_8 && text.valid_encoding?
+
+        text
+      end
+      private_class_method :utf8_string
+
+      def parse_registry_metadata_xml(text, id, expected_registry_id)
+        index = 0
+        stack = []
+        root_seen = false
+        root_closed = false
+        updated = []
+        updated_text = nil
+
+        while index < text.bytesize
+          if text.getbyte(index) != 0x3c
+            finish = text.index("<", index) || text.bytesize
+            content = text.byteslice(index, finish - index)
+            if stack.empty?
+              raise Error, "#{id}: malformed registry metadata XML" unless content.match?(/\A[\t\n\r ]*\z/)
+            elsif updated_text
+              updated_text << content
+            end
+            index = finish
+            next
+          end
+
+          if xml_token_at?(text, index, "<!--")
+            raise Error, "#{id}: invalid registry update date" if updated_text
+
+            finish = text.index("-->", index + 4)
+            raise Error, "#{id}: malformed registry metadata XML" unless finish
+
+            index = finish + 3
+          elsif xml_token_at?(text, index, "<?")
+            raise Error, "#{id}: invalid registry update date" if updated_text
+
+            finish = text.index("?>", index + 2)
+            raise Error, "#{id}: malformed registry metadata XML" unless finish
+
+            index = finish + 2
+          elsif xml_token_at?(text, index, "<![CDATA[")
+            raise Error, "#{id}: malformed registry metadata XML" if stack.empty? || updated_text
+
+            finish = text.index("]]>", index + 9)
+            raise Error, "#{id}: malformed registry metadata XML" unless finish
+
+            index = finish + 3
+          elsif xml_token_at?(text, index, "<!")
+            raise Error, "#{id}: metadata declarations are forbidden"
+          elsif xml_token_at?(text, index, "</")
+            finish = find_xml_tag_end(text, index + 2, id)
+            name = parse_xml_end_tag(text.byteslice(index + 2, finish - index - 2), id)
+            raise Error, "#{id}: malformed registry metadata XML" unless stack.last == name
+
+            if updated_text && stack.length == 2 && name == "updated"
+              updated << updated_text.freeze
+              updated_text = nil
+            end
+            stack.pop
+            root_closed = true if stack.empty?
+            index = finish + 1
+          else
+            finish = find_xml_tag_end(text, index + 1, id)
+            raw = text.byteslice(index + 1, finish - index - 1)
+            name, attributes, self_closing = parse_xml_start_tag(raw, id)
+            if stack.empty?
+              raise Error, "#{id}: malformed registry metadata XML" if root_seen || root_closed
+              unless name == "registry" && attributes["xmlns"] == IANA_XML_NAMESPACE
+                raise Error, "#{id}: invalid registry metadata root"
+              end
+              if expected_registry_id && attributes["id"] != expected_registry_id
+                raise Error, "#{id}: registry metadata identity differs"
+              end
+              root_seen = true
+            elsif updated_text
+              raise Error, "#{id}: invalid registry update date"
+            elsif stack.length == 1 && name == "updated"
+              updated_text = +""
+            end
+
+            if self_closing
+              if updated_text && stack.length == 1 && name == "updated"
+                updated << updated_text.freeze
+                updated_text = nil
+              end
+              root_closed = true if stack.empty?
+            else
+              stack << name
+            end
+            index = finish + 1
+          end
+        end
+
+        unless root_seen && root_closed && stack.empty? && updated_text.nil?
+          raise Error, "#{id}: malformed registry metadata XML"
+        end
+
+        updated.freeze
+      end
+      private_class_method :parse_registry_metadata_xml
+
+      def xml_token_at?(text, index, token)
+        text.byteslice(index, token.bytesize) == token
+      end
+      private_class_method :xml_token_at?
+
+      def find_xml_tag_end(text, index, id)
+        quote = nil
+        while index < text.bytesize
+          byte = text.getbyte(index)
+          if quote
+            quote = nil if byte == quote
+          elsif byte == 0x22 || byte == 0x27
+            quote = byte
+          elsif byte == 0x3e
+            return index
+          end
+          index += 1
+        end
+        raise Error, "#{id}: malformed registry metadata XML"
+      end
+      private_class_method :find_xml_tag_end
+
+      def parse_xml_end_tag(raw, id)
+        match = /\A[\t\n\r ]*([A-Za-z_:][A-Za-z0-9_.:-]*)[\t\n\r ]*\z/.match(raw)
+        raise Error, "#{id}: malformed registry metadata XML" unless match
+
+        match[1]
+      end
+      private_class_method :parse_xml_end_tag
+
+      def parse_xml_start_tag(raw, id)
+        text = String.new(raw)
+        self_closing = false
+        trimmed = text.rstrip
+        if trimmed.end_with?("/")
+          self_closing = true
+          trimmed = trimmed.delete_suffix("/").rstrip
+        end
+
+        name_match = /\A([A-Za-z_:][A-Za-z0-9_.:-]*)/.match(trimmed)
+        raise Error, "#{id}: malformed registry metadata XML" unless name_match
+
+        name = name_match[1]
+        attributes = {}
+        index = name_match.end(0)
+        while index < trimmed.bytesize
+          whitespace_start = index
+          index += 1 while xml_whitespace_byte?(trimmed.getbyte(index))
+          raise Error, "#{id}: malformed registry metadata XML" if index == whitespace_start
+
+          attribute_match = /\A([A-Za-z_:][A-Za-z0-9_.:-]*)/.match(trimmed.byteslice(index..))
+          raise Error, "#{id}: malformed registry metadata XML" unless attribute_match
+
+          attribute = attribute_match[1]
+          raise Error, "#{id}: duplicate XML attribute" if attributes.key?(attribute)
+
+          index += attribute_match.end(0)
+          index += 1 while xml_whitespace_byte?(trimmed.getbyte(index))
+          raise Error, "#{id}: malformed registry metadata XML" unless trimmed.getbyte(index) == 0x3d
+
+          index += 1
+          index += 1 while xml_whitespace_byte?(trimmed.getbyte(index))
+          quote = trimmed.getbyte(index)
+          raise Error, "#{id}: malformed registry metadata XML" unless quote == 0x22 || quote == 0x27
+
+          value_start = index + 1
+          value_finish = trimmed.index(quote.chr, value_start)
+          raise Error, "#{id}: malformed registry metadata XML" unless value_finish
+
+          value = trimmed.byteslice(value_start, value_finish - value_start)
+          raise Error, "#{id}: malformed registry metadata XML" if value.include?("<")
+
+          attributes[attribute] = value.freeze
+          index = value_finish + 1
+        end
+
+        [ name.freeze, attributes.freeze, self_closing ].freeze
+      end
+      private_class_method :parse_xml_start_tag
+
+      def xml_whitespace_byte?(byte)
+        byte == 0x20 || byte == 0x09 || byte == 0x0a || byte == 0x0d
+      end
+      private_class_method :xml_whitespace_byte?
+
+      def reject_duplicate_json_keys!(text, id)
+        index = scan_json_value(text, skip_json_whitespace(text, 0), id)
+        index = skip_json_whitespace(text, index)
+        raise Error, "#{id}: malformed snapshot JSON" unless index == text.bytesize
+      end
+      private_class_method :reject_duplicate_json_keys!
+
+      def scan_json_value(text, index, id)
+        case text.getbyte(index)
+        when 0x7b # {
+          scan_json_object(text, index, id)
+        when 0x5b # [
+          scan_json_array(text, index, id)
+        when 0x22 # "
+          scan_json_string(text, index).last
+        else
+          index += 1 while (byte = text.getbyte(index)) &&
+            !json_whitespace_byte?(byte) && byte != 0x2c && byte != 0x5d && byte != 0x7d
+          index
+        end
+      end
+      private_class_method :scan_json_value
+
+      def scan_json_object(text, index, id)
+        keys = {}
+        index = skip_json_whitespace(text, index + 1)
+        return index + 1 if text.getbyte(index) == 0x7d
+
+        loop do
+          raise Error, "#{id}: malformed snapshot JSON" unless text.getbyte(index) == 0x22
+
+          key, index = scan_json_string(text, index)
+          raise Error, "#{id}: duplicate JSON object field" if keys.key?(key)
+
+          keys[key] = true
+          index = skip_json_whitespace(text, index)
+          raise Error, "#{id}: malformed snapshot JSON" unless text.getbyte(index) == 0x3a
+
+          index = scan_json_value(text, skip_json_whitespace(text, index + 1), id)
+          index = skip_json_whitespace(text, index)
+          case text.getbyte(index)
+          when 0x2c
+            index = skip_json_whitespace(text, index + 1)
+          when 0x7d
+            return index + 1
+          else
+            raise Error, "#{id}: malformed snapshot JSON"
+          end
+        end
+      end
+      private_class_method :scan_json_object
+
+      def scan_json_array(text, index, id)
+        index = skip_json_whitespace(text, index + 1)
+        return index + 1 if text.getbyte(index) == 0x5d
+
+        loop do
+          index = scan_json_value(text, index, id)
+          index = skip_json_whitespace(text, index)
+          case text.getbyte(index)
+          when 0x2c
+            index = skip_json_whitespace(text, index + 1)
+          when 0x5d
+            return index + 1
+          else
+            raise Error, "#{id}: malformed snapshot JSON"
+          end
+        end
+      end
+      private_class_method :scan_json_array
+
+      def scan_json_string(text, index)
+        start = index
+        index += 1
+        loop do
+          case text.getbyte(index)
+          when 0x22
+            token = text.byteslice(start, index - start + 1)
+            return [ JSON.parse(token), index + 1 ]
+          when 0x5c
+            index += 2
+          else
+            index += 1
+          end
+        end
+      end
+      private_class_method :scan_json_string
+
+      def skip_json_whitespace(text, index)
+        index += 1 while json_whitespace_byte?(text.getbyte(index))
+        index
+      end
+      private_class_method :skip_json_whitespace
+
+      def json_whitespace_byte?(byte)
+        byte == 0x20 || byte == 0x09 || byte == 0x0a || byte == 0x0d
+      end
+      private_class_method :json_whitespace_byte?
+
+      def valid_iso_date?(value)
+        match = /\A(\d{4})-(\d{2})-(\d{2})\z/.match(value)
+        return false unless match
+
+        year = Integer(match[1], 10)
+        month = Integer(match[2], 10)
+        day = Integer(match[3], 10)
+        return false if year.zero? || !(1..12).cover?(month)
+
+        leap_year = (year % 4).zero? && (!(year % 100).zero? || (year % 400).zero?)
+        days = [ 31, leap_year ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 ]
+        (1..days.fetch(month - 1)).cover?(day)
+      end
+      private_class_method :valid_iso_date?
+    end
+  end
+end

--- a/script/iana/registry.rb
+++ b/script/iana/registry.rb
@@ -389,7 +389,7 @@ module Surfguard
 
         while index < text.bytesize
           if text.getbyte(index) != 0x3c
-            finish = text.index("<", index) || text.bytesize
+            finish = text.byteindex("<", index) || text.bytesize
             content = text.byteslice(index, finish - index)
             if stack.empty?
               raise Error, "#{id}: malformed registry metadata XML" unless content.match?(/\A[\t\n\r ]*\z/)
@@ -403,21 +403,21 @@ module Surfguard
           if xml_token_at?(text, index, "<!--")
             raise Error, "#{id}: invalid registry update date" if updated_text
 
-            finish = text.index("-->", index + 4)
+            finish = text.byteindex("-->", index + 4)
             raise Error, "#{id}: malformed registry metadata XML" unless finish
 
             index = finish + 3
           elsif xml_token_at?(text, index, "<?")
             raise Error, "#{id}: invalid registry update date" if updated_text
 
-            finish = text.index("?>", index + 2)
+            finish = text.byteindex("?>", index + 2)
             raise Error, "#{id}: malformed registry metadata XML" unless finish
 
             index = finish + 2
           elsif xml_token_at?(text, index, "<![CDATA[")
             raise Error, "#{id}: malformed registry metadata XML" if stack.empty? || updated_text
 
-            finish = text.index("]]>", index + 9)
+            finish = text.byteindex("]]>", index + 9)
             raise Error, "#{id}: malformed registry metadata XML" unless finish
 
             index = finish + 3
@@ -541,7 +541,7 @@ module Surfguard
           raise Error, "#{id}: malformed registry metadata XML" unless quote == 0x22 || quote == 0x27
 
           value_start = index + 1
-          value_finish = trimmed.index(quote.chr, value_start)
+          value_finish = trimmed.byteindex(quote.chr, value_start)
           raise Error, "#{id}: malformed registry metadata XML" unless value_finish
 
           value = trimmed.byteslice(value_start, value_finish - value_start)

--- a/surfguard.gemspec
+++ b/surfguard.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
                      "in a blocked one. Standard library only, no runtime dependencies."
   spec.homepage    = "https://github.com/basecamp/surfguard"
   spec.license     = "MIT"
-  spec.required_ruby_version = ">= 3.1"
+  spec.required_ruby_version = ">= 3.4.5"
 
   # homepage already points at the repo, so a source_code_uri/homepage_uri that
   # repeats it only earns a "same uri for multiple keys" warning. The issue

--- a/test/iana_coverage_test.rb
+++ b/test/iana_coverage_test.rb
@@ -321,6 +321,14 @@ class IanaCoverageTest < Minitest::Test
     assert_equal "2025-10-09", Registry.registry_updated(generic, id: "unregistered")
   end
 
+  def test_registry_metadata_xml_advances_byte_cursor_through_multibyte_content
+    schema = Registry.schema("ipv4_special_use")
+    id = schema.metadata_registry_id
+
+    xml = %(<registry xmlns="#{Iana::IANA_XML_NAMESPACE}" id="#{id}"><!-- «commentaire spécial» --><ignored attr="préfixe">Adresses spéciales — 番地</ignored><updated>2025-10-09</updated></registry>)
+    assert_equal "2025-10-09", Registry.registry_updated(xml, id: schema.id)
+  end
+
   def test_registry_metadata_xml_rejects_every_token_and_structure_failure
     schema = Registry.schema("ipv4_special_use")
     root = %(<registry xmlns="#{Iana::IANA_XML_NAMESPACE}" id="#{schema.metadata_registry_id}">)

--- a/test/iana_coverage_test.rb
+++ b/test/iana_coverage_test.rb
@@ -1,0 +1,592 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+require "digest"
+require "fileutils"
+require "json"
+require "stringio"
+require "tmpdir"
+
+require_relative "../script/check_iana_drift"
+require_relative "../script/generate_iana_data"
+
+class IanaCoverageTest < Minitest::Test
+  Iana = Surfguard::Iana
+  Registry = Iana::Registry
+  Generator = Iana::Generator
+  ROOT = File.expand_path("..", __dir__)
+  SNAPSHOTS = File.join(ROOT, "script/iana")
+  CHECKER = File.join(ROOT, "script/check_iana_drift.rb")
+  GENERATOR_CLI = File.join(ROOT, "script/generate_iana_data.rb")
+
+  def test_http_fetcher_pins_the_owned_origin_and_streams_the_response
+    response = http_response(chunks: [ "hello", " world" ])
+    http = fake_http(response)
+    invocation = nil
+    starter = lambda do |*arguments, **keywords, &block|
+      invocation = [ arguments, keywords ]
+      block.call(http)
+    end
+
+    body = stub_singleton(Net::HTTP, :start, starter) do
+      Iana::HttpFetcher.new.call(
+        "https://www.iana.org/assignments/example.csv", accept: "text/csv"
+      )
+    end
+
+    assert_equal "hello world", body
+    assert_equal Encoding::UTF_8, body.encoding
+    assert_equal "text/csv", http.captured_request["Accept"]
+    assert_equal [ "www.iana.org", 443, nil, nil, nil, nil ], invocation.first
+    assert_equal({ use_ssl: true, open_timeout: 10, read_timeout: 20 }, invocation.last)
+  end
+
+  def test_http_fetcher_rejects_every_origin_escape_and_invalid_url
+    rejected = [
+      "http://www.iana.org/example",
+      "https://iana.org/example",
+      "https://user@www.iana.org/example",
+      "https://www.iana.org:444/example",
+      "https://www.iana.org/example?query=1",
+      "https://www.iana.org/example#fragment"
+    ]
+    rejected.each do |url|
+      error = assert_raises(Iana::Error) { Iana::HttpFetcher.new.call(url, accept: "text/plain") }
+      assert_equal "IANA source must use its code-owned exact HTTPS origin", error.message
+    end
+
+    error = assert_raises(Iana::Error) do
+      Iana::HttpFetcher.new.call("https://[", accept: "text/plain")
+    end
+    assert_match(/invalid code-owned IANA URL/, error.message)
+  end
+
+  def test_http_fetcher_rejects_status_length_and_streaming_failures
+    cases = [
+      [ http_response(klass: Net::HTTPNotFound), /HTTP 404/ ],
+      [ http_response(length: Iana::HttpFetcher::MAX_BYTES + 1), /declared body exceeds/ ],
+      [ http_response(length: -1), /invalid declared body length/ ],
+      [ http_response(length: "not-an-integer"), /invalid declared body length/ ],
+      [ http_response(chunks: [ "x" * (Iana::HttpFetcher::MAX_BYTES + 1) ]), /body exceeds/ ]
+    ]
+
+    cases.each do |response, message|
+      error = assert_raises(Iana::Error) do
+        with_http_response(response) do
+          Iana::HttpFetcher.new.call("https://www.iana.org/example", accept: "text/plain")
+        end
+      end
+      assert_match message, error.message
+    end
+
+    body = with_http_response(http_response(length: 2, chunks: [ "ok" ])) do
+      Iana::HttpFetcher.new.call("https://www.iana.org/example", accept: "text/plain")
+    end
+    assert_equal "ok", body
+  end
+
+  def test_drift_checker_check_and_run_cover_success_failure_and_fail_closed_paths
+    schema = Registry.schema("ipv4_special_use")
+    source = csv_for(schema, [ { "Address Block" => "192.0.2.0/24" } ])
+    metadata = metadata_xml(schema, "2025-10-09")
+    snapshot = parsed_snapshot(schema, [ "192.0.2.0/24" ], source: source)
+    calls = []
+    fetcher = lambda do |url, accept:|
+      calls << [ url, accept ]
+      url == schema.source_url ? source : metadata
+    end
+
+    result = Iana::DriftChecker.new(fetcher: fetcher).check(snapshot)
+    assert_empty result.issues
+    assert_equal 1, result.prefix_count
+    assert_predicate result, :frozen?
+    assert_equal [
+      [ schema.source_url, "text/csv" ],
+      [ schema.metadata_url, "application/xml" ]
+    ], calls
+
+    checker = Iana::DriftChecker.new(snapshot_directory: SNAPSHOTS)
+    out = StringIO.new
+    err = StringIO.new
+    stub_singleton(checker, :check, result) do
+      assert_equal 0, checker.run(out: out, err: err)
+    end
+    assert_equal 3, out.string.lines.length
+    assert_empty err.string
+
+    failure = Iana::DriftChecker::Result.new(
+      snapshot: snapshot, actual_digest: "0" * 64, prefix_count: 0, issues: [ "changed" ]
+    )
+    out = StringIO.new
+    err = StringIO.new
+    stub_singleton(checker, :check, failure) do
+      assert_equal 1, checker.run(out: out, err: err)
+    end
+    assert_empty out.string
+    assert_equal 3, err.string.scan(/FAILED/).length
+    assert_equal 3, err.string.scan(/changed/).length
+
+    Dir.mktmpdir("iana-drift-empty") do |directory|
+      err = StringIO.new
+      assert_equal 1, Iana::DriftChecker.new(snapshot_directory: directory).run(err: err)
+      assert_match(/failed closed: IANA snapshot files differ/, err.string)
+    end
+  end
+
+  def test_drift_audit_reports_parser_failures_and_each_semantic_change_shape
+    schema = Registry.schema("ipv4_special_use")
+    source = csv_for(schema, [ { "Address Block" => "192.0.2.0/24" } ])
+    snapshot = parsed_snapshot(schema, [ "192.0.2.0/24" ], source: source)
+    result = Iana::DriftChecker.new.audit(snapshot, source: "not,csv", metadata: "not xml")
+    assert_equal 0, result.prefix_count
+    assert result.issues.any? { |issue| issue.start_with?("semantic registry parse failed:") }
+    assert result.issues.any? { |issue| issue.start_with?("registry metadata parse failed:") }
+
+    date_drift = Iana::DriftChecker.new.audit(
+      snapshot, source: source, metadata: metadata_xml(schema, "2025-10-10")
+    )
+    assert_equal [
+      "registry update date drift: expected 2025-10-09, got 2025-10-10"
+    ], date_drift.issues
+
+    expected = Registry.records_from_cidrs(schema, [ "192.0.2.0/24" ], context: "expected")
+    added = Registry.records_from_cidrs(schema, [ "198.51.100.0/24" ], context: "added")
+    checker = Iana::DriftChecker.new
+    assert_empty checker.send(:semantic_issues, expected, expected)
+    assert_match(/added/, checker.send(:semantic_issues, [], added).first)
+    assert_match(/removed/, checker.send(:semantic_issues, expected, []).first)
+    both = checker.send(:semantic_issues, expected, added).first
+    assert_match(/added/, both)
+    assert_match(/removed/, both)
+  end
+
+  def test_registry_snapshot_envelope_and_owned_string_validation
+    schema = Registry.schema("ipv4_special_use")
+    source = csv_for(schema, [ { "Address Block" => "192.0.2.0/24" } ])
+    valid = snapshot_data(schema, [ "192.0.2.0/24" ], source: source)
+
+    malformed = {
+      "[]" => /JSON object/,
+      "{" => /malformed snapshot JSON/
+    }
+    malformed.each do |bytes, message|
+      assert_raises_with_message(message) { Registry.parse_snapshot(schema.id, bytes) }
+    end
+
+    mutations = {
+      "schema_version" => 2,
+      "registry" => "other",
+      "url" => "https://www.iana.org/other.csv",
+      "metadata_url" => "https://www.iana.org/other.xml",
+      "selection" => "other",
+      "source_sha256" => "ABC",
+      "semantic_sha256" => 123,
+      "registry_updated" => "2025-02-29",
+      "prefixes" => "192.0.2.0/24"
+    }
+    mutations.each do |field, value|
+      data = valid.merge(field => value)
+      assert_raises(Iana::Error, field) { Registry.parse_snapshot(schema.id, JSON.generate(data)) }
+    end
+
+    invalid_text = String.new("x\xFF", encoding: Encoding::UTF_8)
+    assert_raises(Iana::Error) { Registry.parse_snapshot(schema.id, invalid_text) }
+    assert_raises(Iana::Error) { Registry.parse_snapshot(schema.id, 123) }
+    utf16 = JSON.generate(valid).encode(Encoding::UTF_16LE)
+    assert_raises(Iana::Error) { Registry.parse_snapshot(schema.id, utf16) }
+
+    invalid_prefix = valid.merge("prefixes" => [ 123 ])
+    assert_raises(Iana::Error) { Registry.parse_snapshot(schema.id, JSON.generate(invalid_prefix)) }
+
+    missing_field = valid.dup
+    missing_field.delete("url")
+    assert_raises(Iana::Error) { Registry.parse_snapshot(schema.id, JSON.generate(missing_field)) }
+
+    wrong_semantic_digest = valid.merge("semantic_sha256" => "0" * 64)
+    assert_raises(Iana::Error) do
+      Registry.parse_snapshot(schema.id, JSON.generate(wrong_semantic_digest))
+    end
+  end
+
+  def test_registry_file_set_csv_selection_and_endpoint_validation
+    Dir.mktmpdir("iana-empty-snapshots") do |directory|
+      assert_raises(Iana::Error) { Registry.load_snapshots(directory) }
+    end
+
+    assert_raises(Iana::Error) { Registry.parse_csv("") }
+    assert_equal [ [ "header" ], [ [ "value" ] ] ], Registry.parse_csv("header\nvalue")
+
+    schema = Registry.schema("ipv6_allocated")
+    reserved = csv_for(schema, [ { "Prefix" => "2d00::/8", "Status" => "RESERVED" } ])
+    assert_raises(Iana::Error) { Registry.parse_registry(schema, reserved) }
+    allocated = csv_for(schema, [ { "Prefix" => "2001::/23", "Status" => "ALLOCATED" } ])
+    assert_equal [ "2001::/23" ], Registry.parse_registry(schema, allocated).map(&:cidr)
+    unknown = csv_for(schema, [ { "Prefix" => "2001::/23", "Status" => "unknown" } ])
+    assert_raises(Iana::Error) { Registry.parse_registry(schema, unknown) }
+
+    wrong_fields = csv_rows([ schema.headers, [ "2001::/23" ] ])
+    assert_raises(Iana::Error) { Registry.parse_registry(schema, wrong_fields) }
+    unknown_selector = schema.dup
+    unknown_selector.selection = :unknown
+    assert_raises(Iana::Error) { Registry.parse_registry(unknown_selector, allocated) }
+    assert_raises(Iana::Error) { Registry.records_from_cidrs(schema, "2001::/23", context: "fixture") }
+
+    zero = Registry.parse_cidr(
+      Registry.schema("ipv4_special_use"), "0.0.0.0/0", context: "fixture"
+    )
+    assert_equal 0, zero.integer
+    assert_raises(Iana::Error) do
+      Registry.parse_cidr(schema, "2001:0db8::/32", context: "fixture")
+    end
+
+    invalid_cidrs = [
+      [ schema, "not-a-cidr" ],
+      [ schema, "192.0.2.0/24" ],
+      [ schema, "2001::/129" ],
+      [ schema, "2001::1/64" ],
+      [ schema, "not-an-ip/64" ]
+    ]
+    invalid_cidrs.each do |entry, cidr|
+      assert_raises(Iana::Error, cidr) { Registry.parse_cidr(entry, cidr, context: "fixture") }
+    end
+
+    ipv4 = Registry.schema("ipv4_special_use")
+    [ nil, 123 ].each do |value|
+      assert_raises(Iana::Error) do
+        Registry.records_from_cidrs(ipv4, [ value ], context: "fixture")
+      end
+    end
+    invalid = String.new("bad\xFF", encoding: Encoding::UTF_8)
+    assert_raises(Iana::Error) do
+      Registry.records_from_cidrs(ipv4, [ invalid ], context: "fixture")
+    end
+
+    [ nil, 123, String.new("x\xFF", encoding: Encoding::UTF_8) ].each do |body|
+      assert_raises(Iana::Error) { Registry.parse_registry(ipv4, body) }
+    end
+
+    duplicate = csv_for(ipv4, [
+      { "Address Block" => "192.0.2.0/24" },
+      { "Address Block" => "192.0.2.0/24" }
+    ])
+    assert_raises(Iana::Error) { Registry.parse_registry(ipv4, duplicate) }
+
+    annotated = csv_for(ipv4, [ { "Address Block" => "192.0.2.0/24 [1] [2]" } ])
+    assert_equal [ "192.0.2.0/24" ], Registry.parse_registry(ipv4, annotated).map(&:cidr)
+    unsupported = csv_for(ipv4, [ { "Address Block" => "192.0.2.0/24 [RFC]" } ])
+    assert_raises(Iana::Error) { Registry.parse_registry(ipv4, unsupported) }
+  end
+
+  def test_registry_csv_state_machine_covers_quoted_and_malformed_transitions
+    parsed = Registry.parse_csv(%Q("head,one",head-two\r\n"say ""hi""","line one\nline two"\r\n))
+    assert_equal [ "head,one", "head-two" ], parsed.first
+    assert_equal [ [ 'say "hi"', "line one\nline two" ] ], parsed.last
+
+    malformed = [
+      %(header\r\n"unterminated),
+      %(header\r\n"closed"junk\r\n),
+      %(header\r\nun"quoted\r\n),
+      "header\rvalue\r\n"
+    ]
+    malformed.each do |body|
+      assert_raises(Iana::Error, body.inspect) { Registry.parse_csv(body) }
+    end
+  end
+
+  def test_registry_address_rendering_covers_every_compression_position
+    assert_equal "1.2.3.4", Registry.render_address(Socket::AF_INET, 0x01020304)
+    assert_equal "2001:1:2:3:4:5:6:7", render_ipv6("2001:1:2:3:4:5:6:7")
+    assert_equal "::", render_ipv6("::")
+    assert_equal "::1", render_ipv6("::1")
+    assert_equal "2001::", render_ipv6("2001::")
+    assert_equal "2001::1", render_ipv6("2001::1")
+  end
+
+  def test_registry_metadata_xml_accepts_owned_minimal_forms
+    schema = Registry.schema("ipv4_special_use")
+    namespace = Iana::IANA_XML_NAMESPACE
+    id = schema.metadata_registry_id
+
+    xml = %(<?owned?><registry xmlns = '#{namespace}' id = "#{id}" ><ignored><![CDATA[text]]></ignored><updated>2025-10-09</updated><!--ok--></registry>)
+    assert_equal "2025-10-09", Registry.registry_updated(xml, id: schema.id)
+
+    self_closing_update = %(<registry xmlns="#{namespace}" id="#{id}"><updated/></registry>)
+    assert_raises(Iana::Error) { Registry.registry_updated(self_closing_update, id: schema.id) }
+
+    self_closing_root = %(<registry xmlns="#{namespace}" id="#{id}"/>)
+    assert_raises(Iana::Error) { Registry.registry_updated(self_closing_root, id: schema.id) }
+
+    generic = %(<registry xmlns="#{namespace}"><updated>2025-10-09</updated></registry>)
+    assert_equal "2025-10-09", Registry.registry_updated(generic, id: "unregistered")
+  end
+
+  def test_registry_metadata_xml_rejects_every_token_and_structure_failure
+    schema = Registry.schema("ipv4_special_use")
+    root = %(<registry xmlns="#{Iana::IANA_XML_NAMESPACE}" id="#{schema.metadata_registry_id}">)
+    invalid = [
+      "#{root}<updated><!--bad--></updated></registry>",
+      "#{root}<updated><?bad?></updated></registry>",
+      "#{root}<updated><![CDATA[bad]]></updated></registry>",
+      "<![CDATA[bad]]>",
+      "#{root}<![CDATA[",
+      "<!DOCTYPE registry>",
+      "#{root}<updated><nested/></updated></registry>",
+      "#{root}<updated>2025-10-09</wrong></registry>",
+      "#{root}<updated>2025-10-09</updated></registry><registry xmlns=\"#{Iana::IANA_XML_NAMESPACE}\"/>",
+      root,
+      "#{root}<updated>2025-10-09</updated",
+      "#{root}<updated>2025-10-09</updated extra></registry>",
+      "<!--",
+      "<?",
+      "<![CDATA[",
+      "<registry!>",
+      "<registry !>",
+      "<registry xmlns>",
+      "<registry xmlns=unquoted>",
+      "<registry xmlns=\"unterminated>",
+      "<registry xmlns=\"bad<value\">",
+      "<registry xmlns=\"one\" xmlns=\"two\">"
+    ]
+    invalid.each do |xml|
+      assert_raises(Iana::Error, xml.inspect) { Registry.registry_updated(xml, id: schema.id) }
+    end
+
+
+    wrong_root = %(<wrong xmlns="#{Iana::IANA_XML_NAMESPACE}"/>)
+    assert_raises(Iana::Error) { Registry.registry_updated(wrong_root, id: schema.id) }
+    wrong_identity = %(<registry xmlns="#{Iana::IANA_XML_NAMESPACE}" id="wrong"/>)
+    assert_raises(Iana::Error) { Registry.registry_updated(wrong_identity, id: schema.id) }
+
+    assert_raises(Iana::Error) do
+      Registry.send(:parse_xml_start_tag, 'registry xmlns="unterminated', "fixture")
+    end
+    assert_raises(Iana::Error) { Registry.send(:parse_xml_start_tag, "!", "fixture") }
+  end
+
+  def test_registry_json_scanner_rejects_structural_ambiguity
+    failures = [
+      "{} trailing",
+      "{bad}",
+      %({"key" 1}),
+      %({"key":1]),
+      "[1}"
+    ]
+    failures.each do |json|
+      assert_raises(Iana::Error, json) do
+        Registry.send(:reject_duplicate_json_keys!, json, "fixture")
+      end
+    end
+
+    Registry.send(:reject_duplicate_json_keys!, "{}", "fixture")
+    Registry.send(:reject_duplicate_json_keys!, "[]", "fixture")
+    Registry.send(:reject_duplicate_json_keys!, %(["escaped\\\"string", true, null]), "fixture")
+    assert_raises(Iana::Error) do
+      Registry.send(:reject_duplicate_json_keys!, %({"same":1,"same":2}), "fixture")
+    end
+  end
+
+  def test_registry_date_validation_covers_format_year_month_and_leap_centuries
+    validate = ->(value) { Registry.send(:valid_iso_date?, value) }
+    refute validate.call("not-a-date")
+    refute validate.call("0000-01-01")
+    refute validate.call("2025-13-01")
+    refute validate.call("1900-02-29")
+    assert validate.call("2000-02-29")
+  end
+
+  def test_generator_cli_is_loadable_and_reports_every_result
+    out = StringIO.new
+    err = StringIO.new
+    stub_singleton(Generator, :check!, true) do
+      assert_equal 0, Iana::GeneratorCLI.run([ "--check" ], out: out, err: err)
+    end
+    assert_equal "IANA generated constants: ok\n", out.string
+
+    [
+      [ true, "Updated generated IANA constants; review the diff\n" ],
+      [ false, "IANA generated constants already current\n" ]
+    ].each do |changed, expected|
+      out = StringIO.new
+      stub_singleton(Generator, :update!, changed) do
+        assert_equal 0, Iana::GeneratorCLI.run([ "--update" ], out: out, err: err)
+      end
+      assert_equal expected, out.string
+    end
+
+    err = StringIO.new
+    assert_equal 2, Iana::GeneratorCLI.run([], out: StringIO.new, err: err)
+    assert_equal "usage: script/generate_iana_data.rb --check|--update\n", err.string
+  end
+
+  def test_generator_rejects_non_files_and_cleans_a_failed_atomic_replacement
+    Dir.mktmpdir("iana-generator-coverage") do |directory|
+      assert_raises(Iana::Error) { Generator.update!(target: directory) }
+
+      symlink = File.join(directory, "link")
+      File.symlink(File.join(ROOT, "lib/surfguard.rb"), symlink)
+      assert_raises(Iana::Error) { Generator.update!(target: symlink) }
+
+      target = File.join(directory, "surfguard.rb")
+      source = File.binread(File.join(ROOT, "lib/surfguard.rb"))
+      File.binwrite(target, source)
+      assert Generator.check!(target: target)
+      refute Generator.update!(target: target)
+
+      File.binwrite(target, source.sub("2001::/23", "2001::/24"))
+      assert_raises(Iana::Error) { Generator.check!(target: target) }
+      stub_singleton(File, :rename, ->(*) { raise IOError, "simulated rename failure" }) do
+        assert_raises(IOError) { Generator.update!(target: target) }
+      end
+      assert_empty Dir[File.join(directory, ".iana-generated*")]
+
+      assert Generator.update!(target: target)
+      assert_equal source, File.binread(target)
+    end
+  end
+
+  def test_generator_empty_render_reversed_markers_and_platform_fsync
+    rendered = Generator.render_region("EMPTY", [], [])
+    assert_includes rendered, "EMPTY = %w["
+    assert_includes rendered, "].map"
+
+    opening = "  # iana-generator:begin EMPTY"
+    closing = "  # iana-generator:end EMPTY"
+    assert_raises(Iana::Error) do
+      Generator.send(:replace_region, "#{closing}\n#{opening}\n", "EMPTY", "replacement")
+    end
+    assert_raises(Iana::Error) do
+      Generator.send(:replace_region, "#{closing}\n", "EMPTY", "replacement")
+    end
+
+    assert_equal "\n", Generator.send(:source_newline, "one\ntwo\n")
+    assert_equal "\r\n", Generator.send(:source_newline, "one\r\ntwo\r\n")
+    assert_raises(Iana::Error) { Generator.send(:source_newline, "one\r\ntwo\n") }
+
+    assert_nil Generator.send(:fsync_directory, ROOT, platform: "mingw32")
+    stub_singleton(File, :open, ->(*) { raise Errno::ENOTSUP }) do
+      assert_nil Generator.send(:fsync_directory, ROOT, platform: "ruby")
+    end
+  end
+
+  def test_cli_guards_execute_only_when_loaded_as_the_program
+    fake_checker = Object.new
+    fake_checker.define_singleton_method(:run) { 7 }
+    stub_singleton(Iana::DriftChecker, :new, fake_checker) do
+      assert_nil Iana::DriftChecker.run_if_main("not-the-program", CHECKER)
+      error = assert_raises(SystemExit) { Iana::DriftChecker.run_if_main(CHECKER, CHECKER) }
+      assert_equal 7, error.status
+    end
+
+    assert_nil Iana::GeneratorCLI.run_if_main("not-the-program", GENERATOR_CLI, [])
+    _out, _err = capture_io do
+      error = assert_raises(SystemExit) do
+        Iana::GeneratorCLI.run_if_main(GENERATOR_CLI, GENERATOR_CLI, [])
+      end
+      assert_equal 2, error.status
+    end
+  end
+
+  private
+    def http_response(klass: Net::HTTPOK, length: nil, chunks: [])
+      response = klass.new("1.1", klass == Net::HTTPNotFound ? "404" : "200", "fixture")
+      response["content-length"] = length.to_s unless length.nil?
+      response.define_singleton_method(:read_body) do |&consumer|
+        chunks.each(&consumer)
+      end
+      response
+    end
+
+    def fake_http(response)
+      Object.new.tap do |http|
+        http.define_singleton_method(:request) do |request, &consumer|
+          @request = request
+          consumer.call(response)
+        end
+        http.define_singleton_method(:captured_request) { @request }
+      end
+    end
+
+    def with_http_response(response)
+      http = fake_http(response)
+      starter = ->(*, **, &block) { block.call(http) }
+      stub_singleton(Net::HTTP, :start, starter) { yield }
+    end
+
+    def csv_for(schema, rows)
+      csv_rows([ schema.headers ] + rows.map do |values|
+        schema.headers.map { |header| values.fetch(header, "") }
+      end)
+    end
+
+    def csv_rows(rows)
+      rows.map do |fields|
+        fields.map do |field|
+          value = field.to_s
+          value.match?(/[,"\r\n]/) ? %Q("#{value.gsub('"', '""')}") : value
+        end.join(",")
+      end.join("\r\n") + "\r\n"
+    end
+
+    def metadata_xml(schema, date)
+      <<~XML
+        <registry xmlns="#{Iana::IANA_XML_NAMESPACE}" id="#{schema.metadata_registry_id}">
+          <updated>#{date}</updated>
+        </registry>
+      XML
+    end
+
+    def snapshot_data(schema, prefixes, source:)
+      records = Registry.records_from_cidrs(schema, prefixes, context: "fixture")
+      {
+        "schema_version" => Iana::SCHEMA_VERSION,
+        "registry" => schema.id,
+        "url" => schema.source_url,
+        "metadata_url" => schema.metadata_url,
+        "registry_updated" => "2025-10-09",
+        "source_sha256" => Digest::SHA256.hexdigest(source),
+        "selection" => schema.selection.to_s,
+        "semantic_sha256" => Registry.semantic_digest(records),
+        "prefixes" => prefixes
+      }
+    end
+
+    def parsed_snapshot(schema, prefixes, source:)
+      Registry.parse_snapshot(schema.id, JSON.generate(snapshot_data(schema, prefixes, source: source)))
+    end
+
+    def render_ipv6(address)
+      Registry.render_address(Socket::AF_INET6, IPAddr.new(address).to_i)
+    end
+
+    def assert_raises_with_message(message)
+      error = assert_raises(Iana::Error) { yield }
+      assert_match message, error.message
+    end
+
+    def stub_singleton(object, name, replacement)
+      singleton = object.singleton_class
+      visibilities = {
+        public: singleton.public_instance_methods(false),
+        protected: singleton.protected_instance_methods(false),
+        private: singleton.private_instance_methods(false)
+      }
+      visibility = visibilities.find { |_kind, methods| methods.include?(name) }&.first
+      original = singleton.instance_method(name) if visibility
+      singleton.define_method(name) do |*arguments, **keywords, &block|
+        if replacement.respond_to?(:call)
+          replacement.call(*arguments, **keywords, &block)
+        else
+          replacement
+        end
+      end
+      yield
+    ensure
+      if visibility
+        singleton.define_method(name, original)
+        singleton.send(visibility, name)
+      else
+        singleton.remove_method(name)
+      end
+    end
+end

--- a/test/iana_snapshot_test.rb
+++ b/test/iana_snapshot_test.rb
@@ -1,0 +1,335 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+require "digest"
+require "fileutils"
+require "json"
+require "tmpdir"
+
+require_relative "../lib/surfguard"
+require_relative "../script/check_iana_drift"
+require_relative "../script/iana/generator"
+
+class IanaSnapshotTest < Minitest::Test
+  Iana = Surfguard::Iana
+  Registry = Iana::Registry
+  Generator = Iana::Generator
+  ROOT = File.expand_path("..", __dir__)
+  SNAPSHOTS = File.join(ROOT, "script/iana")
+
+  RUNTIME_CONSTANTS = {
+    "ipv4_special_use" => Surfguard::IANA_SPECIAL_USE_IPV4,
+    "ipv6_allocated" => Surfguard::IANA_ALLOCATED_IPV6_UNICAST,
+    "ipv6_special_use" => Surfguard::IANA_SPECIAL_USE_IPV6
+  }.freeze
+
+  def test_current_snapshots_are_schema_valid_and_match_exact_runtime_tuples
+    snapshots = Registry.load_snapshots(SNAPSHOTS)
+    assert_equal Iana::SCHEMAS.map(&:id).sort, snapshots.keys.sort
+
+    snapshots.each do |id, snapshot|
+      expected = snapshot.prefixes.map(&:tuple)
+      actual = RUNTIME_CONSTANTS.fetch(id).map do |range|
+        [ range.ipv4? ? 4 : 6, range.to_i, range.prefix ]
+      end
+      assert_equal expected, actual, id
+      assert_equal snapshot.semantic_sha256, Registry.semantic_digest(snapshot.prefixes), id
+    end
+  end
+
+  def test_prefix_length_is_part_of_snapshot_identity
+    network = IPAddr.new("2001::/23")
+    narrowed = IPAddr.new("2001::/128")
+    assert_equal network, narrowed # IPAddr#== deliberately ignores the mask.
+    refute_equal [ 6, network.to_i, network.prefix ], [ 6, narrowed.to_i, narrowed.prefix ]
+  end
+
+  def test_semantic_tuples_use_portable_ip_versions_not_socket_family_numbers
+    ipv4 = Registry.records_from_cidrs(
+      Registry.schema("ipv4_special_use"), [ "192.0.2.0/24" ], context: "fixture"
+    ).first
+    ipv6 = Registry.records_from_cidrs(
+      Registry.schema("ipv6_allocated"), [ "2001::/23" ], context: "fixture"
+    ).first
+
+    assert_equal [ 4, IPAddr.new("192.0.2.0").to_i, 24 ], ipv4.tuple
+    assert_equal [ 6, IPAddr.new("2001::").to_i, 23 ], ipv6.tuple
+    assert_equal Digest::SHA256.hexdigest(JSON.generate([ ipv4.tuple, ipv6.tuple ])),
+      Registry.semantic_digest([ ipv4, ipv6 ])
+  end
+
+  def test_generated_regions_exactly_match_snapshots_and_are_deeply_frozen
+    assert Generator.check!
+    RUNTIME_CONSTANTS.each_value do |ranges|
+      assert_predicate ranges, :frozen?
+      ranges.each { |range| assert_predicate range, :frozen? }
+    end
+  end
+
+  def test_allocated_selector_admits_only_exact_allocated_status
+    schema = Registry.schema("ipv6_allocated")
+    body = csv_for(schema, [
+      { "Prefix" => "2001::/23", "Status" => "ALLOCATED" },
+      { "Prefix" => "2d00::/8", "Status" => "RESERVED" }
+    ])
+    assert_equal [ "2001::/23" ], Registry.parse_registry(schema, body).map(&:cidr)
+
+    unknown = csv_for(schema, [ { "Prefix" => "2d00::/8", "Status" => "allocated" } ])
+    assert_raises(Iana::Error) { Registry.parse_registry(schema, unknown) }
+  end
+
+  def test_unknown_selector_schema_and_snapshot_fields_fail_closed
+    schema = Registry.schema("ipv6_allocated")
+    body = csv_for(schema, [ { "Prefix" => "2001::/23", "Status" => "ALLOCATED" } ])
+    bad_schema = schema.dup
+    bad_schema.selection = :unknown
+    assert_raises(Iana::Error) { Registry.parse_registry(bad_schema, body) }
+    assert_raises(Iana::Error) { Registry.schema("not-a-registry") }
+
+    data = snapshot_data(schema, [ "2001::/23" ], source: body)
+    data["selection"] = "Status=ALLOCATED"
+    assert_raises(Iana::Error) { Registry.parse_snapshot(schema.id, JSON.generate(data)) }
+    data["selection"] = schema.selection.to_s
+    data["schema_version"] = 99
+    assert_raises(Iana::Error) { Registry.parse_snapshot(schema.id, JSON.generate(data)) }
+    data["schema_version"] = Iana::SCHEMA_VERSION
+    data["surprise"] = true
+    assert_raises(Iana::Error) { Registry.parse_snapshot(schema.id, JSON.generate(data)) }
+  end
+
+  def test_registry_headers_are_exact_and_code_owned
+    schema = Registry.schema("ipv6_allocated")
+    missing_headers = schema.headers.reject { |header| header == "Status" }
+    missing_header = csv_rows([ missing_headers, [ "2001::/23" ] ])
+    assert_raises(Iana::Error) { Registry.parse_registry(schema, missing_header) }
+
+    reordered = schema.dup
+    reordered.headers = schema.headers.reverse.freeze
+    body = csv_for(reordered, [ { "Prefix" => "2001::/23", "Status" => "ALLOCATED" } ])
+    assert_raises(Iana::Error) { Registry.parse_registry(schema, body) }
+  end
+
+  def test_current_footnotes_multi_prefix_fields_and_intentional_overlaps_normalize
+    schema = Registry.schema("ipv4_special_use")
+    body = csv_for(schema, [
+      { "Address Block" => "192.0.0.0/24 [2]" },
+      { "Address Block" => "192.0.0.8/32" },
+      { "Address Block" => "192.0.0.170/32, 192.0.0.171/32" },
+      { "Address Block" => "198.18.0.0/15 [1] [9]" }
+    ])
+    assert_equal %w[
+      192.0.0.0/24 192.0.0.8/32 192.0.0.170/32 192.0.0.171/32 198.18.0.0/15
+    ], Registry.parse_registry(schema, body).map(&:cidr)
+  end
+
+  def test_invalid_noncanonical_wrong_family_annotated_and_duplicate_prefixes_fail_closed
+    schema = Registry.schema("ipv4_special_use")
+    invalid = [
+      "192.0.2.1/24",
+      "192.0.002.0/24",
+      "2001:db8::/32",
+      "192.0.2.0/33",
+      "192.0.2.0/24 [RFC]"
+    ]
+    invalid.each do |prefix|
+      body = csv_for(schema, [ { "Address Block" => prefix } ])
+      assert_raises(Iana::Error, prefix) { Registry.parse_registry(schema, body) }
+    end
+
+    duplicate = csv_for(schema, [
+      { "Address Block" => "192.0.2.0/24" },
+      { "Address Block" => "192.0.2.0/24" }
+    ])
+    assert_raises(Iana::Error) { Registry.parse_registry(schema, duplicate) }
+  end
+
+  def test_snapshot_semantic_digest_and_metadata_are_validated
+    schema = Registry.schema("ipv4_special_use")
+    body = csv_for(schema, [ { "Address Block" => "192.0.2.0/24" } ])
+    data = snapshot_data(schema, [ "192.0.2.0/24" ], source: body)
+    data["semantic_sha256"] = "0" * 64
+    assert_raises(Iana::Error) { Registry.parse_snapshot(schema.id, JSON.generate(data)) }
+
+    data = snapshot_data(schema, [ "192.0.2.0/24" ], source: body)
+    data["url"] = "https://www.iana.org/unreviewed.csv"
+    assert_raises(Iana::Error) { Registry.parse_snapshot(schema.id, JSON.generate(data)) }
+
+    data = snapshot_data(schema, [ "192.0.2.0/24" ], source: body)
+    valid = JSON.generate(data)
+    assert_equal "{", valid.byteslice(0)
+    object_body = valid.byteslice(1..)
+    duplicate = %({"url":"https://attacker.invalid/decoy.csv",) + object_body
+    escaped_duplicate = %({"\\u0075rl":"https://attacker.invalid/decoy.csv",) + object_body
+    [ duplicate, escaped_duplicate ].each do |snapshot|
+      error = assert_raises(Iana::Error) { Registry.parse_snapshot(schema.id, snapshot) }
+      assert_match(/duplicate JSON object field/, error.message)
+    end
+  end
+
+  def test_raw_semantic_and_metadata_drift_are_reported_independently
+    schema = Registry.schema("ipv4_special_use")
+    original = csv_for(schema, [ { "Address Block" => "192.0.2.0/24", "Name" => "original" } ])
+    description_only = csv_for(schema, [ { "Address Block" => "192.0.2.0/24", "Name" => "reworded" } ])
+    metadata = metadata_xml(schema, "2025-10-09")
+    checker = Iana::DriftChecker.new
+
+    snapshot = parsed_snapshot(schema, [ "192.0.2.0/24" ], source: original)
+    result = checker.audit(snapshot, source: description_only, metadata: metadata)
+    assert_equal 1, result.issues.length
+    assert_match(/raw source SHA-256 drift/, result.issues.first)
+
+    changed_policy = csv_for(schema, [ { "Address Block" => "198.51.100.0/24" } ])
+    snapshot = parsed_snapshot(schema, [ "192.0.2.0/24" ], source: changed_policy)
+    result = checker.audit(snapshot, source: changed_policy, metadata: metadata)
+    assert_equal 1, result.issues.length
+    assert_match(/semantic policy drift.*added.*removed/, result.issues.first)
+
+    snapshot = parsed_snapshot(schema, [ "192.0.2.0/24" ], source: original)
+    result = checker.audit(snapshot, source: original,
+      metadata: metadata_xml(schema, "2025-10-10"))
+    assert_equal [ "registry update date drift: expected 2025-10-09, got 2025-10-10" ], result.issues
+  end
+
+  def test_registry_metadata_requires_one_update_date
+    schema = Registry.schema("ipv4_special_use")
+    assert_equal "2025-10-09", Registry.registry_updated(metadata_xml(schema, "2025-10-09"), id: schema.id)
+    assert_raises(Iana::Error) { Registry.registry_updated("<registry/>") }
+    assert_raises(Iana::Error) { Registry.registry_updated(metadata_xml(schema, "2025-02-29"), id: schema.id) }
+    assert_equal "2024-02-29", Registry.registry_updated(metadata_xml(schema, "2024-02-29"), id: schema.id)
+
+    duplicate = metadata_xml(schema, "2025-10-09", extra: "<updated>2025-10-10</updated>")
+    assert_raises(Iana::Error) { Registry.registry_updated(duplicate, id: schema.id) }
+    assert_raises(Iana::Error) do
+      Registry.registry_updated("not XML <updated>2025-10-09</updated> at all")
+    end
+    assert_raises(Iana::Error) do
+      Registry.registry_updated(%(<!DOCTYPE registry><registry xmlns="#{Iana::IANA_XML_NAMESPACE}"/>))
+    end
+    wrong_identity = metadata_xml(schema, "2025-10-09").sub(schema.metadata_registry_id, "other-registry")
+    assert_raises(Iana::Error) { Registry.registry_updated(wrong_identity, id: schema.id) }
+
+    source = csv_for(schema, [ { "Address Block" => "192.0.2.0/24" } ])
+    data = snapshot_data(schema, [ "192.0.2.0/24" ], source: source)
+    data["registry_updated"] = "2025-02-29"
+    assert_raises(Iana::Error) { Registry.parse_snapshot(schema.id, JSON.generate(data)) }
+  end
+
+  def test_csv_parser_handles_quoted_content_and_rejects_malformed_records
+    parsed = Registry.parse_csv(%Q("head,one",head-two\r\n"say ""hi""","line one\nline two"\r\n))
+    assert_equal [ "head,one", "head-two" ], parsed.first
+    assert_equal [ [ 'say "hi"', "line one\nline two" ] ], parsed.last
+
+    malformed = [
+      %(header\r\n"unterminated),
+      %(header\r\n"closed"junk\r\n),
+      %(header\r\nun"quoted\r\n),
+      "header\rvalue\r\n"
+    ]
+    malformed.each do |body|
+      assert_raises(Iana::Error, body.inspect) { Registry.parse_csv(body) }
+    end
+
+    schema = Registry.schema("ipv6_allocated")
+    wrong_field_count = csv_rows([ schema.headers, [ "2001::/23" ] ])
+    assert_raises(Iana::Error) { Registry.parse_registry(schema, wrong_field_count) }
+  end
+
+  def test_generator_check_is_read_only_and_update_repairs_only_generated_regions
+    Dir.mktmpdir("surfguard-iana-generator") do |directory|
+      target = File.join(directory, "surfguard.rb")
+      source = File.binread(File.join(ROOT, "lib/surfguard.rb"))
+      changed = source.sub("2001::/23", "2001::/24")
+      File.binwrite(target, changed)
+      File.chmod(0o640, target)
+
+      assert_raises(Iana::Error) { Generator.check!(target: target) }
+      assert_equal changed, File.binread(target)
+      assert Generator.update!(target: target)
+      assert_equal source, File.binread(target)
+      assert_equal 0o640, File.stat(target).mode & 0o777
+      assert Generator.check!(target: target)
+      refute Generator.update!(target: target)
+      assert_empty Dir[File.join(directory, ".iana-generated*")]
+    end
+  end
+
+  def test_generator_rejects_duplicate_or_missing_markers
+    source = File.binread(File.join(ROOT, "lib/surfguard.rb"))
+    marker = "  # iana-generator:begin IANA_ALLOCATED_IPV6_UNICAST"
+
+    assert_raises(Iana::Error) { Generator.generated_source(source.sub(marker, "")) }
+    assert_raises(Iana::Error) { Generator.generated_source(source.sub(marker, "#{marker}\n#{marker}")) }
+  end
+
+  def test_generator_preserves_crlf_and_rejects_mixed_line_endings
+    Dir.mktmpdir("surfguard-iana-generator-crlf") do |directory|
+      target = File.join(directory, "surfguard.rb")
+      source = File.binread(File.join(ROOT, "lib/surfguard.rb")).gsub("\n", "\r\n")
+      File.binwrite(target, source)
+
+      assert Generator.check!(target: target)
+      changed = source.sub("2001::/23", "2001::/24")
+      File.binwrite(target, changed)
+      assert Generator.update!(target: target)
+      assert_equal source, File.binread(target)
+      assert Generator.check!(target: target)
+
+      mixed = source.sub("\r\n", "\n")
+      error = assert_raises(Iana::Error) { Generator.generated_source(mixed) }
+      assert_equal "generation target mixes line endings", error.message
+    end
+  end
+
+  def test_generator_tolerates_filesystems_without_directory_fsync
+    original = File.method(:open)
+    File.define_singleton_method(:open) { |*| raise Errno::EINVAL }
+    assert_nil Generator.send(:fsync_directory, ROOT)
+  ensure
+    File.define_singleton_method(:open, original) if original
+  end
+
+  private
+    def csv_for(schema, rows)
+      csv_rows([ schema.headers ] + rows.map do |values|
+        schema.headers.map { |header| values.fetch(header, "") }
+      end)
+    end
+
+    def csv_rows(rows)
+      rows.map do |fields|
+        fields.map do |field|
+          value = field.to_s
+          value.match?(/[,"\r\n]/) ? %Q("#{value.gsub('"', '""')}") : value
+        end.join(",")
+      end.join("\r\n") + "\r\n"
+    end
+
+    def parsed_snapshot(schema, prefixes, source:)
+      Registry.parse_snapshot(schema.id, JSON.generate(snapshot_data(schema, prefixes, source: source)))
+    end
+
+    def metadata_xml(schema, date, extra: "")
+      <<~XML
+        <?xml version="1.0" encoding="UTF-8"?>
+        <registry xmlns="#{Iana::IANA_XML_NAMESPACE}" id="#{schema.metadata_registry_id}">
+          <updated>#{date}</updated>#{extra}
+        </registry>
+      XML
+    end
+
+    def snapshot_data(schema, prefixes, source:)
+      records = Registry.records_from_cidrs(schema, prefixes, context: "fixture")
+      {
+        "schema_version" => Iana::SCHEMA_VERSION,
+        "registry" => schema.id,
+        "url" => schema.source_url,
+        "metadata_url" => schema.metadata_url,
+        "registry_updated" => "2025-10-09",
+        "source_sha256" => Digest::SHA256.hexdigest(source),
+        "selection" => schema.selection.to_s,
+        "semantic_sha256" => Registry.semantic_digest(records),
+        "prefixes" => prefixes
+      }
+    end
+end

--- a/test/readme_recipe_test.rb
+++ b/test/readme_recipe_test.rb
@@ -1,0 +1,369 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+require "net/http"
+require "openssl"
+require "socket"
+if ENV["SURFGUARD_INSTALLED_SUITE"]
+  require "surfguard"
+else
+  require_relative "../lib/surfguard"
+end
+
+class ReadmeRecipeTest < Minitest::Test
+  README = File.expand_path("../README.md", __dir__)
+
+  FakeHTTP = Struct.new(
+    :hostname, :port, :handler, :requests, :use_ssl, :ipaddr, :verify_mode,
+    :verify_hostname, :open_timeout, :read_timeout, :write_timeout,
+    keyword_init: true
+  ) do
+    def request(request)
+      requests << request
+      result = handler.call(self, request)
+      raise result if result.is_a?(Exception)
+
+      yield result
+      result
+    end
+  end
+
+  def test_net_http_recipe_is_valid_ruby_and_contains_the_pinning_invariants
+    recipe = read_recipe
+    refute_nil recipe
+    RubyVM::InstructionSequence.compile(recipe)
+    assert_includes recipe, "uri.hostname"
+    assert_includes recipe, "Net::HTTP.new(hostname, uri.port, nil)"
+    assert_includes recipe, "http.ipaddr = address"
+    assert_includes recipe, "OpenSSL::SSL::VERIFY_PEER"
+    assert_includes recipe, "http.verify_hostname = true"
+    assert_includes recipe, "candidate.read_body"
+    assert_includes recipe, "URI.join(base, value)"
+    assert_equal 1, recipe.scan("resolve_public_ips").length
+  end
+
+  def test_recipe_retries_only_pinned_addresses_and_revalidates_redirects
+    events = [
+      IOError.new("first address failed"),
+      response(Net::HTTPFound, "302", chunks: [ "redirect" ], location: "https://next.example/final"),
+      response(Net::HTTPOK, "200", chunks: [ "o", "k" ])
+    ]
+    resolver = {
+      "feeds.example" => %w[93.184.216.34 93.184.216.35],
+      "next.example" => [ "93.184.216.36" ]
+    }
+
+    with_fake_recipe_network(resolver: resolver, handler: ->(_http, _request) { events.shift }) do |client, state|
+      http_response, body = client.pinned_get("https://feeds.example/feed")
+
+      assert_instance_of Net::HTTPOK, http_response
+      assert_equal "ok", body
+      assert_predicate body, :frozen?
+      assert_equal [
+        [ "feeds.example", :default ],
+        [ "next.example", :default ]
+      ], state[:resolver_calls]
+      assert_equal %w[feeds.example feeds.example next.example], state[:http].map(&:hostname)
+      assert_equal [ 443, 443, 443 ], state[:http].map(&:port)
+      assert_equal [ nil, nil, nil ], state[:proxies]
+      assert_equal %w[93.184.216.34 93.184.216.35 93.184.216.36], state[:http].map(&:ipaddr)
+      assert state[:http].all?(&:use_ssl)
+      assert state[:http].all?(&:verify_hostname)
+      assert state[:http].all? { |http| http.verify_mode == OpenSSL::SSL::VERIFY_PEER }
+      assert_equal %w[/feed /feed /final], state[:requests].map(&:path)
+      assert state[:requests].all? { |request| request["accept-encoding"] == "identity" }
+    end
+  end
+
+  def test_recipe_uses_unbracketed_ipv6_hostname_and_pins_the_literal
+    resolver = { "2606:4700:4700::1111" => [ "2606:4700:4700::1111" ] }
+    handler = ->(_http, _request) { response(Net::HTTPOK, "200", chunks: [ "ipv6" ]) }
+
+    with_fake_recipe_network(resolver: resolver, handler: handler) do |client, state|
+      _http_response, body = client.pinned_get("https://[2606:4700:4700::1111]:444/path")
+
+      assert_equal "ipv6", body
+      assert_equal [ [ "2606:4700:4700::1111", :default ] ], state[:resolver_calls]
+      assert_equal "2606:4700:4700::1111", state[:http].first.hostname
+      assert_equal "2606:4700:4700::1111", state[:http].first.ipaddr
+      assert_equal 444, state[:http].first.port
+    end
+  end
+
+  def test_recipe_enforces_streamed_byte_limit_without_retrying
+    resolver = { "large.example" => %w[93.184.216.34 93.184.216.35] }
+    handler = ->(_http, _request) { response(Net::HTTPOK, "200", chunks: %w[abc def]) }
+
+    with_fake_recipe_network(resolver: resolver, handler: handler) do |client, state, recipe_module|
+      error = assert_raises(recipe_module.const_get(:PinnedResponseTooLarge)) do
+        client.pinned_get("https://large.example/file", max_bytes: 5)
+      end
+      assert_equal "response body exceeds limit", error.message
+      assert_equal 1, state[:http].length
+      assert_equal 1, state[:resolver_calls].length
+    end
+  end
+
+  def test_recipe_bounds_redirects_and_rejects_an_unsafe_redirect_before_resolution
+    redirect = response(Net::HTTPFound, "302", chunks: [], location: "http://internal.example/")
+    resolver = { "start.example" => [ "93.184.216.34" ] }
+
+    with_fake_recipe_network(resolver: resolver, handler: ->(_http, _request) { redirect }) do |client, state|
+      error = assert_raises(ArgumentError) { client.pinned_get("https://start.example/", max_redirects: 1) }
+      assert_equal "HTTPS required", error.message
+      assert_equal [ [ "start.example", :default ] ], state[:resolver_calls]
+    end
+
+    with_fake_recipe_network(resolver: resolver, handler: ->(_http, _request) { redirect }) do |client, _state, recipe_module|
+      error = assert_raises(recipe_module.const_get(:PinnedRedirectError)) do
+        client.pinned_get("https://start.example/", max_redirects: 0)
+      end
+      assert_equal "redirect limit exceeded", error.message
+    end
+  end
+
+  def test_recipe_hard_caps_caller_configurable_bounds
+    client, = recipe_client
+
+    assert_raises(ArgumentError) { client.pinned_get("https://example.com", max_redirects: 11) }
+    assert_raises(ArgumentError) { client.pinned_get("https://example.com", max_redirects: -1) }
+    assert_raises(ArgumentError) { client.pinned_get("https://example.com", max_bytes: 0) }
+    assert_raises(ArgumentError) { client.pinned_get("https://example.com", max_bytes: 16 * 1024 * 1024 + 1) }
+  end
+
+  def test_recipe_fixed_url_and_limit_errors_discard_causes_and_attacker_input
+    client, = recipe_client
+    ambient = "attacker-controlled-ambient-detail"
+    credential = "attacker-controlled-credential"
+    malformed_url = "https://alice:#{credential}@example.invalid/ bad"
+    cases = [
+      [ -> { client.pinned_get(malformed_url) }, ArgumentError, "malformed URL", credential ],
+      [ -> { client.pinned_get("https://alice:#{credential}@example.invalid/") },
+        ArgumentError, "userinfo forbidden", credential ],
+      [ -> { client.pinned_get("http://example.invalid/") }, ArgumentError, "HTTPS required", nil ],
+      [ -> { client.pinned_get("https:///path") }, ArgumentError, "host required", nil ],
+      [ -> { client.pinned_get("https://example.invalid/", max_redirects: -1) },
+        ArgumentError, "invalid redirect limit", nil ],
+      [ -> { client.pinned_get("https://example.invalid/", max_bytes: 0) },
+        ArgumentError, "invalid response limit", nil ]
+    ]
+
+    cases.each do |call, type, message, input_detail|
+      error = capture_during_rescue(ambient, &call)
+      assert_sanitized_exception(error, type, message, ambient, input_detail)
+    end
+  end
+
+  def test_recipe_fixed_network_and_redirect_errors_discard_causes
+    ambient = "attacker-controlled-ambient-detail"
+
+    with_fake_recipe_network(resolver: { "blocked.example" => [] }, handler: ->(*) { flunk }) do |client|
+      error = capture_during_rescue(ambient) { client.pinned_get("https://blocked.example/") }
+      assert_sanitized_exception(error, Surfguard::Violation, Surfguard::BLOCKED_MESSAGE, ambient)
+    end
+
+    network_detail = "attacker-controlled-network-detail"
+    handler = ->(*) { IOError.new(network_detail) }
+    with_fake_recipe_network(resolver: { "retry.example" => [ "93.184.216.34" ] }, handler: handler) do |client|
+      error = capture_during_rescue(ambient) { client.pinned_get("https://retry.example/") }
+      assert_sanitized_exception(
+        error, Surfguard::Unresolvable, Surfguard::UNRESOLVABLE_MESSAGE, ambient, network_detail
+      )
+    end
+
+    large = ->(*) { response(Net::HTTPOK, "200", chunks: [ "too large" ]) }
+    with_fake_recipe_network(resolver: { "large.example" => [ "93.184.216.34" ] }, handler: large) do |client, _state, recipe_module|
+      error = capture_during_rescue(ambient) do
+        client.pinned_get("https://large.example/", max_bytes: 1)
+      end
+      assert_sanitized_exception(
+        error, recipe_module.const_get(:PinnedResponseTooLarge), "response body exceeds limit", ambient
+      )
+    end
+
+    redirect = ->(location) { response(Net::HTTPFound, "302", chunks: [], location: location) }
+    resolver = { "start.example" => [ "93.184.216.34" ] }
+    with_fake_recipe_network(resolver: resolver, handler: ->(*) { redirect.call("https://next.example/") }) do |client, _state, recipe_module|
+      error = capture_during_rescue(ambient) do
+        client.pinned_get("https://start.example/", max_redirects: 0)
+      end
+      assert_sanitized_exception(
+        error, recipe_module.const_get(:PinnedRedirectError), "redirect limit exceeded", ambient
+      )
+    end
+
+    with_fake_recipe_network(resolver: resolver, handler: ->(*) { redirect.call(nil) }) do |client, _state, recipe_module|
+      error = capture_during_rescue(ambient) { client.pinned_get("https://start.example/") }
+      assert_sanitized_exception(
+        error, recipe_module.const_get(:PinnedRedirectError), "redirect location missing", ambient
+      )
+    end
+
+    redirect_detail = "attacker-controlled-redirect-detail"
+    malformed_redirect = "https://alice:#{redirect_detail}@next.example/ bad"
+    with_fake_recipe_network(resolver: resolver, handler: ->(*) { redirect.call(malformed_redirect) }) do |client|
+      error = capture_during_rescue(ambient) { client.pinned_get("https://start.example/") }
+      assert_sanitized_exception(error, ArgumentError, "malformed URL", ambient, redirect_detail)
+    end
+  end
+
+  def test_real_net_http_retains_host_sni_and_certificate_identity_while_pinning
+    hostname = "origin.test"
+    ca_certificate, server_certificate, server_key = certificates_for(hostname)
+    tcp_server = begin
+      TCPServer.new("127.0.0.1", 0)
+    rescue Errno::EACCES, Errno::EPERM
+      raise if ENV["CI"]
+
+      skip "local TCP sockets are unavailable"
+    end
+    port = tcp_server.local_address.ip_port
+    server_result = nil
+    server_name = nil
+    context = OpenSSL::SSL::SSLContext.new
+    context.cert = server_certificate
+    context.key = server_key
+    context.servername_cb = lambda do |socket_and_hostname|
+      server_name = socket_and_hostname.last
+      nil
+    end
+    server = Thread.new do
+      socket = tcp_server.accept
+      ssl = OpenSSL::SSL::SSLSocket.new(socket, context)
+      ssl.sync_close = true
+      ssl.accept
+      request = String.new(encoding: Encoding::BINARY)
+      request << ssl.readpartial(1024) until request.include?("\r\n\r\n")
+      host = request[/\r\nHost:\s*([^\r\n]+)/i, 1]
+      server_result = [ server_name, host ]
+      ssl.write("HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok")
+      ssl.close
+    end
+
+    client, = recipe_client
+    original_resolver = Surfguard.method(:resolve_public_ips)
+    original_http_new = Net::HTTP.method(:new)
+    constructors = []
+    Surfguard.define_singleton_method(:resolve_public_ips) do |host, policy:|
+      raise "wrong host or policy" unless host == hostname && policy == :iana_special_use
+
+      [ "127.0.0.1" ]
+    end
+    Net::HTTP.define_singleton_method(:new) do |host, requested_port, proxy|
+      constructors << [ host, requested_port, proxy ]
+      http = original_http_new.call(host, requested_port, proxy)
+      store = OpenSSL::X509::Store.new
+      store.add_cert(ca_certificate)
+      http.cert_store = store
+      http
+    end
+
+    response_value, body = client.pinned_get(
+      "https://#{hostname}:#{port}/secure", policy: :iana_special_use
+    )
+    assert_instance_of Net::HTTPOK, response_value
+    assert_equal "ok", body
+    assert server.join(5), "TLS test server did not finish"
+    server.value
+    assert_equal [ hostname, "#{hostname}:#{port}" ], server_result
+    assert_equal [ [ hostname, port, nil ] ], constructors
+  ensure
+    Surfguard.define_singleton_method(:resolve_public_ips, original_resolver) if original_resolver
+    Net::HTTP.define_singleton_method(:new, original_http_new) if original_http_new
+    tcp_server&.close
+    server&.kill if server&.alive?
+  end
+
+  private
+    def assert_sanitized_exception(error, type, message, *forbidden_details)
+      assert_instance_of type, error
+      assert_equal message, error.message
+      assert_nil error.cause
+      forbidden_details.compact.each { |detail| refute_includes error.full_message, detail }
+    end
+
+    def capture_during_rescue(detail)
+      raise RuntimeError, detail
+    rescue RuntimeError
+      begin
+        yield
+      rescue StandardError => error
+        error
+      end
+    end
+
+    def read_recipe
+      markdown = File.read(README)
+      markdown[/<!-- net-http-recipe:start -->\s*```ruby\n(.*?)```\s*<!-- net-http-recipe:end -->/m, 1]
+    end
+
+    def recipe_client
+      recipe_module = Module.new
+      recipe_module.module_eval(read_recipe.gsub(/^require .+\n/, ""))
+      [ Class.new { include recipe_module }.new, recipe_module ]
+    end
+
+    def response(type, code, chunks:, location: nil)
+      value = type.new("1.1", code, "test")
+      value["location"] = location if location
+      value.define_singleton_method(:read_body) { |&block| chunks.each(&block) }
+      value
+    end
+
+    def with_fake_recipe_network(resolver:, handler:)
+      client, recipe_module = recipe_client
+      original_resolver = Surfguard.method(:resolve_public_ips)
+      original_http_new = Net::HTTP.method(:new)
+      state = { resolver_calls: [], http: [], requests: [], proxies: [] }
+      Surfguard.define_singleton_method(:resolve_public_ips) do |host, policy:|
+        state[:resolver_calls] << [ host, policy ]
+        resolver.fetch(host)
+      end
+      Net::HTTP.define_singleton_method(:new) do |host, port, proxy|
+        state[:proxies] << proxy
+        FakeHTTP.new(hostname: host, port: port, handler: handler, requests: state[:requests]).tap do |http|
+          state[:http] << http
+        end
+      end
+
+      yield client, state, recipe_module
+    ensure
+      Surfguard.define_singleton_method(:resolve_public_ips, original_resolver) if original_resolver
+      Net::HTTP.define_singleton_method(:new, original_http_new) if original_http_new
+    end
+
+    def certificates_for(hostname)
+      now = Time.now
+      ca_key = OpenSSL::PKey::RSA.new(2048)
+      ca = OpenSSL::X509::Certificate.new
+      ca.version = 2
+      ca.serial = 1
+      ca.subject = OpenSSL::X509::Name.parse("/CN=Surfguard Recipe Test CA")
+      ca.issuer = ca.subject
+      ca.public_key = ca_key.public_key
+      ca.not_before = now - 60
+      ca.not_after = now + 3600
+      ca_factory = OpenSSL::X509::ExtensionFactory.new(nil, ca)
+      ca.add_extension(ca_factory.create_extension("basicConstraints", "CA:TRUE", true))
+      ca.add_extension(ca_factory.create_extension("keyUsage", "keyCertSign,cRLSign", true))
+      ca.sign(ca_key, OpenSSL::Digest::SHA256.new)
+
+      server_key = OpenSSL::PKey::RSA.new(2048)
+      certificate = OpenSSL::X509::Certificate.new
+      certificate.version = 2
+      certificate.serial = 2
+      certificate.subject = OpenSSL::X509::Name.parse("/CN=#{hostname}")
+      certificate.issuer = ca.subject
+      certificate.public_key = server_key.public_key
+      certificate.not_before = now - 60
+      certificate.not_after = now + 3600
+      factory = OpenSSL::X509::ExtensionFactory.new(ca, certificate)
+      certificate.add_extension(factory.create_extension("basicConstraints", "CA:FALSE", true))
+      certificate.add_extension(factory.create_extension("keyUsage", "digitalSignature,keyEncipherment", true))
+      certificate.add_extension(factory.create_extension("extendedKeyUsage", "serverAuth"))
+      certificate.add_extension(factory.create_extension("subjectAltName", "DNS:#{hostname}"))
+      certificate.sign(ca_key, OpenSSL::Digest::SHA256.new)
+
+      [ ca, certificate, server_key ]
+    end
+end

--- a/test/readme_recipe_test.rb
+++ b/test/readme_recipe_test.rb
@@ -223,8 +223,9 @@ class ReadmeRecipeTest < Minitest::Test
     context = OpenSSL::SSL::SSLContext.new
     context.cert = server_certificate
     context.key = server_key
-    context.servername_cb = lambda do |socket_and_hostname|
-      server_name = socket_and_hostname.last
+    # Ruby's OpenSSL invokes servername_cb with a single [socket, hostname] array.
+    context.servername_cb = lambda do |(_socket, hostname)|
+      server_name = hostname
       nil
     end
     server = Thread.new do

--- a/test/resolv_version_check_test.rb
+++ b/test/resolv_version_check_test.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+require_relative "../script/check_resolv_version"
+
+require "stringio"
+
+class ResolvVersionCheckTest < Minitest::Test
+  CHECK = SurfguardRelease::ResolvVersionCheck
+
+  def test_rejects_every_affected_range_at_its_boundaries
+    %w[0 0.2.2 0.3.0 0.4.0 0.6.1].each do |version|
+      assert CHECK.vulnerable?(version), version
+    end
+  end
+
+  def test_accepts_patched_versions_and_gaps_between_affected_ranges
+    %w[0.2.3 0.2.999 0.3.1 0.3.999 0.6.2 1.0.0].each do |version|
+      refute CHECK.vulnerable?(version), version
+    end
+  end
+
+  def test_main_fails_closed_with_a_fixed_diagnostic_for_an_affected_version
+    output = StringIO.new
+    error = StringIO.new
+
+    assert_equal 1, CHECK.main(version: "0.4.1", output: output, error: error)
+    assert_empty output.string
+    assert_equal "unsupported vulnerable resolv 0.4.1\n", error.string
+  end
+
+  def test_main_reports_the_effective_supported_version
+    output = StringIO.new
+    error = StringIO.new
+
+    assert_equal 0, CHECK.main(version: "0.6.2", output: output, error: error)
+    assert_equal "resolv 0.6.2: supported\n", output.string
+    assert_empty error.string
+  end
+
+  def test_current_version_is_the_resolv_version_ruby_loaded
+    loaded = Struct.new(:version).new("0.6.3")
+    default = Struct.new(:version) { def default_gem? = true }.new("0.7.0")
+
+    assert_equal Gem::Version.new("0.6.3"), CHECK.current_version(
+      loaded_specs: { "resolv" => loaded }, available_specs: [ default ]
+    )
+    assert_equal Gem::Version.new("0.7.0"), CHECK.current_version(
+      loaded_specs: {}, available_specs: [ default ]
+    )
+  end
+
+  def test_current_version_fails_closed_if_rubygems_cannot_identify_resolv
+    error = assert_raises(RuntimeError) do
+      CHECK.current_version(loaded_specs: {}, available_specs: [])
+    end
+
+    assert_equal "could not identify the effective resolv version", error.message
+  end
+end

--- a/test/runtime_coverage_test.rb
+++ b/test/runtime_coverage_test.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+require_relative "../lib/surfguard"
+require_relative "../script/check_resolv_version"
+
+require "stringio"
+
+class RuntimeCoverageTest < Minitest::Test
+  def test_network_ipaddr_is_not_accepted_as_a_host_endpoint
+    assert_empty Surfguard.resolve_public_ips(IPAddr.new("192.0.2.0/24"))
+  end
+
+  def test_corrupt_ipaddr_internals_fail_closed
+    corruptions = [
+      [ :@mask_addr, "not an integer" ],
+      [ :@mask_addr, 1 << 100 ],
+      [ :@addr, -1 ],
+      [ :@mask_addr, 5 ]
+    ]
+
+    corruptions.each do |variable, value|
+      address = IPAddr.new("8.8.8.8")
+      Object.instance_method(:instance_variable_set).bind_call(address, variable, value)
+      assert Surfguard.blocked_address?(address), "#{variable}=#{value.inspect} must fail closed"
+    end
+  end
+
+  def test_owned_string_rejects_non_strings_even_when_called_directly
+    invalid_input = Surfguard.const_get(:InvalidInput, false)
+
+    assert_raises(invalid_input) { Surfguard.send(:owned_string, Object.new) }
+  end
+
+  def test_numeric_resolver_adapter_rejects_malformed_container_shapes
+    malformed = [
+      Object.new,
+      [ Object.new ],
+      [ [ nil, nil, nil, Object.new ] ]
+    ]
+
+    malformed.each do |answer|
+      with_singleton_method(Socket, :getaddrinfo, ->(*) { answer }) do
+        error = assert_raises(Surfguard::Unresolvable) do
+          Surfguard.resolve_public_ips("example.com")
+        end
+        assert_equal "Host could not be resolved", error.message
+      end
+    end
+  end
+
+  def test_host_syntax_rejects_an_absolute_empty_label_set
+    refute Surfguard.send(:valid_host_syntax?, ".")
+  end
+
+  def test_resolv_checker_cli_guard_propagates_the_runner_status
+    checker = SurfguardRelease::ResolvVersionCheck
+    with_singleton_method(checker, :main, -> { 7 }) do
+      error = assert_raises(SystemExit) do
+        checker.cli(program_name: "checker", file: "checker")
+      end
+      assert_equal 7, error.status
+    end
+  end
+
+  private
+    def with_singleton_method(object, name, replacement)
+      original = object.method(name)
+      object.define_singleton_method(name, replacement)
+      yield
+    ensure
+      object.define_singleton_method(name, original)
+    end
+end

--- a/test/surfguard_hardening_test.rb
+++ b/test/surfguard_hardening_test.rb
@@ -1,0 +1,676 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+require "resolv"
+if ENV["SURFGUARD_INSTALLED_SUITE"]
+  require "surfguard"
+else
+  require_relative "../lib/surfguard"
+end
+
+class SurfguardHardeningTest < Minitest::Test
+  REPORTED_PREFIXES = %w[100:0:0:1::/64 3fff::/20 5f00::/16].freeze
+  RESERVED_LITERALS = %w[
+    1::1 400::1 100:0:0:2::1 2000::1 3ffe::1 3fff:1000:: 4000::1 f000::1
+  ].freeze
+
+  def with_answers(answers)
+    original = Resolv.method(:getaddresses)
+    Resolv.define_singleton_method(:getaddresses) { |_host| answers }
+    yield
+  ensure
+    Resolv.define_singleton_method(:getaddresses, original)
+  end
+
+  def with_resolver_failure(error)
+    original = Resolv.method(:getaddresses)
+    Resolv.define_singleton_method(:getaddresses) { |_host| raise error }
+    yield
+  ensure
+    Resolv.define_singleton_method(:getaddresses, original)
+  end
+
+  def all_api_results(address, policy: :default)
+    url = "https://target.example/path"
+    with_answers([ address ]) do
+      violation = begin
+        Surfguard.enforce_public_ip(url, policy: policy)
+        nil
+      rescue StandardError => error
+        error
+      end
+      {
+        plural: Surfguard.resolve_public_ips("target.example", policy: policy),
+        predicate: Surfguard.resolvable_public_ip?(url, policy: policy),
+        enforce: violation,
+        single: Surfguard.resolve_public_ip(url, policy: policy),
+        classifier: Surfguard.blocked_address?(address, policy: policy)
+      }
+    end
+  end
+
+  def test_reported_prefix_endpoints_are_blocked_through_every_api_as_literals_and_dns
+    REPORTED_PREFIXES.each do |cidr|
+      range = IPAddr.new(cidr).to_range
+      [ range.begin, range.end ].each do |address|
+        assert Surfguard.blocked_address?(address), address.to_s
+        assert_empty Surfguard.resolve_public_ips(address), address.to_s
+        assert_nil Surfguard.resolve_public_ip("https://[#{address}]/"), address.to_s
+        refute Surfguard.resolvable_public_ip?("https://[#{address}]/"), address.to_s
+        error = assert_raises(Surfguard::Violation) { Surfguard.enforce_public_ip("https://[#{address}]/") }
+        assert_equal Surfguard::BLOCKED_MESSAGE, error.message
+
+        results = all_api_results(address.to_s)
+        assert_empty results[:plural]
+        refute results[:predicate]
+        assert_instance_of Surfguard::Violation, results[:enforce]
+        assert_nil results[:single]
+        assert results[:classifier]
+      end
+    end
+  end
+
+  def test_unallocated_ipv6_examples_are_refused
+    RESERVED_LITERALS.each do |address|
+      assert Surfguard.blocked_address?(address), address
+    end
+  end
+
+  def test_allocated_ipv6_boundaries_are_admitted_unless_explicitly_denied
+    %w[2003::/18 2400::/12 2410::/12 2600::/12 2630::/12 2c00::/12].each do |cidr|
+      range = IPAddr.new(cidr).to_range
+      refute Surfguard.blocked_address?(range.begin), cidr
+      refute Surfguard.blocked_address?(range.end), cidr
+      before = IPAddr.new(range.begin.to_i - 1, Socket::AF_INET6)
+      after = IPAddr.new(range.end.to_i + 1, Socket::AF_INET6)
+      [ [ "before", before ], [ "after", after ] ].each do |label, address|
+        allocated = Surfguard::IANA_ALLOCATED_IPV6_UNICAST.any? { |entry| entry.include?(address) }
+        explicit_deny = Surfguard::DISALLOWED_IPV6.any? { |entry| entry.include?(address) } ||
+          Surfguard::IETF_PROTOCOL_ASSIGNMENTS.include?(address)
+        assert_equal !allocated || explicit_deny, Surfguard.blocked_address?(address), "#{label} #{cidr}"
+      end
+    end
+  end
+
+  def test_every_allocated_ipv6_prefix_has_before_first_last_after_regressions
+    Surfguard::IANA_ALLOCATED_IPV6_UNICAST.each do |network|
+      range = network.to_range
+      points = [ range.begin.to_i - 1, range.begin.to_i, range.end.to_i, range.end.to_i + 1 ]
+      points.each do |integer|
+        address = IPAddr.new(integer, Socket::AF_INET6)
+        assert_equal ipv6_default_oracle(address), Surfguard.blocked_address?(address),
+          "#{network}/#{network.prefix} at #{address}"
+      end
+    end
+  end
+
+  def test_default_transition_and_global_service_exceptions
+    %w[64:ff9b::5db8:d822 ::ffff:0:5db8:d822 2001:3::1 2001:4:112::1 192.31.196.1 192.52.193.1 192.175.48.1 2620:4f:8000::1].each do |address|
+      refute Surfguard.blocked_address?(address), address
+    end
+  end
+
+  def test_strict_policy_blocks_every_registered_special_use_prefix
+    [ Surfguard::IANA_SPECIAL_USE_IPV4, Surfguard::IANA_SPECIAL_USE_IPV6 ].flatten.each do |network|
+      assert Surfguard.blocked_address?(network.to_range.begin, policy: :iana_special_use), network.to_s
+      assert Surfguard.blocked_address?(network.to_range.end, policy: :iana_special_use), network.to_s
+    end
+  end
+
+  def test_strict_policy_blocks_every_registered_endpoint_through_all_apis
+    networks = [ Surfguard::IANA_SPECIAL_USE_IPV4, Surfguard::IANA_SPECIAL_USE_IPV6 ].flatten
+    endpoints = networks.flat_map { |network| [ network.to_range.begin, network.to_range.end ] }
+      .uniq { |address| [ address.family, address.to_i ] }
+
+    endpoints.each do |address|
+      results = all_api_results(address.to_s, policy: :iana_special_use)
+      assert_empty results[:plural], address.to_s
+      refute results[:predicate], address.to_s
+      assert_instance_of Surfguard::Violation, results[:enforce], address.to_s
+      assert_equal Surfguard::BLOCKED_MESSAGE, results[:enforce].message, address.to_s
+      assert_nil results[:single], address.to_s
+      assert results[:classifier], address.to_s
+    end
+  end
+
+  def test_strict_and_default_service_boundaries_are_exact
+    %w[192.31.196.0/24 192.52.193.0/24 192.175.48.0/24].each do |cidr|
+      range = IPAddr.new(cidr).to_range
+      [ range.begin, range.end ].each do |address|
+        refute Surfguard.blocked_address?(address), address.to_s
+        assert Surfguard.blocked_address?(address, policy: :iana_special_use), address.to_s
+      end
+
+      [ range.begin.to_i - 1, range.end.to_i + 1 ].each do |integer|
+        address = IPAddr.new(integer, Socket::AF_INET)
+        refute Surfguard.blocked_address?(address), address.to_s
+        refute Surfguard.blocked_address?(address, policy: :iana_special_use), address.to_s
+      end
+    end
+  end
+
+  def test_every_explicit_default_deny_has_before_first_last_after_regressions
+    [ Surfguard::DISALLOWED_IPV4, Surfguard::DISALLOWED_IPV6 ].each do |ranges|
+      ranges.each do |network|
+        range = network.to_range
+        family = network.ipv4? ? Socket::AF_INET : Socket::AF_INET6
+        maximum = network.ipv4? ? (1 << 32) - 1 : (1 << 128) - 1
+        [ range.begin.to_i - 1, range.begin.to_i, range.end.to_i, range.end.to_i + 1 ].each do |integer|
+          next unless (0..maximum).cover?(integer)
+
+          address = IPAddr.new(integer, family)
+          oracle = address.ipv4? ? ipv4_default_oracle(address) : ipv6_default_oracle(address)
+          assert_equal oracle, Surfguard.blocked_address?(address), "#{network}/#{network.prefix} at #{address}"
+        end
+      end
+    end
+  end
+
+  def test_strict_policy_blocks_nat64_and_service_exceptions_but_not_ordinary_public_addresses
+    %w[64:ff9b::5db8:d822 2001:3::1 2001:4:112::1 192.31.196.1 192.52.193.1 192.175.48.1 2620:4f:8000::1].each do |address|
+      assert Surfguard.blocked_address?(address, policy: :iana_special_use), address
+    end
+    refute Surfguard.blocked_address?("93.184.216.34", policy: :iana_special_use)
+    refute Surfguard.blocked_address?("2606:2800:220:1:248:1893:25c8:1946", policy: :iana_special_use)
+  end
+
+  def test_unknown_policy_raises_argument_error_from_every_api
+    calls = [
+      -> { Surfguard.resolve_public_ips("example.com", policy: :unknown) },
+      -> { Surfguard.resolvable_public_ip?("https://example.com", policy: :unknown) },
+      -> { Surfguard.enforce_public_ip("https://example.com", policy: :unknown) },
+      -> { Surfguard.resolve_public_ip("https://example.com", policy: :unknown) },
+      -> { Surfguard.blocked_address?("93.184.216.34", policy: :unknown) }
+    ]
+    calls.each do |call|
+      error = assert_raises(ArgumentError, &call)
+      assert_equal "unknown policy", error.message
+    end
+  end
+
+  def test_malformed_direct_input_contract_and_fixed_messages
+    malformed = Object.new
+    assert_empty Surfguard.resolve_public_ips(malformed)
+    refute Surfguard.resolvable_public_ip?(malformed)
+    error = assert_raises(Surfguard::Violation) { Surfguard.enforce_public_ip(malformed) }
+    assert_equal Surfguard::MALFORMED_MESSAGE, error.message
+    assert_nil Surfguard.resolve_public_ip(malformed)
+    assert Surfguard.blocked_address?(malformed)
+  end
+
+  def test_wrong_types_are_not_coerced_and_ipaddr_overrides_are_bypassed
+    unstable = Object.new
+    unstable.define_singleton_method(:to_s) { raise "must not coerce" }
+    assert_empty Surfguard.resolve_public_ips(unstable)
+    assert Surfguard.blocked_address?(unstable)
+
+    address = IPAddr.new("93.184.216.34")
+    address.define_singleton_method(:to_i) { raise "must use owned IPAddr implementation" }
+    refute Surfguard.blocked_address?(address)
+    assert_equal [ "93.184.216.34" ], Surfguard.resolve_public_ips(address)
+  end
+
+  def test_input_type_checks_do_not_dispatch_to_input_overrides
+    wrong_type = Object.new
+    wrong_type.define_singleton_method(:is_a?) { |_type| raise "must not dispatch is_a?" }
+    assert_empty Surfguard.resolve_public_ips(wrong_type)
+    refute Surfguard.resolvable_public_ip?(wrong_type)
+    malformed = assert_raises(Surfguard::Violation) { Surfguard.enforce_public_ip(wrong_type) }
+    assert_equal Surfguard::MALFORMED_MESSAGE, malformed.message
+    assert_nil Surfguard.resolve_public_ip(wrong_type)
+    assert Surfguard.blocked_address?(wrong_type)
+
+    string_class = Class.new(String) do
+      def is_a?(_type)
+        raise "must copy without dispatching is_a?"
+      end
+    end
+    host = string_class.new("93.184.216.34")
+    url = string_class.new("https://93.184.216.34/")
+    assert_equal [ "93.184.216.34" ], Surfguard.resolve_public_ips(host)
+    assert Surfguard.resolvable_public_ip?(url)
+    assert_nil Surfguard.enforce_public_ip(url)
+    assert_equal "93.184.216.34", Surfguard.resolve_public_ip(url)
+    refute Surfguard.blocked_address?(host)
+
+    ipaddr_class = Class.new(IPAddr) do
+      def is_a?(_type)
+        raise "must copy IPAddr without dispatching is_a?"
+      end
+    end
+    address = ipaddr_class.new("93.184.216.34")
+    refute Surfguard.blocked_address?(address)
+    assert_equal [ "93.184.216.34" ], Surfguard.resolve_public_ips(address)
+  end
+
+  def test_invalid_encoding_nul_non_ascii_and_long_hosts_are_malformed
+    bad_encoding = "example.com".dup.force_encoding(Encoding::UTF_16LE)
+    [ bad_encoding, "example\0.com", "caf\u00e9.example", "a" * 256 ].each do |host|
+      assert_empty Surfguard.resolve_public_ips(host)
+    end
+  end
+
+  def test_zones_ipvfuture_empty_hosts_and_platform_embedding_corpus_fail_closed
+    malformed_urls = [ "https://", "https://[fe80::1%25lo]/", "https://[v1.fe]/" ]
+    malformed_urls.each do |url|
+      refute Surfguard.resolvable_public_ip?(url), url
+      assert_nil Surfguard.resolve_public_ip(url), url
+    end
+    %w[
+      100.100.100.200
+      64:ff9b::6464:64c8
+      ::ffff:0:6464:64c8
+      64:ff9b::a83f:8110
+      ::ffff:0:a83f:8110
+    ].each do |address|
+      assert Surfguard.blocked_address?(address), address
+    end
+  end
+
+  def test_ipv6_zones_are_malformed_through_direct_and_url_apis
+    zoned_text = "2606:4700:4700::1111%lo"
+    zoned_ip = IPAddr.new(zoned_text)
+    url = "https://[#{zoned_text}]/"
+
+    [ zoned_text, zoned_ip ].each do |input|
+      assert_empty Surfguard.resolve_public_ips(input)
+      assert Surfguard.blocked_address?(input)
+      assert Surfguard.blocked_address?(input, policy: :iana_special_use)
+    end
+    refute Surfguard.resolvable_public_ip?(url)
+    assert_nil Surfguard.resolve_public_ip(url)
+    error = assert_raises(Surfguard::Violation) { Surfguard.enforce_public_ip(url) }
+    assert_equal Surfguard::MALFORMED_MESSAGE, error.message
+  end
+
+  def test_zoned_resolver_answer_invalidates_the_entire_lookup
+    zoned_answers = [
+      [ "93.184.216.34", "2606:4700:4700::1111%lo" ],
+      [ "93.184.216.34", IPAddr.new("2606:4700:4700::1111%lo") ]
+    ]
+
+    zoned_answers.each do |answers|
+      with_answers(answers) { assert_unresolvable_api_contract }
+    end
+  end
+
+  def test_malformed_resolver_answer_invalidates_the_entire_lookup
+    [ nil, [ "93.184.216.34", "bad" ], [ "93.184.216.34", "10.0.0.1/8" ], [ Object.new ] ].each do |answers|
+      with_answers(answers) do
+        error = assert_raises(Surfguard::Unresolvable) { Surfguard.resolve_public_ips("example.com") }
+        assert_equal Surfguard::UNRESOLVABLE_MESSAGE, error.message
+        refute Surfguard.resolvable_public_ip?("https://example.com")
+        assert_raises(Surfguard::Unresolvable) { Surfguard.enforce_public_ip("https://example.com") }
+        assert_raises(Surfguard::Unresolvable) { Surfguard.resolve_public_ip("https://example.com") }
+      end
+    end
+  end
+
+  def test_resolver_result_validation_uses_owned_builtin_values
+    string_class = Class.new(String) do
+      def is_a?(_type)
+        raise "must not dispatch resolver-answer is_a?"
+      end
+    end
+    array_class = Class.new(Array) do
+      def each(*)
+        raise "must use the owned Array implementation"
+      end
+    end
+    answers = array_class.new([ string_class.new("93.184.216.34") ])
+    with_answers(answers) do
+      assert_equal [ "93.184.216.34" ], Surfguard.resolve_public_ips("example.com")
+      assert Surfguard.resolvable_public_ip?("https://example.com")
+      assert_nil Surfguard.enforce_public_ip("https://example.com")
+      assert_equal "93.184.216.34", Surfguard.resolve_public_ip("https://example.com")
+    end
+
+    malformed = Object.new
+    malformed.define_singleton_method(:is_a?) { |_type| raise "must not inspect malformed answer" }
+    with_answers([ malformed ]) { assert_unresolvable_api_contract }
+  end
+
+  def test_numeric_parser_result_validation_bypasses_array_overrides
+    answer_class = Class.new(Array) do
+      def is_a?(_type)
+        raise "must not dispatch numeric-answer is_a?"
+      end
+
+      def [](*)
+        raise "must use the owned Array implementation"
+      end
+    end
+    result_class = Class.new(Array) do
+      def map(*)
+        raise "must use the owned Array implementation"
+      end
+    end
+    original = Socket.method(:getaddrinfo)
+    Socket.define_singleton_method(:getaddrinfo) do |*|
+      result_class.new([ answer_class.new([ "AF_INET", 0, nil, "93.184.216.34" ]) ])
+    end
+
+    assert_equal [ "93.184.216.34" ], Surfguard.resolve_public_ips("93.184.216.34")
+  ensure
+    Socket.define_singleton_method(:getaddrinfo, original) if original
+  end
+
+  def test_mixed_answers_follow_the_required_contract
+    with_answers(%w[2606:2800:220:1:248:1893:25c8:1946 10.0.0.1 93.184.216.34]) do
+      assert_equal %w[93.184.216.34 2606:2800:220:1:248:1893:25c8:1946],
+        Surfguard.resolve_public_ips("example.com")
+      refute Surfguard.resolvable_public_ip?("https://example.com")
+      error = assert_raises(Surfguard::Violation) { Surfguard.enforce_public_ip("https://example.com") }
+      assert_equal Surfguard::BLOCKED_MESSAGE, error.message
+      assert_nil Surfguard.resolve_public_ip("https://example.com")
+    end
+  end
+
+  def test_single_preserves_resolver_order_and_plural_is_ipv4_first
+    answers = %w[2606:2800:220:1:248:1893:25c8:1946 93.184.216.34]
+    with_answers(answers) do
+      assert_equal answers.first, Surfguard.resolve_public_ip("https://example.com")
+      assert_equal answers.reverse, Surfguard.resolve_public_ips("example.com")
+    end
+  end
+
+  def test_answers_are_deduplicated_in_order_and_cardinality_is_bounded
+    with_answers([ "93.184.216.34" ] * 256) do
+      assert_equal [ "93.184.216.34" ], Surfguard.resolve_public_ips("example.com")
+      assert Surfguard.resolvable_public_ip?("https://example.com")
+      assert_nil Surfguard.enforce_public_ip("https://example.com")
+      assert_equal "93.184.216.34", Surfguard.resolve_public_ip("https://example.com")
+    end
+    with_answers([ "93.184.216.34" ] * 257) { assert_unresolvable_api_contract }
+  end
+
+  def test_unique_answer_cardinality_accepts_256_and_refuses_257
+    addresses = 257.times.map do |index|
+      IPAddr.new(IPAddr.new("11.0.0.0").to_i + index, Socket::AF_INET).to_s
+    end
+
+    with_answers(addresses.first(256)) do
+      assert_equal addresses.first(256), Surfguard.resolve_public_ips("example.com")
+      assert Surfguard.resolvable_public_ip?("https://example.com")
+      assert_nil Surfguard.enforce_public_ip("https://example.com")
+      assert_equal addresses.first, Surfguard.resolve_public_ip("https://example.com")
+    end
+    with_answers(addresses) { assert_unresolvable_api_contract }
+  end
+
+  def test_operational_resolver_failures_use_the_fixed_failure_contract
+    errors = [
+      SocketError.new("attacker-controlled resolver detail"),
+      Errno::ECONNREFUSED.new,
+      IOError.new("attacker-controlled resolver detail"),
+      EOFError.new("attacker-controlled resolver detail")
+    ]
+
+    errors.each do |error|
+      with_resolver_failure(error) do
+        assert_unresolvable_api_contract(forbidden_detail: "attacker-controlled resolver detail")
+      end
+    end
+  end
+
+  def test_expected_public_errors_never_chain_attacker_or_ambient_exceptions
+    malformed_detail = "attacker-controlled-uri-detail"
+    malformed = assert_raises(Surfguard::Violation) do
+      Surfguard.enforce_public_ip("https://example.invalid/ #{malformed_detail}")
+    end
+    assert_sanitized_exception(malformed, Surfguard::MALFORMED_MESSAGE, malformed_detail)
+
+    ambient_detail = "attacker-controlled-ambient-detail"
+    blocked = capture_during_rescue(ambient_detail) do
+      Surfguard.enforce_public_ip("https://127.0.0.1/")
+    end
+    assert_instance_of Surfguard::Violation, blocked
+    assert_sanitized_exception(blocked, Surfguard::BLOCKED_MESSAGE, ambient_detail)
+
+    public_calls = [
+      -> { Surfguard.resolve_public_ips("target.example", policy: :unknown) },
+      -> { Surfguard.resolvable_public_ip?("https://target.example", policy: :unknown) },
+      -> { Surfguard.enforce_public_ip("https://target.example", policy: :unknown) },
+      -> { Surfguard.resolve_public_ip("https://target.example", policy: :unknown) },
+      -> { Surfguard.blocked_address?("93.184.216.34", policy: :unknown) }
+    ]
+    public_calls.each do |call|
+      error = capture_during_rescue(ambient_detail, &call)
+      assert_instance_of ArgumentError, error
+      assert_sanitized_exception(error, "unknown policy", ambient_detail)
+    end
+  end
+
+  def test_malformed_ipaddr_instances_fail_closed_as_inputs_and_answers
+    malformed = [ IPAddr.allocate ]
+
+    bad_family = IPAddr.new("93.184.216.34")
+    bad_family.instance_variable_set(:@family, -1)
+    malformed << bad_family
+
+    bad_address = IPAddr.new("93.184.216.34")
+    bad_address.instance_variable_set(:@addr, Object.new)
+    malformed << bad_address
+
+    bad_mask = IPAddr.new("93.184.216.34")
+    bad_mask.instance_variable_set(:@mask_addr, Object.new)
+    malformed << bad_mask
+
+    bad_zone = IPAddr.new("93.184.216.34")
+    bad_zone.instance_variable_set(:@zone_id, "%lo")
+    malformed << bad_zone
+
+    hostile_family = Object.new
+    hostile_family.define_singleton_method(:==) { |_other| raise "must not compare hostile family" }
+    bad_family = IPAddr.new("93.184.216.34")
+    bad_family.instance_variable_set(:@family, hostile_family)
+    malformed << bad_family
+
+    spoofed_family = Object.new
+    spoofed_family.define_singleton_method(:==) { |other| other == Socket::AF_INET }
+    bad_family = IPAddr.new("93.184.216.34")
+    bad_family.instance_variable_set(:@family, spoofed_family)
+    malformed << bad_family
+
+    hostile_address = Object.new
+    hostile_address.define_singleton_method(:instance_of?) { |_type| raise "must not inspect hostile address" }
+    bad_address = IPAddr.new("93.184.216.34")
+    bad_address.instance_variable_set(:@addr, hostile_address)
+    malformed << bad_address
+
+    hostile_mask = Object.new
+    hostile_mask.define_singleton_method(:instance_of?) { |_type| raise "must not inspect hostile mask" }
+    bad_mask = IPAddr.new("93.184.216.34")
+    bad_mask.instance_variable_set(:@mask_addr, hostile_mask)
+    malformed << bad_mask
+
+    spoofed_zone = Object.new
+    spoofed_zone.define_singleton_method(:nil?) { true }
+    bad_zone = IPAddr.new("93.184.216.34")
+    bad_zone.instance_variable_set(:@zone_id, spoofed_zone)
+    malformed << bad_zone
+
+    hostile_zone = Object.new
+    hostile_zone.define_singleton_method(:nil?) { raise "must not inspect hostile zone" }
+    bad_zone = IPAddr.new("93.184.216.34")
+    bad_zone.instance_variable_set(:@zone_id, hostile_zone)
+    malformed << bad_zone
+
+    malformed.each do |address|
+      assert Surfguard.blocked_address?(address)
+      assert_empty Surfguard.resolve_public_ips(address)
+      with_answers([ address ]) { assert_unresolvable_api_contract }
+    end
+  end
+
+  def test_unexpected_resolver_failures_escape
+    original = Resolv.method(:getaddresses)
+    Resolv.define_singleton_method(:getaddresses) { |_host| raise RuntimeError, "programmer bug" }
+    assert_raises(RuntimeError) { Surfguard.resolve_public_ips("example.com") }
+    assert_raises(RuntimeError) { Surfguard.resolvable_public_ip?("https://example.com") }
+    assert_raises(RuntimeError) { Surfguard.enforce_public_ip("https://example.com") }
+    assert_raises(RuntimeError) { Surfguard.resolve_public_ip("https://example.com") }
+  ensure
+    Resolv.define_singleton_method(:getaddresses, original)
+  end
+
+  def test_returned_values_and_policy_graph_are_deeply_frozen
+    with_answers(%w[93.184.216.34]) do
+      result = Surfguard.resolve_public_ips("example.com")
+      assert_predicate result, :frozen?
+      assert_predicate result.first, :frozen?
+    end
+    assert_predicate Surfguard::POLICY_RANGES, :frozen?
+    Surfguard::POLICY_RANGES.each_value do |policy|
+      assert_predicate policy, :frozen?
+      policy.each_value do |ranges|
+        assert_predicate ranges, :frozen?
+        ranges.each { |range| assert_predicate range, :frozen? }
+        assert_raises(FrozenError) { ranges.first.prefix = 0 } unless ranges.empty?
+      end
+    end
+  end
+
+  def test_deterministic_standard_library_parser_property_corpus
+    random = Random.new(0x5_55_52_46)
+    20_000.times do |index|
+      family = index.even? ? Socket::AF_INET : Socket::AF_INET6
+      bits = family == Socket::AF_INET ? 32 : 128
+      address = IPAddr.new(random.rand(1 << bits), family)
+      expected_default = default_policy_oracle(address)
+      expected_strict = expected_default || iana_special_use_oracle(address)
+      assert_equal expected_default, Surfguard.blocked_address?(address), address.to_s
+      assert_equal expected_default, Surfguard.blocked_address?(address.to_s), address.to_s
+      assert_equal expected_strict,
+        Surfguard.blocked_address?(address, policy: :iana_special_use), address.to_s
+      assert_equal expected_strict,
+        Surfguard.blocked_address?(address.to_s, policy: :iana_special_use), address.to_s
+    end
+  end
+
+  def test_numeric_host_parser_and_classification_agree_on_deterministic_spellings
+    cases = {
+      "127.0.0.1" => true,
+      "169.254.169.254" => true,
+      "10.23.45.67" => true,
+      "168.63.129.16" => true,
+      "93.184.216.34" => false
+    }
+    dns_queries = []
+    original = Resolv.method(:getaddresses)
+    Resolv.define_singleton_method(:getaddresses) do |host|
+      dns_queries << host
+      [ "203.0.113.1" ]
+    end
+
+    assert_spellings = lambda do |canonical, blocked|
+      ip = IPAddr.new(canonical)
+      assert_equal blocked, ipv4_default_oracle(ip), canonical
+      octets = canonical.split(".").map(&:to_i)
+      spellings = [
+        canonical,
+        ip.to_i.to_s,
+        "0x#{ip.to_i.to_s(16)}",
+        octets.map { |octet| octet.zero? ? "0" : "0#{octet.to_s(8)}" }.join("."),
+        "#{octets.first}.#{ip.to_i & 0x00ff_ffff}"
+      ]
+
+      spellings.each do |spelling|
+        system_addresses = begin
+          Socket.getaddrinfo(
+            spelling, nil, Socket::AF_UNSPEC, Socket::SOCK_STREAM, 0, Socket::AI_NUMERICHOST
+          ).map { |entry| IPAddr.new(entry[3]) }
+        rescue SocketError
+          []
+        end
+        actual = Surfguard.resolve_public_ips(spelling)
+        if system_addresses.empty?
+          assert_empty actual, spelling
+        else
+          expected = system_addresses.reject { |address| ipv4_default_oracle(address) }
+            .uniq { |address| [ address.family, address.to_i ] }
+            .map(&:to_s)
+          assert_equal expected, actual, spelling
+        end
+      end
+    end
+    cases.each { |canonical, blocked| assert_spellings.call(canonical, blocked) }
+
+    random = Random.new(0x4e_55_4d_45_52_49_43)
+    1_000.times do
+      address = IPAddr.new(random.rand(1 << 32), Socket::AF_INET)
+      assert_spellings.call(address.to_s, ipv4_default_oracle(address))
+    end
+    assert_empty dns_queries
+  ensure
+    Resolv.define_singleton_method(:getaddresses, original) if original
+  end
+
+  private
+    def assert_unresolvable_api_contract(forbidden_detail: nil)
+      plural = assert_raises(Surfguard::Unresolvable) do
+        Surfguard.resolve_public_ips("target.example")
+      end
+      assert_sanitized_exception(plural, Surfguard::UNRESOLVABLE_MESSAGE, forbidden_detail)
+      refute Surfguard.resolvable_public_ip?("https://target.example")
+
+      enforce = assert_raises(Surfguard::Unresolvable) do
+        Surfguard.enforce_public_ip("https://target.example")
+      end
+      assert_sanitized_exception(enforce, Surfguard::UNRESOLVABLE_MESSAGE, forbidden_detail)
+
+      single = assert_raises(Surfguard::Unresolvable) do
+        Surfguard.resolve_public_ip("https://target.example")
+      end
+      assert_sanitized_exception(single, Surfguard::UNRESOLVABLE_MESSAGE, forbidden_detail)
+    end
+
+    def assert_sanitized_exception(error, message, forbidden_detail)
+      assert_equal message, error.message
+      assert_nil error.cause
+      refute_includes error.full_message, forbidden_detail if forbidden_detail
+    end
+
+    def capture_during_rescue(detail)
+      raise RuntimeError, detail
+    rescue RuntimeError
+      begin
+        yield
+      rescue StandardError => error
+        error
+      end
+    end
+
+    def ipv6_default_oracle(address)
+      carveout = Surfguard::GLOBALLY_REACHABLE_IETF_ASSIGNMENTS.any? { |range| range.include?(address) }
+      return false if carveout
+      return true if address.private? || address.loopback? || address.link_local?
+      return true if Surfguard::IETF_PROTOCOL_ASSIGNMENTS.include?(address)
+      return true if Surfguard::DISALLOWED_IPV6.any? { |range| range.include?(address) }
+
+      Surfguard::IANA_ALLOCATED_IPV6_UNICAST.none? { |range| range.include?(address) }
+    end
+
+    def ipv4_default_oracle(address)
+      address.private? || address.loopback? || address.link_local? ||
+        Surfguard::DISALLOWED_IPV4.any? { |range| range.include?(address) }
+    end
+
+    def default_policy_oracle(address)
+      return true if address.ipv4_mapped? || Surfguard::IPV4_COMPATIBLE.include?(address)
+      return ipv4_default_oracle(address) if address.ipv4?
+      return true if Surfguard::NAT64_LOCAL_USE.include?(address)
+
+      if Surfguard::NAT64_WELL_KNOWN.include?(address) || Surfguard::IPV4_TRANSLATABLE.include?(address)
+        embedded = IPAddr.new(address.to_i & 0xffff_ffff, Socket::AF_INET)
+        return ipv4_default_oracle(embedded)
+      end
+
+      ipv6_default_oracle(address)
+    end
+
+    def iana_special_use_oracle(address)
+      ranges = address.ipv4? ? Surfguard::IANA_SPECIAL_USE_IPV4 : Surfguard::IANA_SPECIAL_USE_IPV6
+      ranges.any? { |range| range.include?(address) }
+    end
+end

--- a/test/surfguard_hardening_test.rb
+++ b/test/surfguard_hardening_test.rb
@@ -174,6 +174,14 @@ class SurfguardHardeningTest < Minitest::Test
     refute Surfguard.blocked_address?("2606:2800:220:1:248:1893:25c8:1946", policy: :iana_special_use)
   end
 
+  def test_strict_policy_applies_to_ipv4_addresses_embedded_in_transition_prefixes
+    %w[::ffff:0:192.31.196.1 ::ffff:0:192.52.193.1 ::ffff:0:192.175.48.1].each do |address|
+      assert Surfguard.blocked_address?(address, policy: :iana_special_use), address
+      refute Surfguard.blocked_address?(address), address
+    end
+    refute Surfguard.blocked_address?("::ffff:0:5db8:d822", policy: :iana_special_use)
+  end
+
   def test_unknown_policy_raises_argument_error_from_every_api
     calls = [
       -> { Surfguard.resolve_public_ips("example.com", policy: :unknown) },

--- a/test/surfguard_test.rb
+++ b/test/surfguard_test.rb
@@ -2,7 +2,11 @@
 
 require_relative "test_helper"
 require "resolv"
-require_relative "../lib/surfguard"
+if ENV["SURFGUARD_INSTALLED_SUITE"]
+  require "surfguard"
+else
+  require_relative "../lib/surfguard"
+end
 
 class SurfguardTest < Minitest::Test
   # --- classification: the full policy matrix, checked as execution -----------
@@ -76,7 +80,8 @@ class SurfguardTest < Minitest::Test
     "single-integer loopback"     => "2130706433",
     "short loopback"              => "127.1",
     "hex loopback"                => "0x7f000001",
-    "octal dotted loopback"       => "0177.0.0.1",
+    # Leading-zero dotted forms are platform-defined by the connection parser;
+    # the cross-platform differential corpus below covers them.
     "single zero"                 => "0",
     "octal zero"                  => "00",
     "hex zero"                    => "0x0",
@@ -151,8 +156,8 @@ class SurfguardTest < Minitest::Test
   def test_expanded_documentation_prefix_boundaries
     assert Surfguard.blocked_address?("3fff::")
     assert Surfguard.blocked_address?("3fff:fff:ffff:ffff:ffff:ffff:ffff:ffff")
-    refute Surfguard.blocked_address?("3ffe:ffff:ffff:ffff:ffff:ffff:ffff:ffff")
-    refute Surfguard.blocked_address?("3fff:1000::")
+    assert Surfguard.blocked_address?("3ffe:ffff:ffff:ffff:ffff:ffff:ffff:ffff")
+    assert Surfguard.blocked_address?("3fff:1000::")
   end
 
   def test_azure_wire_server_deny_is_one_exact_address


### PR DESCRIPTION
## Stack

1 of 5. Base: `main`. Next: `security-hardening-02-package-assurance`.

## Summary

- Replace broad IPv6 assumptions with reviewed IANA ALLOCATED prefixes and add the trusted-caller `:iana_special_use` policy.
- Own and bound inputs and resolver answers, deep-freeze policy data, and enforce fixed failure contracts across all five APIs.
- Add provenance-bearing IANA snapshots, deterministic drift checks, vulnerable-resolv enforcement, expanded runtime/platform CI, and a tested pinned Net::HTTP recipe.

## Verification

- Full runtime/IANA suite and platform-numeric differential corpus, 0 failures
- RuboCop, actionlint, pedantic Zizmor, and IANA generator check

This is an intermediate hardening branch. Do not tag, publish, or dispatch release/recovery until the complete stack is merged.
