### PR TITLE
Prove gem identity and harden release helpers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,59 @@ jobs:
           fail-on-scopes: development, runtime, unknown
           show-openssf-scorecard: false
 
+  package-build:
+    name: Build package candidate
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
+        with:
+          ruby-version: "3.4.5"
+          bundler-cache: false
+      - name: Determine package version
+        id: version
+        run: echo "version=$(ruby -Ilib -rsurfguard/version -e 'puts Surfguard::VERSION')" >> "$GITHUB_OUTPUT"
+      - name: Build candidate
+        run: |
+          bundle install --jobs 4 --retry 3
+          SOURCE_DATE_EPOCH="$(git log -1 --format=%ct)" gem build --strict surfguard.gemspec
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ci-rubygem
+          path: surfguard-${{ steps.version.outputs.version }}.gem
+          if-no-files-found: error
+
+  package:
+    name: Fresh-runner isolated package suite
+    needs: package-build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
+        with:
+          ruby-version: "3.4.5"
+          bundler-cache: false
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ci-rubygem
+      - name: Verify exact package against this commit and installed bytes
+        env:
+          VERSION: ${{ needs.package-build.outputs.version }}
+        run: ruby script/release/verify_package.rb "surfguard-${VERSION}.gem" surfguard "$VERSION" "$GITHUB_SHA"
+
   platforms:
     name: "Core suite (${{ matrix.os }})"
     strategy:
@@ -215,7 +268,7 @@ jobs:
     name: CI
     if: always()
     timeout-minutes: 15
-    needs: [ test, lint, lint-actions, dependency-review, platforms, musl, iana-drift, codeql ]
+    needs: [ test, lint, lint-actions, dependency-review, package-build, package, platforms, musl, iana-drift, codeql ]
     runs-on: ubuntu-latest
     permissions: {}
     steps:
@@ -229,7 +282,7 @@ jobs:
         if: needs.dependency-review.result == 'skipped' && github.event_name == 'pull_request'
         run: exit 1
       - name: Reject every other skipped required job
-        if: needs.test.result == 'skipped' || needs.lint.result == 'skipped' || needs.lint-actions.result == 'skipped' || needs.platforms.result == 'skipped' || needs.musl.result == 'skipped' || needs.codeql.result == 'skipped'
+        if: needs.test.result == 'skipped' || needs.lint.result == 'skipped' || needs.lint-actions.result == 'skipped' || needs.package-build.result == 'skipped' || needs.package.result == 'skipped' || needs.platforms.result == 'skipped' || needs.musl.result == 'skipped' || needs.codeql.result == 'skipped'
         run: exit 1
       - name: All green
         run: echo "All required jobs succeeded (or were legitimately skipped)."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Verify the packaged gem (rehearsals included)
         env:
           VERSION: ${{ steps.version.outputs.version }}
-        run: ruby script/release/verify_package.rb "surfguard-${VERSION}.gem" surfguard "$VERSION"
+        run: ruby script/release/verify_package.rb "surfguard-${VERSION}.gem" surfguard "$VERSION" "$(git rev-parse HEAD)"
       - name: Record the artifact digest
         id: digest
         env:

--- a/Rakefile
+++ b/Rakefile
@@ -53,6 +53,7 @@ end
 def clean_bundler_environment
   ENV.each_key.grep(/\ABUNDLE_/).to_h { |key| [ key, nil ] }.merge(
     "BUNDLE_IGNORE_CONFIG" => "1",
+    "BUNDLER_VERSION" => nil,
     "RUBYOPT" => nil,
     "RUBYLIB" => nil,
     "RUBYGEMS_GEMDEPS" => nil

--- a/Rakefile
+++ b/Rakefile
@@ -1,78 +1,149 @@
 # frozen_string_literal: true
 
-# No top-level requires beyond rake itself: the CI matrix runs `rake test`
-# on bare Ruby with no bundle, so everything else loads lazily inside tasks.
+require "open3"
+require "fileutils"
 require "rake/testtask"
+require "tmpdir"
 
-Rake::TestTask.new(:test) do |t|
-  t.libs << "lib" << "test"
-  t.test_files = FileList["test/**/*_test.rb"]
-  t.warning = false
+Rake::TestTask.new(:test) do |task|
+  task.libs << "lib" << "test"
+  task.test_files = FileList["test/**/*_test.rb"]
+  task.warning = false
 end
 
 task default: :test
 
 desc "Run RuboCop"
 task :rubocop do
-  sh "bundle exec rubocop"
+  sh "bundle", "exec", "rubocop"
 end
 
 VERSION_FILE = "lib/surfguard/version.rb"
+LOCK_FILE = "Gemfile.lock"
+SEMVER_PATTERN = /\A(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\z/
+CANONICAL_PUSH_URL = "https://github.com/basecamp/surfguard"
+
+def exact_semver?(version)
+  SEMVER_PATTERN.match?(version)
+end
 
 def surfguard_version
-  require_relative "lib/surfguard/version"
+  load File.expand_path(VERSION_FILE)
   Surfguard::VERSION
 end
 
+def git_capture(*args)
+  stdout, stderr, status = Open3.capture3("git", *args)
+  abort "git #{args.first} failed: #{stderr.strip}" unless status.success?
+  stdout
+end
+
 def clean_tree?
-  `git status --porcelain`.empty?
+  git_capture("status", "--porcelain").empty?
+end
+
+def canonical_push_url
+  url = git_capture("remote", "get-url", "--push", "origin").strip
+  fetch_url = git_capture("remote", "get-url", "origin").strip
+  abort "tag: origin is not the canonical basecamp/surfguard push URL" unless url == CANONICAL_PUSH_URL
+  abort "tag: origin fetch/push URLs differ; validate the canonical remote" unless url == fetch_url
+  url.freeze
+end
+
+def clean_bundler_environment
+  ENV.each_key.grep(/\ABUNDLE_/).to_h { |key| [ key, nil ] }.merge(
+    "BUNDLE_IGNORE_CONFIG" => "1",
+    "RUBYOPT" => nil,
+    "RUBYLIB" => nil,
+    "RUBYGEMS_GEMDEPS" => nil
+  )
 end
 
 desc "Rewrite version.rb to VERSION (exact semver, strictly greater) and refresh Gemfile.lock; commits nothing"
-task :bump, [ :version ] do |_t, args|
+task :bump, [ :version ] do |_task, args|
   version = args[:version].to_s
-  # Exact SemVer: numeric identifiers may not have leading zeros.
-  unless version.match?(/\A(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\z/)
-    abort "bump: version must be exact semver X.Y.Z (got #{version.inspect})"
-  end
+  abort "bump: version must be exact semver X.Y.Z (got #{version.inspect})" unless exact_semver?(version)
   abort "bump: working tree must be clean" unless clean_tree?
 
   current = surfguard_version
-  unless Gem::Version.new(version) > Gem::Version.new(current)
-    abort "bump: #{version} must be strictly greater than the current #{current}"
+  abort "bump: repository version is not exact semver" unless exact_semver?(current)
+  abort "bump: #{version} must be strictly greater than the current #{current}" unless Gem::Version.new(version) > Gem::Version.new(current)
+
+  originals = [ VERSION_FILE, LOCK_FILE ].to_h { |path| [ path, File.binread(path) ] }
+  original_locked_versions = originals.fetch(LOCK_FILE).scan(/^    surfguard \(([^)]+)\)$/).flatten
+  abort "bump: lockfile did not record exactly the current surfguard #{current}" unless original_locked_versions == [ current ]
+
+  completed = false
+  begin
+    rewritten = originals.fetch(VERSION_FILE).sub(%(VERSION = "#{current}"), %(VERSION = "#{version}"))
+    abort "bump: version declaration was not exact" if rewritten == originals.fetch(VERSION_FILE)
+
+    staged_lock = nil
+    Dir.mktmpdir("surfguard-bump") do |temporary|
+      git_capture("ls-files", "-z").split("\0").each do |path|
+        destination = File.join(temporary, path)
+        FileUtils.mkdir_p(File.dirname(destination))
+        FileUtils.copy_file(path, destination)
+      end
+      File.binwrite(File.join(temporary, VERSION_FILE), rewritten)
+      Dir.chdir(temporary) do
+        sh(clean_bundler_environment, "bundle", "install", "--quiet")
+      end
+      staged_lock = File.binread(File.join(temporary, LOCK_FILE))
+    end
+    locked_versions = staged_lock.scan(/^    surfguard \(([^)]+)\)$/).flatten
+    abort "bump: lockfile did not record exactly surfguard #{version}" unless locked_versions == [ version ]
+
+    File.binwrite(VERSION_FILE, rewritten)
+    File.binwrite(LOCK_FILE, staged_lock)
+    expected = [ VERSION_FILE, LOCK_FILE ].sort
+    status = git_capture("status", "--porcelain=v1", "-z", "--untracked-files=all").split("\0").reject(&:empty?).sort
+    expected_status = expected.map { |path| " M #{path}" }
+    abort "bump: unexpected working tree state: #{status.inspect}" unless status == expected_status
+    abort "bump: resulting version is invalid" unless surfguard_version == version
+    completed = true
+  ensure
+    originals.each { |path, bytes| File.binwrite(path, bytes) } unless completed
   end
 
-  contents = File.read(VERSION_FILE)
-  rewritten = contents.sub(%(VERSION = "#{current}"), %(VERSION = "#{version}"))
-  abort "bump: could not find VERSION = \"#{current}\" in #{VERSION_FILE}" if rewritten == contents
-  File.write(VERSION_FILE, rewritten)
-
-  sh "bundle install --quiet" # refresh Gemfile.lock's surfguard version
-  puts "Bumped #{current} -> #{version}. Review, commit, and PR; `rake tag` after merge cuts the release."
+  puts "Bumped #{current} -> #{version}. Review and commit; rake tag after merge cuts the release."
 end
 
 desc "Tag and push v<current version> to trigger the release workflow"
 task :tag do
   version = surfguard_version
+  abort "tag: repository version is not exact semver" unless exact_semver?(version)
   tag = "v#{version}"
+  expected_message = "surfguard #{tag}"
 
   abort "tag: working tree must be clean" unless clean_tree?
-
-  branch = `git rev-parse --abbrev-ref HEAD`.strip
+  branch = git_capture("rev-parse", "--abbrev-ref", "HEAD").strip
   abort "tag: must be on main (currently on #{branch})" unless branch == "main"
 
-  sh "git fetch origin main --quiet"
-  head = `git rev-parse HEAD`.strip
-  origin = `git rev-parse origin/main`.strip
-  abort "tag: HEAD (#{head[0, 12]}) != origin/main (#{origin[0, 12]}); reconcile first" unless head == origin
+  push_url = canonical_push_url
+  sh "git", "fetch", push_url, "main", "--quiet"
+  head = git_capture("rev-parse", "HEAD").strip
+  fetched_main = git_capture("rev-parse", "FETCH_HEAD").strip
+  abort "tag: HEAD (#{head[0, 12]}) != fetched main (#{fetched_main[0, 12]}); reconcile first" unless head == fetched_main
 
-  abort "tag: #{tag} already exists locally" unless `git tag --list #{tag}`.strip.empty?
-  abort "tag: #{tag} already exists on origin" unless `git ls-remote --tags origin refs/tags/#{tag}`.strip.empty?
+  remote_tag = git_capture("ls-remote", "--tags", push_url, "refs/tags/#{tag}").strip
+  abort "tag: #{tag} already exists on origin" unless remote_tag.empty?
 
-  # Push main first so the release workflow's ancestry guard (tag commit must
-  # be on origin/main) can never race the tag.
-  sh "git push origin main"
-  sh "git tag --annotate #{tag} --message 'surfguard #{tag}'"
-  sh "git push origin #{tag}"
-  puts "Pushed #{tag}. The release workflow takes it from here — approve the release-rubygems environment when prompted."
+  local_tag = git_capture("tag", "--list", tag).strip
+  if local_tag.empty?
+    sh "git", "tag", "--annotate", "--no-sign", tag, "--message", expected_message
+  end
+
+  type = git_capture("cat-file", "-t", tag).strip
+  message = if type == "tag"
+    git_capture("cat-file", "tag", tag).split("\n\n", 2)[1]
+  end
+  peeled = git_capture("rev-parse", "#{tag}^{commit}").strip
+  unless type == "tag" && message == "#{expected_message}\n" && peeled == head
+    abort "tag: existing local #{tag} is not the exact retryable annotated tag"
+  end
+
+  sh "git", "push", push_url, "HEAD:refs/heads/main"
+  sh "git", "push", push_url, "refs/tags/#{tag}:refs/tags/#{tag}"
+  puts "Pushed #{tag}. The release workflow takes it from here; approve the release environment when prompted."
 end

--- a/script/release/package_verification.rb
+++ b/script/release/package_verification.rb
@@ -282,6 +282,13 @@ module Surfguard
           raise "dependencies #{spec.dependencies.map(&:to_s).inspect}" unless spec.dependencies.empty?
           raise "extensions #{spec.extensions.inspect}" unless spec.extensions.empty?
           raise "executables #{spec.executables.inspect}" unless spec.executables.empty?
+          raise "autorequire #{spec.autorequire.inspect}" unless spec.autorequire.nil?
+          raise "post-install message present" unless spec.post_install_message.nil?
+          raise "signing key present" unless spec.signing_key.nil?
+          raise "external requirements #{spec.requirements.inspect}" unless spec.requirements.empty?
+          unless spec.required_rubygems_version.to_s == ">= 0"
+            raise "required RubyGems #{spec.required_rubygems_version}"
+          end
 
           return unless @name == "surfguard"
 

--- a/script/release/package_verification.rb
+++ b/script/release/package_verification.rb
@@ -1,42 +1,48 @@
 # frozen_string_literal: true
 
+require "digest"
+require "open3"
 require "rubygems/package"
+require "stringio"
 require "tmpdir"
+require "zlib"
 
 module Surfguard
   module Release
-    # Verifies a freshly built .gem end to end: archive integrity, spec
-    # identity, exact contents, zero runtime dependencies, and a real
-    # install + require into an isolated GEM_HOME. Run on every build,
-    # rehearsals included. Fails closed on the first problem.
     class PackageVerification
       class Failure < StandardError; end
 
-      REQUIRED_FILES = %w[ lib/surfguard.rb lib/surfguard/version.rb README.md LICENSE SECURITY.md ].freeze
-      ALLOWED_PATTERNS = [ %r{\Alib/.+\.rb\z}, /\AREADME\.md\z/, /\ALICENSE\z/, /\ASECURITY\.md\z/ ].freeze
-
-      # Keep child processes honest: no bundler, ruby options, or load-path
-      # additions leaking in from CI — RUBYLIB especially, which could let
-      # `require "surfguard"` resolve from the checkout instead of the
-      # installed gem and wave a broken package through.
+      # RubyGems canonicalizes spec.files lexicographically when serializing.
+      REQUIRED_FILES = %w[LICENSE README.md SECURITY.md lib/surfguard.rb lib/surfguard/version.rb].freeze
+      OUTER_MEMBERS = %w[metadata.gz data.tar.gz checksums.yaml.gz].freeze
+      REGULAR_TYPEFLAGS = [ "0", "\0", "" ].freeze
+      TAR_BLOCK_SIZE = 512
+      MAX_GEM_BYTES = 16 << 20
+      MAX_ARCHIVE_MEMBERS = 64
+      MAX_METADATA_BYTES = 1 << 20
+      MAX_CHECKSUM_BYTES = 1 << 20
+      MAX_DATA_TAR_BYTES = 16 << 20
+      CORE_TEST_FILES = %w[test/surfguard_hardening_test.rb test/surfguard_test.rb].freeze
+      SUMMARY = "One SSRF address policy: resolve a host and classify special-use IPv4/IPv6 ranges"
+      DESCRIPTION = "Surfguard resolves a hostname to the public IP addresses it points at and refuses anything that would reach an internal network: private, loopback, link-local and carrier-grade NAT space, plus the IPv6 transition ranges a naive guard misses (IPv4-mapped, SIIT, NAT64, 6to4, Teredo). It resolves and classifies only; the caller owns the fetch and pins the connection to a returned address so DNS rebinding cannot swap in a blocked one. Standard library only, no runtime dependencies."
       CLEAN_ENV = {
         "RUBYOPT" => nil, "RUBYLIB" => nil, "RUBYGEMS_GEMDEPS" => nil,
-        "BUNDLE_GEMFILE" => nil, "BUNDLE_PATH" => nil
+        "BUNDLE_GEMFILE" => nil, "BUNDLE_LOCKFILE" => nil, "BUNDLE_PATH" => nil,
+        "BUNDLE_APP_CONFIG" => nil, "BUNDLE_BIN_PATH" => nil, "BUNDLER_SETUP" => nil,
+        "BUNDLER_VERSION" => nil
       }.freeze
 
-      # Live wiring: subprocesses run for real. Tests inject a scripted runner.
-      # simplecov:disable
-      def self.live(gem_file, name:, version:, out: $stdout)
-        new(gem_file, name: name, version: version, out: out,
-            runner: ->(env, *command) { Kernel.system(env, *command) })
+      def self.live(gem_file, name:, version:, source_commit:, out: $stdout)
+        new(gem_file, name: name, version: version, source_commit: source_commit, out: out,
+          suite_root: ENV.fetch("SURFGUARD_SUITE_ROOT", "."),
+          runner: ->(env, *command) { Kernel.system(env, *command) })
       end
-      # simplecov:enable
 
-      # CLI entry point; returns a process exit status.
       def self.run(argv, out: $stdout, err: $stderr, verification_for: method(:live))
-        gem_file, name, version = argv
-        if argv.size != 3
-          err.puts "usage: verify_package.rb GEM_FILE NAME VERSION"
+        gem_file, name, version, source_commit = argv
+        object_id = /\A(?:[0-9a-f]{40}|[0-9a-f]{64})\z/
+        unless argv.size == 4 && String === source_commit && source_commit.match?(object_id)
+          err.puts "usage: verify_package.rb GEM_FILE NAME VERSION IMMUTABLE_COMMIT_SHA"
           return 2
         end
         unless File.file?(gem_file)
@@ -44,82 +50,362 @@ module Surfguard
           return 2
         end
 
-        verification_for.call(gem_file, name: name, version: version, out: out).verify!
+        verification_for.call(gem_file, name: name, version: version,
+          source_commit: source_commit, out: out).verify!
         0
-      rescue Failure => e
-        err.puts "verify_package: #{e.message}"
+      rescue Failure => error
+        err.puts "verify_package: #{error.message}"
         1
       end
 
-      def initialize(gem_file, name:, version:, runner:, out: $stdout)
+      def self.run_if_main(program_name, file_name, argv, runner: method(:run))
+        return unless program_name == file_name
+
+        exit runner.call(argv)
+      end
+
+      def initialize(gem_file, name:, version:, runner:, source_commit: nil, source_reader: nil,
+        suite_root: ".", out: $stdout, capture: Open3.method(:capture3))
         @gem_file = gem_file
         @name = name
         @version = version
         @runner = runner
+        @source_commit = source_commit
+        @source_reader = source_reader
+        @suite_root = suite_root
         @out = out
+        @capture = capture
       end
 
       def verify!
-        package = check("archive integrity (Gem::Package#verify)") do
-          Gem::Package.new(@gem_file).tap(&:verify)
-        end
-        spec = package.spec
+        with_private_snapshot do |snapshot|
+          entries = check("raw nested archive structure") { inspect_raw_archive(snapshot.fetch(:bytes)) }
+          package = check("archive integrity") { Gem::Package.new(snapshot.fetch(:path)).tap(&:verify) }
+          spec = package.spec
 
-        check("spec name is #{@name}") do
-          raise "got #{spec.name.inspect}" unless spec.name == @name
-        end
-
-        check("spec version is #{@version}") do
-          raise "got #{spec.version}" unless spec.version.to_s == @version
-        end
-
-        check("zero runtime dependencies") do
-          deps = spec.runtime_dependencies
-          raise "got: #{deps.map(&:name).sort.join(", ")}" unless deps.empty?
-        end
-
-        contents = package.contents
-        @out.puts "verify: archive contents:"
-        contents.sort.each { |path| @out.puts "  #{path}" }
-
-        check("required files all present") do
-          missing = REQUIRED_FILES - contents
-          raise "missing: #{missing.join(", ")}" unless missing.empty?
-        end
-
-        check("no unexpected files") do
-          unexpected = contents.reject { |path| ALLOWED_PATTERNS.any? { |pattern| pattern.match?(path) } }
-          raise "unexpected: #{unexpected.sort.join(", ")}" unless unexpected.empty?
-        end
-
-        check("installs and requires cleanly in an isolated GEM_HOME") do
-          Dir.mktmpdir("#{@name}-verify") do |gem_home|
-            env = CLEAN_ENV.merge("GEM_HOME" => gem_home, "GEM_PATH" => gem_home)
-
-            unless @runner.call(env, "gem", "install", "--local", "--no-document", @gem_file)
-              raise "gem install failed"
-            end
-
-            probe = %(require "surfguard"; abort "version mismatch: \#{Surfguard::VERSION}" unless Surfguard::VERSION == ARGV[0])
-            unless @runner.call(env, "ruby", "-e", probe, @version)
-              raise "require probe failed"
-            end
+          check("exact package specification") { verify_spec(spec) }
+          check("exact packaged files") { verify_file_set(spec.files, entries.keys) }
+          check("immutable source commit identity") { verify_source_commit! } if @source_commit
+          if @source_commit || @source_reader
+            check("packaged bytes and modes match immutable source") { compare_source(entries) }
           end
+          check("isolated install, loaded-feature identity, and installed core suite") do
+            verify_installed(snapshot.fetch(:path))
+          end
+          check("source and private snapshot remained byte-identical") { verify_snapshot_unchanged(snapshot) }
         end
 
         @out.puts "verify: #{File.basename(@gem_file)} passed all checks"
         true
+      rescue Failure
+        raise
+      rescue StandardError => error
+        raise Failure, "private artifact snapshot: #{error.message}"
       end
 
       private
+        def with_private_snapshot
+          source_flags = File::RDONLY
+          source_lstat = File.lstat(@gem_file)
+          raise "source artifact is not a regular file" unless source_lstat.file? && !source_lstat.symlink?
+
+          File.open(@gem_file, source_flags) do |source|
+            source.binmode
+            source_stat = source.stat
+            unless source_stat.file? && same_identity?(source_stat, source_lstat)
+              raise "source artifact changed while opening"
+            end
+
+            bytes = read_io_bounded(source, MAX_GEM_BYTES, "gem").freeze
+            digest = Digest::SHA256.hexdigest(bytes).freeze
+            Dir.mktmpdir("surfguard-package-snapshot") do |directory|
+              snapshot_path = File.join(directory, "artifact.gem")
+              snapshot_stat = write_private_snapshot(snapshot_path, bytes)
+              snapshot = {
+                path: snapshot_path.freeze,
+                bytes: bytes,
+                digest: digest,
+                source: source,
+                source_identity: [ source_stat.dev, source_stat.ino ].freeze,
+                snapshot_identity: [ snapshot_stat.dev, snapshot_stat.ino ].freeze
+              }.freeze
+              yield snapshot
+            end
+          end
+        end
+
+        def write_private_snapshot(path, bytes)
+          File.open(path, File::WRONLY | File::CREAT | File::EXCL, 0o600) do |file|
+            file.binmode
+            offset = 0
+            while offset < bytes.bytesize
+              written = file.write(bytes.byteslice(offset..))
+              raise "private snapshot write made no progress" unless written.positive?
+
+              offset += written
+            end
+            file.flush
+            file.fsync
+            file.stat
+          end
+        end
+
+        def verify_snapshot_unchanged(snapshot)
+          source_stat = File.lstat(@gem_file)
+          unless source_stat.file? && !source_stat.symlink? &&
+              [ source_stat.dev, source_stat.ino ] == snapshot.fetch(:source_identity)
+            raise "source artifact identity changed during verification"
+          end
+          source_bytes = read_io_bounded(snapshot.fetch(:source), MAX_GEM_BYTES, "gem")
+          raise "source artifact bytes changed during verification" unless Digest::SHA256.hexdigest(source_bytes) == snapshot.fetch(:digest)
+
+          snapshot_path = snapshot.fetch(:path)
+          snapshot_stat = File.lstat(snapshot_path)
+          unless snapshot_stat.file? && !snapshot_stat.symlink? &&
+              [ snapshot_stat.dev, snapshot_stat.ino ] == snapshot.fetch(:snapshot_identity)
+            raise "private snapshot identity changed during verification"
+          end
+          File.open(snapshot_path, "rb") do |file|
+            private_bytes = read_io_bounded(file, MAX_GEM_BYTES, "private snapshot")
+            unless Digest::SHA256.hexdigest(private_bytes) == snapshot.fetch(:digest)
+              raise "private snapshot bytes changed during verification"
+            end
+          end
+        end
+
+        def same_identity?(left, right)
+          [ left.dev, left.ino ] == [ right.dev, right.ino ]
+        end
+
+        def read_io_bounded(file, limit, label)
+          file.rewind
+          bytes = file.read(limit + 1)
+          raise "#{label} exceeds #{limit} bytes" if bytes.bytesize > limit
+
+          bytes
+        end
+
+        def inspect_raw_archive(bytes)
+          outer = read_tar(bytes, outer: true, limit: MAX_GEM_BYTES)
+          raise "outer members differ: #{outer.keys.sort.inspect}" unless outer.keys.sort == OUTER_MEMBERS.sort
+
+          read_gzip(outer.fetch("metadata.gz").fetch(:data), limit: MAX_METADATA_BYTES, label: "metadata.gz")
+          read_gzip(outer.fetch("checksums.yaml.gz").fetch(:data), limit: MAX_CHECKSUM_BYTES,
+            label: "checksums.yaml.gz")
+          compressed = outer.fetch("data.tar.gz").fetch(:data)
+          data_tar = read_gzip(compressed, limit: MAX_DATA_TAR_BYTES, label: "data.tar.gz")
+          read_tar(data_tar, outer: false, limit: MAX_DATA_TAR_BYTES)
+        rescue Gem::Package::TarInvalidError, Zlib::Error, EOFError => error
+          raise "invalid archive: #{error.message}"
+        end
+
+        def read_gzip(bytes, limit:, label:)
+          input = StringIO.new(bytes)
+          reader = Zlib::GzipReader.new(input)
+          output = +"".b
+          while (chunk = reader.read(16_384))
+            output << chunk
+            raise "#{label} expands beyond #{limit} bytes" if output.bytesize > limit
+          end
+          trailing = reader.unused
+          unread = input.pos < bytes.bytesize
+          raise "#{label} contains trailing gzip data" if unread || (trailing && !trailing.empty?)
+
+          output
+        ensure
+          reader&.close
+        end
+
+        def read_tar(bytes, outer:, limit:)
+          raise "tar exceeds #{limit} bytes" if bytes.bytesize > limit
+          raise "tar length is not block-aligned" unless (bytes.bytesize % TAR_BLOCK_SIZE).zero?
+
+          entries = {}
+          canonical = {}
+          input = StringIO.new(bytes)
+          Gem::Package::TarReader.new(input) do |tar|
+            tar.each do |entry|
+              raise "archive contains too many members" if entries.size >= MAX_ARCHIVE_MEMBERS
+
+              path = entry.full_name
+              validate_path!(path)
+              raise "duplicate member #{path.inspect}" if entries.key?(path)
+              collision_key = path.unicode_normalize(:nfc).downcase
+              raise "colliding member #{path.inspect}" if canonical.key?(collision_key)
+
+              header = entry.header
+              typeflag = header.typeflag.to_s
+              unless REGULAR_TYPEFLAGS.include?(typeflag)
+                raise "non-regular member #{path.inspect} (type #{typeflag.inspect})"
+              end
+              raise "member #{path.inspect} exceeds archive limit" if header.size > limit
+              mode = header.mode & 0o7777
+              permitted = outer ? [ 0o444, 0o644 ] : [ 0o644 ]
+              unless permitted.include?(mode)
+                raise "abnormal mode #{format('%04o', mode)} for #{path.inspect}"
+              end
+
+              canonical[collision_key] = path
+              data = entry.read
+              raise "truncated member #{path.inspect}" unless data.bytesize == header.size
+
+              entries[path] = { data: data, mode: mode }.freeze
+            end
+          end
+          padding = bytes.byteslice(input.pos..)
+          raise "tar contains data after its logical end" unless valid_tar_padding?(padding)
+
+          entries.freeze
+        end
+
+        def validate_path!(path)
+          components = path.split("/", -1)
+          control_byte = path.each_byte.any? { |byte| byte < 0x20 || byte == 0x7f }
+          invalid = path.empty? || path.start_with?("/") || path.include?("\\") ||
+            components.any? { |part| part.empty? || part == "." || part == ".." } ||
+            !path.ascii_only? || control_byte
+          raise "traversing or non-canonical member #{path.inspect}" if invalid
+        end
+
+        def valid_tar_padding?(padding)
+          return false unless padding
+          return false if padding.bytesize < TAR_BLOCK_SIZE
+          return false unless (padding.bytesize % TAR_BLOCK_SIZE).zero?
+
+          padding.each_byte.all?(&:zero?)
+        end
+
+        def verify_spec(spec)
+          raise "name #{spec.name.inspect}" unless spec.name == @name
+          raise "version #{spec.version}" unless spec.version.to_s == @version
+          raise "require_paths #{spec.require_paths.inspect}" unless spec.require_paths == [ "lib" ]
+          raise "dependencies #{spec.dependencies.map(&:to_s).inspect}" unless spec.dependencies.empty?
+          raise "extensions #{spec.extensions.inspect}" unless spec.extensions.empty?
+          raise "executables #{spec.executables.inspect}" unless spec.executables.empty?
+
+          return unless @name == "surfguard"
+
+          raise "authors #{spec.authors.inspect}" unless spec.authors == [ "37signals" ]
+          raise "summary #{spec.summary.inspect}" unless spec.summary == SUMMARY
+          raise "description #{spec.description.inspect}" unless spec.description == DESCRIPTION
+          raise "license #{spec.licenses.inspect}" unless spec.licenses == [ "MIT" ]
+          raise "homepage #{spec.homepage.inspect}" unless spec.homepage == "https://github.com/basecamp/surfguard"
+          raise "required Ruby #{spec.required_ruby_version}" unless spec.required_ruby_version.to_s == ">= 3.4.5"
+          raise "platform #{spec.platform}" unless spec.platform == Gem::Platform::RUBY
+          raise "certificate chain present" unless spec.cert_chain.empty?
+          expected_metadata = {
+            "bug_tracker_uri" => "https://github.com/basecamp/surfguard/issues",
+            "changelog_uri" => "https://github.com/basecamp/surfguard/releases",
+            "rubygems_mfa_required" => "true"
+          }
+          raise "metadata #{spec.metadata.inspect}" unless spec.metadata == expected_metadata
+        end
+
+        def verify_file_set(spec_files, archive_files)
+          raise "spec.files #{spec_files.inspect}" unless spec_files == REQUIRED_FILES
+          raise "archive files #{archive_files.inspect}" unless archive_files == REQUIRED_FILES
+        end
+
+        def compare_source(entries)
+          entries.each do |path, entry|
+            bytes, mode = source_entry(path)
+            raise "#{path.inspect} bytes differ from source" unless entry.fetch(:data) == bytes
+            raise "#{path.inspect} mode differs from source" unless entry.fetch(:mode) == mode
+          end
+        end
+
+        def verify_source_commit!
+          commit = @source_commit.to_s
+          unless commit.match?(/\A(?:[0-9a-f]{40}|[0-9a-f]{64})\z/)
+            raise "source identity is not a full commit object ID"
+          end
+
+          type, type_error, type_status = @capture.call("git", "cat-file", "-t", commit)
+          unless type_status.success? && type.strip == "commit"
+            detail = type_error.strip
+            raise "source identity is not an immutable commit object#{detail.empty? ? nil : ": #{detail}"}"
+          end
+          canonical, resolve_error, resolve_status = @capture.call(
+            "git", "rev-parse", "--verify", "#{commit}^{commit}"
+          )
+          unless resolve_status.success? && canonical.strip == commit
+            detail = resolve_error.strip
+            raise "source commit did not resolve canonically#{detail.empty? ? nil : ": #{detail}"}"
+          end
+        end
+
+        def source_entry(path)
+          return @source_reader.call(path) if @source_reader
+
+          stdout, stderr, status = @capture.call("git", "show", "#{@source_commit}:#{path}")
+          raise "git show failed for #{path.inspect}: #{stderr.strip.inspect}" unless status.success?
+          tree, tree_error, tree_status = @capture.call("git", "ls-tree", @source_commit, "--", path)
+          unless tree_status.success?
+            raise "git ls-tree failed for #{path.inspect}: #{tree_error.strip.inspect}"
+          end
+          mode_text = tree.split.first
+          raise "source member missing: #{path.inspect}" unless mode_text
+          unless mode_text == "100644"
+            raise "source member has abnormal git mode #{mode_text.inspect}: #{path.inspect}"
+          end
+          [ stdout.b, 0o644 ]
+        end
+
+        def verify_installed(gem_file)
+          Dir.mktmpdir("#{@name}-verify") do |gem_home|
+            env = CLEAN_ENV.merge("GEM_HOME" => gem_home, "GEM_PATH" => gem_home)
+            raise "gem install failed" unless @runner.call(env, "gem", "install", "--local", "--no-document", gem_file)
+
+            probe = <<~'RUBY'
+              require "surfguard"
+              abort "version mismatch" unless Surfguard::VERSION == ARGV.fetch(0)
+              feature = $LOADED_FEATURES.find { |item| item.end_with?("/surfguard.rb") }
+              abort "loaded feature missing" unless feature
+              expected = File.realpath(ARGV.fetch(1))
+              actual = File.realpath(feature)
+              abort "loaded outside isolated GEM_HOME: #{actual}" unless actual.start_with?(expected + File::SEPARATOR)
+            RUBY
+            raise "require probe failed" unless @runner.call(env, "ruby", "-e", probe, @version, gem_home)
+
+            # Development-only test tooling may come from the runner's gem
+            # path. The isolated home stays first, and the probe above already
+            # proved Surfguard itself loaded from that fresh install.
+            suite_path = ([ gem_home ] + Gem.path).uniq.join(File::PATH_SEPARATOR)
+            suite_env = env.merge("GEM_PATH" => suite_path, "SURFGUARD_INSTALLED_SUITE" => "1")
+            suite = <<~'RUBY'
+              root, version, gem_home, *expected = ARGV
+              root = File.realpath(root)
+              files = Dir[File.join(root, "test/surfguard*_test.rb")].sort
+              relative = files.map { |file| file.delete_prefix(root + File::SEPARATOR) }
+              abort "core test set mismatch" unless !expected.empty? && relative == expected.sort
+
+              installed_root = File.realpath(File.join(gem_home, "gems", "surfguard-#{version}"))
+              installed_lib = File.join(installed_root, "lib")
+              $LOAD_PATH.unshift(installed_lib)
+              require "surfguard"
+              feature = $LOADED_FEATURES.find { |item| item.end_with?("/surfguard.rb") }
+              abort "installed suite feature missing" unless feature
+              expected_feature = File.realpath(File.join(installed_lib, "surfguard.rb"))
+              abort "installed suite loaded wrong feature" unless File.realpath(feature) == expected_feature
+              abort "installed suite version mismatch" unless Surfguard::VERSION == version
+
+              files.each { |file| require file }
+              abort "installed suite feature changed" unless File.realpath(feature) == expected_feature
+              abort "installed suite version changed" unless Surfguard::VERSION == version
+            RUBY
+            arguments = [ @suite_root, @version, gem_home, *CORE_TEST_FILES ]
+            raise "installed core suite failed" unless @runner.call(suite_env, "ruby", "-e", suite, *arguments)
+          end
+        end
+
         def check(description)
           @out.print "verify: #{description}... "
           result = yield
           @out.puts "ok"
           result
-        rescue StandardError => e
+        rescue StandardError => error
           @out.puts "FAIL"
-          raise Failure, "#{description}: #{e.message}"
+          raise Failure, "#{description}: #{error.message}"
         end
     end
   end

--- a/script/release/verify_package.rb
+++ b/script/release/verify_package.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Build-job package verification, run on every build — rehearsals included.
-#   ruby script/release/verify_package.rb GEM_FILE NAME VERSION
+# Fresh-runner package verification, run on every CI and release candidate.
+#   ruby script/release/verify_package.rb GEM_FILE NAME VERSION IMMUTABLE_COMMIT_SHA
 require_relative "package_verification"
-exit Surfguard::Release::PackageVerification.run(ARGV)
+Surfguard::Release::PackageVerification.run_if_main($PROGRAM_NAME, __FILE__, ARGV)

--- a/surfguard.gemspec
+++ b/surfguard.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
     "rubygems_mfa_required" => "true"
   }
 
-  spec.files = Dir["lib/**/*.rb", "README.md", "LICENSE", "SECURITY.md"]
+  spec.files = %w[lib/surfguard.rb lib/surfguard/version.rb README.md LICENSE SECURITY.md]
   spec.require_paths = [ "lib" ]
 
   # Standard library only: ipaddr, resolv, socket, uri. No runtime dependencies on

--- a/test/package_metadata_coverage_test.rb
+++ b/test/package_metadata_coverage_test.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+class PackageMetadataCoverageTest < Minitest::Test
+  ROOT = File.expand_path("..", __dir__)
+
+  def test_version_and_gemspec_are_evaluated_under_coverage
+    _out, _err = capture_io { load File.join(ROOT, "lib/surfguard/version.rb") }
+    _out, _err = capture_io { load File.join(ROOT, "surfguard.gemspec") }
+    spec = Gem::Specification.load(File.join(ROOT, "surfguard.gemspec"))
+
+    assert_equal "0.1.3", Surfguard::VERSION
+    assert_equal "surfguard", spec.name
+    assert_equal Surfguard::VERSION, spec.version.to_s
+    assert_equal %w[LICENSE README.md SECURITY.md lib/surfguard.rb lib/surfguard/version.rb], spec.files
+    assert_empty spec.runtime_dependencies
+  end
+end

--- a/test/package_metadata_coverage_test.rb
+++ b/test/package_metadata_coverage_test.rb
@@ -10,7 +10,9 @@ class PackageMetadataCoverageTest < Minitest::Test
     _out, _err = capture_io { load File.join(ROOT, "surfguard.gemspec") }
     spec = Gem::Specification.load(File.join(ROOT, "surfguard.gemspec"))
 
-    assert_equal "0.1.3", Surfguard::VERSION
+    # Exact semver with optional RubyGems prerelease segments; asserting the
+    # format rather than the literal keeps `rake bump` transactional.
+    assert_match(/\A\d+\.\d+\.\d+(\.[a-z0-9]+)*\z/i, Surfguard::VERSION)
     assert_equal "surfguard", spec.name
     assert_equal Surfguard::VERSION, spec.version.to_s
     assert_equal %w[LICENSE README.md SECURITY.md lib/surfguard.rb lib/surfguard/version.rb], spec.files

--- a/test/release/cli_entrypoints_test.rb
+++ b/test/release/cli_entrypoints_test.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+require_relative "../../script/release/verify_package"
+
+class CliEntrypointsTest < Minitest::Test
+  def test_package_entrypoint_guard_propagates_the_selected_runner_status
+    runner = ->(argv) { argv.empty? ? 6 : 8 }
+
+    error = assert_raises(SystemExit) do
+      Surfguard::Release::PackageVerification.run_if_main("script", "script", [], runner: runner)
+    end
+    assert_equal 6, error.status
+  end
+end

--- a/test/release/package_verification_test.rb
+++ b/test/release/package_verification_test.rb
@@ -6,6 +6,7 @@ require_relative "../../script/release/package_verification"
 require "fileutils"
 require "stringio"
 require "tmpdir"
+require "zlib"
 
 # Fixture tests for the build-job package verifier: every check is exercised
 # with a real (tiny) gem built in a temp dir — valid, corrupted, misnamed,
@@ -13,6 +14,7 @@ require "tmpdir"
 # The install/require subprocesses are scripted so failures are testable.
 class PackageVerificationTest < Minitest::Test
   Verification = Surfguard::Release::PackageVerification
+  FakeStatus = Data.define(:success?)
 
   DEFAULT_FILES = {
     "lib/surfguard.rb"         => "# fixture\n",
@@ -36,18 +38,54 @@ class PackageVerificationTest < Minitest::Test
     commands = []
     runner = lambda { |env, *command|
       commands << command
-      assert_equal env["GEM_HOME"], env["GEM_PATH"]
+      assert_equal env["GEM_HOME"], env["GEM_PATH"].split(File::PATH_SEPARATOR).first
       assert_nil env["RUBYOPT"]
       assert_nil env["RUBYLIB"]
       assert_nil env["RUBYGEMS_GEMDEPS"]
+      if command.first == "gem"
+        refute_equal gem_file, command.last
+        assert_equal File.binread(gem_file), File.binread(command.last)
+      end
       true
     }
 
     assert Verification.new(gem_file, name: "surfguard", version: "0.1.0", runner: runner, out: @out).verify!
-    assert_equal 2, commands.size
+    assert_equal 3, commands.size
     assert_equal %w[ gem install --local --no-document ], commands.first.first(4)
+    assert_equal %w[ ruby -e ], commands[1].first(2)
     assert_equal %w[ ruby -e ], commands.last.first(2)
+    assert_includes commands.last.fetch(2), "installed suite loaded wrong feature"
+    assert_equal Verification::CORE_TEST_FILES, commands.last.last(Verification::CORE_TEST_FILES.size)
     assert_match(/passed all checks/, @out.string)
+  end
+
+  def test_verification_fails_if_the_source_artifact_changes_after_install
+    gem_file = build_fixture
+    calls = 0
+    runner = lambda { |_env, *|
+      calls += 1
+      File.binwrite(gem_file, "attacker replacement") if calls == 1
+      true
+    }
+
+    error = assert_raises(Verification::Failure) { verification(gem_file, runner: runner).verify! }
+    assert_match(/source artifact bytes changed during verification/, error.message)
+  end
+
+  def test_installed_suite_rejects_an_empty_core_test_set
+    files = DEFAULT_FILES.merge(
+      "lib/surfguard.rb" => "require_relative \"surfguard/version\"\n",
+      "lib/surfguard/version.rb" => "module Surfguard; VERSION = \"0.1.0\"; end\n"
+    )
+    gem_file = build_fixture(files: files)
+    empty_suite = File.join(@dir, "empty-suite")
+    FileUtils.mkdir_p(empty_suite)
+    runner = ->(env, *command) { Kernel.system(env, *command, out: File::NULL, err: File::NULL) }
+
+    error = assert_raises(Verification::Failure) do
+      verification(gem_file, runner: runner, suite_root: empty_suite).verify!
+    end
+    assert_match(/installed core suite failed/, error.message)
   end
 
   def test_a_corrupted_archive_fails_the_integrity_check
@@ -55,37 +93,114 @@ class PackageVerificationTest < Minitest::Test
     File.binwrite(gem_file, File.binread(gem_file).byteslice(0, 100))
 
     error = assert_raises(Verification::Failure) { verification(gem_file).verify! }
-    assert_match(/archive integrity/, error.message)
+    assert_match(/raw nested archive structure/, error.message)
   end
 
   def test_a_different_gem_name_fails
     gem_file = build_fixture(name: "imposter")
     error = assert_raises(Verification::Failure) { verification(gem_file).verify! }
-    assert_match(/spec name/, error.message)
+    assert_match(/exact package specification: name/, error.message)
   end
 
   def test_a_different_version_fails
     gem_file = build_fixture(version: "9.9.9")
     error = assert_raises(Verification::Failure) { verification(gem_file).verify! }
-    assert_match(/spec version/, error.message)
+    assert_match(/exact package specification: version/, error.message)
   end
 
   def test_a_runtime_dependency_fails
     gem_file = build_fixture(dependencies: %w[ rake ])
     error = assert_raises(Verification::Failure) { verification(gem_file).verify! }
-    assert_match(/zero runtime dependencies: got: rake/, error.message)
+    assert_match(/exact package specification: dependencies.*rake/, error.message)
   end
 
   def test_a_missing_required_file_fails
     gem_file = build_fixture(files: DEFAULT_FILES.except("SECURITY.md"))
     error = assert_raises(Verification::Failure) { verification(gem_file).verify! }
-    assert_match(/required files all present: missing: SECURITY\.md/, error.message)
+    assert_match(/exact packaged files/, error.message)
   end
 
   def test_an_unexpected_file_fails
     gem_file = build_fixture(files: DEFAULT_FILES.merge("lib/surfguard/payload.txt" => "!\n"))
     error = assert_raises(Verification::Failure) { verification(gem_file).verify! }
-    assert_match(/no unexpected files: unexpected: lib\/surfguard\/payload\.txt/, error.message)
+    assert_match(/exact packaged files.*lib\/surfguard\/payload\.txt/, error.message)
+  end
+
+  def test_raw_archive_rejects_duplicate_colliding_traversing_symlink_and_abnormal_mode_members
+    mutations = {
+      duplicate: ->(writer) { writer.add_file_simple("README.md", 0o644, 1) { |io| io.write("x") } },
+      collision: ->(writer) { writer.add_file_simple("readme.md", 0o644, 1) { |io| io.write("x") } },
+      traversal: ->(writer) { writer.add_file_simple("../escape", 0o644, 1) { |io| io.write("x") } },
+      symlink: ->(writer) { writer.add_symlink("payload", "README.md", 0o777) },
+      mode: ->(writer) { writer.add_file_simple("payload", 0o755, 1) { |io| io.write("x") } }
+    }
+    mutations.each_value do |mutation|
+      gem_file = mutate_data_tar(build_fixture, &mutation)
+      error = assert_raises(Verification::Failure) { verification(gem_file).verify! }
+      assert_match(/raw nested archive structure/, error.message)
+    end
+  end
+
+  def test_raw_archive_rejects_a_second_tar_after_the_logical_end
+    gem_file = build_fixture
+    tail = StringIO.new
+    Gem::Package::TarWriter.new(tail) do |writer|
+      writer.add_file_simple("hidden-payload", 0o644, 1) { |io| io.write("x") }
+    end
+    File.open(gem_file, "ab") { |file| file.write(tail.string) }
+
+    error = assert_raises(Verification::Failure) { verification(gem_file).verify! }
+    assert_match(/data after its logical end/, error.message)
+  end
+
+  def test_raw_archive_rejects_a_second_nested_tar_after_the_logical_end
+    gem_file = build_fixture
+    tail = StringIO.new
+    Gem::Package::TarWriter.new(tail) do |writer|
+      writer.add_file_simple("hidden-payload", 0o644, 1) { |io| io.write("x") }
+    end
+    mutate_outer_member(gem_file, "data.tar.gz") do |bytes|
+      data_tar = Zlib::GzipReader.wrap(StringIO.new(bytes), &:read)
+      gzip(data_tar + tail.string)
+    end
+
+    error = assert_raises(Verification::Failure) { verification(gem_file).verify! }
+    assert_match(/data after its logical end/, error.message)
+  end
+
+  def test_raw_archive_rejects_trailing_data_after_every_gzip_stream
+    %w[metadata.gz data.tar.gz checksums.yaml.gz].each do |member|
+      gem_file = build_fixture
+      mutate_outer_member(gem_file, member) { |bytes| bytes + gzip("hidden") }
+
+      error = assert_raises(Verification::Failure) { verification(gem_file).verify! }
+      assert_match(/#{Regexp.escape(member)} contains trailing gzip data/, error.message)
+    end
+  end
+
+  def test_raw_archive_rejects_unread_trailing_data_at_a_gzip_buffer_boundary
+    gem_file = build_fixture
+    mutate_outer_member(gem_file, "metadata.gz") do |bytes|
+      metadata = Zlib::GzipReader.wrap(StringIO.new(bytes), &:read)
+      gzip_with_size(metadata, 2048) + "X"
+    end
+
+    error = assert_raises(Verification::Failure) { verification(gem_file).verify! }
+    assert_match(/metadata\.gz contains trailing gzip data/, error.message)
+  end
+
+  def test_raw_archive_bounds_physical_and_expanded_sizes
+    gem_file = build_fixture
+    File.truncate(gem_file, Verification::MAX_GEM_BYTES + 1)
+    error = assert_raises(Verification::Failure) { verification(gem_file).verify! }
+    assert_match(/gem exceeds/, error.message)
+
+    gem_file = build_fixture
+    mutate_outer_member(gem_file, "metadata.gz") do |_bytes|
+      gzip("x" * (Verification::MAX_METADATA_BYTES + 1))
+    end
+    error = assert_raises(Verification::Failure) { verification(gem_file).verify! }
+    assert_match(/metadata\.gz expands beyond/, error.message)
   end
 
   def test_a_failing_install_fails
@@ -103,18 +218,286 @@ class PackageVerificationTest < Minitest::Test
     assert_match(/require probe failed/, error.message)
   end
 
+  def test_immutable_source_byte_and_mode_mismatches_fail
+    gem_file = build_fixture
+    bad_bytes = ->(path) { [ path == "README.md" ? "different" : DEFAULT_FILES.fetch(path), 0o644 ] }
+    error = assert_raises(Verification::Failure) do
+      Verification.new(gem_file, name: "surfguard", version: "0.1.0", runner: ->(_env, *) { true },
+        source_reader: bad_bytes, out: @out).verify!
+    end
+    assert_match(/"README\.md" bytes differ/, error.message)
+
+    bad_mode = ->(path) { [ DEFAULT_FILES.fetch(path), path == "LICENSE" ? 0o755 : 0o644 ] }
+    error = assert_raises(Verification::Failure) do
+      Verification.new(gem_file, name: "surfguard", version: "0.1.0", runner: ->(_env, *) { true },
+        source_reader: bad_mode, out: @out).verify!
+    end
+    assert_match(/"LICENSE" mode differs/, error.message)
+  end
+
+  def test_source_identity_must_name_a_commit_object_not_a_tree
+    tree, status = Open3.capture2("git", "rev-parse", "HEAD^{tree}")
+    assert status.success?
+    gem_file = build_fixture
+    verifier = Verification.new(gem_file, name: "surfguard", version: "0.1.0",
+      runner: ->(_env, *) { true }, source_commit: tree.strip, out: @out)
+
+    error = assert_raises(Verification::Failure) { verifier.verify! }
+    assert_match(/immutable source commit identity: source identity is not an immutable commit object/, error.message)
+  end
+
+  def test_live_factory_owns_suite_root_and_uses_the_kernel_runner
+    original_root = ENV["SURFGUARD_SUITE_ROOT"]
+    ENV["SURFGUARD_SUITE_ROOT"] = @dir
+    calls = []
+    with_singleton_method(Kernel, :system, ->(*arguments) { calls << arguments; :ran }) do
+      live = Verification.live("artifact.gem", name: "surfguard", version: "1.2.3", source_commit: "a" * 40,
+        out: @out)
+      assert_equal @dir, live.instance_variable_get(:@suite_root)
+      assert_equal :ran, live.instance_variable_get(:@runner).call({ "A" => "B" }, "command", "argument")
+    end
+    assert_equal [ [ { "A" => "B" }, "command", "argument" ] ], calls
+
+    ENV.delete("SURFGUARD_SUITE_ROOT")
+    assert_equal ".", Verification.live("artifact.gem", name: "surfguard", version: "1.2.3",
+      source_commit: "a" * 40, out: @out).instance_variable_get(:@suite_root)
+  ensure
+    ENV["SURFGUARD_SUITE_ROOT"] = original_root
+  end
+
+  def test_private_snapshot_rejects_symlinks_open_races_and_zero_progress_writes
+    source = File.join(@dir, "artifact.gem")
+    File.binwrite(source, "original")
+    symlink = File.join(@dir, "artifact-link.gem")
+    File.symlink(source, symlink)
+    verifier = verification(symlink)
+    error = assert_raises(RuntimeError) { verifier.send(:with_private_snapshot) { flunk } }
+    assert_match(/not a regular file/, error.message)
+
+    replacement = File.join(@dir, "replacement.gem")
+    File.binwrite(replacement, "replacement")
+    original_open = File.method(:open)
+    replaced = false
+    wrapper = lambda do |path, *arguments, &block|
+      if path == source && !replaced
+        replaced = true
+        File.rename(replacement, source)
+      end
+      original_open.call(path, *arguments, &block)
+    end
+    with_singleton_method(File, :open, wrapper) do
+      error = assert_raises(RuntimeError) { verification(source).send(:with_private_snapshot) { flunk } }
+      assert_match(/changed while opening/, error.message)
+    end
+
+    fake = Object.new
+    fake.define_singleton_method(:binmode) { }
+    fake.define_singleton_method(:write) { |_bytes| 0 }
+    snapshot_path = File.join(@dir, "snapshot")
+    wrapper = lambda do |path, *arguments, &block|
+      path == snapshot_path ? block.call(fake) : original_open.call(path, *arguments, &block)
+    end
+    with_singleton_method(File, :open, wrapper) do
+      error = assert_raises(RuntimeError) do
+        verification(source).send(:write_private_snapshot, snapshot_path, "bytes")
+      end
+      assert_match(/made no progress/, error.message)
+    end
+  end
+
+  def test_snapshot_end_checks_reject_each_identity_and_byte_change
+    assert_snapshot_change(:source_identity, /source artifact identity/) do |fixture|
+      replacement = "#{fixture.fetch(:source_path)}.replacement"
+      File.binwrite(replacement, fixture.fetch(:bytes))
+      File.rename(replacement, fixture.fetch(:source_path))
+    end
+    assert_snapshot_change(:private_identity, /private snapshot identity/) do |fixture|
+      replacement = "#{fixture.fetch(:snapshot_path)}.replacement"
+      File.binwrite(replacement, fixture.fetch(:bytes))
+      File.rename(replacement, fixture.fetch(:snapshot_path))
+    end
+    assert_snapshot_change(:private_bytes, /private snapshot bytes/) do |fixture|
+      File.binwrite(fixture.fetch(:snapshot_path), "changed")
+    end
+  end
+
+  def test_archive_helpers_cover_invalid_compression_member_limits_and_padding
+    verifier = verification(build_fixture)
+    error = assert_raises(RuntimeError) { verifier.send(:inspect_raw_archive, "\xff".b * 1024) }
+    assert_match(/invalid archive/, error.message)
+
+    assert_equal false, verifier.send(:valid_tar_padding?, nil)
+    assert_equal false, verifier.send(:valid_tar_padding?, "\0" * 511)
+    assert_equal false, verifier.send(:valid_tar_padding?, "\0" * 513)
+    assert_equal false, verifier.send(:valid_tar_padding?, "x" + ("\0" * 511))
+    assert_equal true, verifier.send(:valid_tar_padding?, "\0" * 512)
+
+    error = assert_raises(Zlib::Error) do
+      verifier.send(:read_gzip, "not gzip", limit: 100, label: "fixture")
+    end
+    assert_match(/not in gzip format/, error.message)
+
+    error = assert_raises(RuntimeError) { verifier.send(:read_tar, "x", outer: false, limit: 0) }
+    assert_match(/tar exceeds/, error.message)
+
+    outer = tar_entries(File.binread(build_fixture))
+    outer.delete("metadata.gz")
+    missing_outer = File.join(@dir, "missing-outer.gem")
+    write_outer(missing_outer, outer)
+    error = assert_raises(RuntimeError) do
+      verifier.send(:inspect_raw_archive, File.binread(missing_outer))
+    end
+    assert_match(/outer members differ/, error.message)
+
+    tar = StringIO.new
+    Gem::Package::TarWriter.new(tar) do |writer|
+      (Verification::MAX_ARCHIVE_MEMBERS + 1).times do |index|
+        writer.add_file_simple("member-#{index}", 0o644, 0) { }
+      end
+    end
+    error = assert_raises(RuntimeError) do
+      verifier.send(:read_tar, tar.string, outer: false, limit: Verification::MAX_DATA_TAR_BYTES)
+    end
+    assert_match(/too many members/, error.message)
+
+    oversized_header = tar_header(name: "oversized", size: 4096) + ("\0" * 1024)
+    error = assert_raises(RuntimeError) do
+      verifier.send(:read_tar, oversized_header, outer: false, limit: oversized_header.bytesize)
+    end
+    assert_match(/member "oversized" exceeds/, error.message)
+
+    error = assert_raises(RuntimeError) do
+      verifier.send(:read_tar, oversized_header, outer: false, limit: 5000)
+    end
+    assert_match(/truncated member|unexpected end/, error.message)
+  end
+
+  def test_path_validator_rejects_every_noncanonical_shape
+    verifier = verification(build_fixture)
+    paths = [ "", "/absolute", "back\\slash", "empty//part", "dot/./part", "dotdot/../part", "non-ascii-\u00e9" ]
+    paths.concat((0x00..0x1f).map { |byte| "control-#{byte.chr}-path" })
+    paths << "control-#{0x7f.chr}-path"
+    paths.each do |path|
+      error = assert_raises(RuntimeError) { verifier.send(:validate_path!, path) }
+      assert_match(/non-canonical/, error.message)
+      assert_equal 1, error.message.lines.size
+      refute_match(/[\x00-\x1f\x7f]/, error.message)
+      assert_includes error.message, path.inspect
+    end
+    assert_nil verifier.send(:validate_path!, "lib/surfguard.rb")
+  end
+
+  def test_spec_verifier_checks_every_identity_and_metadata_field
+    gem_file = build_fixture
+    valid = Gem::Package.new(gem_file).spec
+    verifier = verification(gem_file)
+    mutations = {
+      /require_paths/ => ->(spec) { spec.require_paths = [ "src" ] },
+      /dependencies/ => ->(spec) { spec.add_dependency("rake") },
+      /extensions/ => lambda { |spec|
+        spec.extensions = [ "extconf.rb" ]
+        spec.define_singleton_method(:require_paths) { [ "lib" ] }
+      },
+      /executables/ => ->(spec) { spec.executables = [ "surfguard" ] },
+      /authors/ => ->(spec) { spec.authors = [ "attacker" ] },
+      /summary/ => ->(spec) { spec.summary = "wrong" },
+      /description/ => ->(spec) { spec.description = "wrong" },
+      /license/ => ->(spec) { spec.licenses = [ "GPL" ] },
+      /homepage/ => ->(spec) { spec.homepage = "https://example.test" },
+      /required Ruby/ => ->(spec) { spec.required_ruby_version = ">= 3.0" },
+      /platform/ => ->(spec) { spec.platform = Gem::Platform.new("x86_64-linux") },
+      /certificate chain/ => ->(spec) { spec.cert_chain = [ "certificate" ] },
+      /metadata/ => ->(spec) { spec.metadata = { "rubygems_mfa_required" => "false" } }
+    }
+    mutations.each do |message, mutation|
+      spec = valid.dup
+      mutation.call(spec)
+      error = assert_raises(RuntimeError) { verifier.send(:verify_spec, spec) }
+      assert_match message, error.message
+    end
+
+    other = valid.dup
+    other.name = "fixture"
+    assert_nil Verification.new(gem_file, name: "fixture", version: "0.1.0", runner: ->(*) { true })
+      .send(:verify_spec, other)
+  end
+
+  def test_file_set_verifier_checks_metadata_and_archive_lists
+    verifier = verification(build_fixture)
+    required = Verification::REQUIRED_FILES
+    error = assert_raises(RuntimeError) { verifier.send(:verify_file_set, [], required) }
+    assert_match(/spec\.files/, error.message)
+    error = assert_raises(RuntimeError) { verifier.send(:verify_file_set, required, []) }
+    assert_match(/archive files/, error.message)
+    assert_nil verifier.send(:verify_file_set, required, required)
+  end
+
+  def test_source_commit_validation_covers_status_errors_and_canonical_resolution
+    commit = "a" * 40
+    [ 39, 41, 63, 65 ].each do |length|
+      malformed = private_verifier(source_commit: "a" * length)
+      assert_match(/full commit/, assert_raises(RuntimeError) { malformed.send(:verify_source_commit!) }.message)
+    end
+
+    [ "", "fatal: missing" ].each do |detail|
+      capture = ->(*) { [ "", detail, FakeStatus.new(false) ] }
+      error = assert_raises(RuntimeError) do
+        private_verifier(source_commit: commit, capture: capture).send(:verify_source_commit!)
+      end
+      assert_match(/immutable commit object/, error.message)
+      assert_includes error.message, detail unless detail.empty?
+    end
+
+    [ [ false, "" ], [ false, "fatal: resolve" ], [ true, "" ] ].each do |success, detail|
+      responses = [ [ "commit\n", "", FakeStatus.new(true) ],
+        [ success ? "b" * 40 : "", detail, FakeStatus.new(success) ] ]
+      error = assert_raises(RuntimeError) do
+        private_verifier(source_commit: commit, capture: ->(*) { responses.shift }).send(:verify_source_commit!)
+      end
+      assert_match(/did not resolve canonically/, error.message)
+      assert_includes error.message, detail unless detail.empty?
+    end
+
+    responses = [ [ "commit\n", "", FakeStatus.new(true) ], [ "#{commit}\n", "", FakeStatus.new(true) ] ]
+    assert_nil private_verifier(source_commit: commit, capture: ->(*) { responses.shift }).send(:verify_source_commit!)
+  end
+
+  def test_source_entry_rejects_each_git_failure_and_accepts_regular_blob
+    commit = "a" * 40
+    cases = [
+      [ [ [ "", "show failed", false ] ], /git show failed/ ],
+      [ [ [ "bytes", "", true ], [ "", "tree failed", false ] ], /git ls-tree failed/ ],
+      [ [ [ "bytes", "", true ], [ "", "", true ] ], /source member missing/ ],
+      [ [ [ "bytes", "", true ], [ "100755 blob deadbeef\tREADME.md\n", "", true ] ], /abnormal git mode/ ]
+    ]
+    cases.each do |raw_responses, message|
+      responses = raw_responses.map { |stdout, stderr, success| [ stdout, stderr, FakeStatus.new(success) ] }
+      verifier = private_verifier(source_commit: commit, capture: ->(*) { responses.shift })
+      assert_match message, assert_raises(RuntimeError) { verifier.send(:source_entry, "README.md") }.message
+    end
+
+    source_bytes = "security \u2014 policy\n".encode(Encoding::UTF_8)
+    responses = [ [ source_bytes, "", FakeStatus.new(true) ],
+      [ "100644 blob deadbeef\tREADME.md\n", "", FakeStatus.new(true) ] ]
+    entry = private_verifier(source_commit: commit,
+      capture: ->(*) { responses.shift }).send(:source_entry, "README.md")
+    assert_equal [ source_bytes.b, 0o644 ], entry
+    assert_equal Encoding::BINARY, entry.first.encoding
+  end
+
   # --- CLI entry point --------------------------------------------------------
 
   def test_run_verifies_and_exits_zero
     gem_file = build_fixture
     err = StringIO.new
     built = nil
-    factory = lambda { |file, name:, version:, out:|
+    factory = lambda { |file, name:, version:, source_commit:, out:|
       built = [ file, name, version ]
       Verification.new(file, name: name, version: version, runner: ->(_env, *) { true }, out: out)
     }
 
-    status = Verification.run([ gem_file, "surfguard", "0.1.0" ], out: @out, err: err, verification_for: factory)
+    status = Verification.run([ gem_file, "surfguard", "0.1.0", "a" * 40 ], out: @out, err: err,
+      verification_for: factory)
     assert_equal 0, status
     assert_equal [ gem_file, "surfguard", "0.1.0" ], built
   end
@@ -123,29 +506,178 @@ class PackageVerificationTest < Minitest::Test
     err = StringIO.new
     assert_equal 2, Verification.run([ "x.gem" ], out: @out, err: err)
     assert_match(/usage/, err.string)
+
+    assert_equal 2, Verification.run([ "x.gem", "surfguard", "0.1.0", nil ], out: @out, err: err)
+    [ 39, 41, 63, 65 ].each do |length|
+      assert_equal 2, Verification.run([ "x.gem", "surfguard", "0.1.0", "a" * length ], out: @out, err: err)
+    end
   end
 
   def test_run_missing_file_exits_two
     err = StringIO.new
-    assert_equal 2, Verification.run([ File.join(@dir, "nope.gem"), "surfguard", "0.1.0" ], out: @out, err: err)
+    assert_equal 2, Verification.run(
+      [ File.join(@dir, "nope.gem"), "surfguard", "0.1.0", "a" * 40 ], out: @out, err: err
+    )
     assert_match(/no such file/, err.string)
   end
 
   def test_run_failure_exits_one
     gem_file = build_fixture(version: "9.9.9")
     err = StringIO.new
-    factory = lambda { |file, name:, version:, out:|
+    factory = lambda { |file, name:, version:, source_commit:, out:|
       Verification.new(file, name: name, version: version, runner: ->(_env, *) { true }, out: out)
     }
 
-    status = Verification.run([ gem_file, "surfguard", "0.1.0" ], out: @out, err: err, verification_for: factory)
+    status = Verification.run([ gem_file, "surfguard", "0.1.0", "a" * 40 ], out: @out, err: err,
+      verification_for: factory)
     assert_equal 1, status
-    assert_match(/verify_package: spec version/, err.string)
+    assert_match(/verify_package: exact package specification: version/, err.string)
+  end
+
+  def test_run_escapes_control_and_workflow_command_archive_paths_on_one_stderr_line
+    cases = [
+      [ "payload\n::error file=README.md::newline", 1 ],
+      [ "payload\e::error file=README.md::escape", 1 ],
+      [ "payload\x7f::error file=README.md::delete", 1 ],
+      [ "::error file=README.md,line=1::workflow-command", 2 ]
+    ]
+    factory = lambda { |file, name:, version:, source_commit:, out:|
+      Verification.new(file, name: name, version: version, runner: ->(_env, *) { true }, out: out)
+    }
+
+    cases.each do |path, copies|
+      gem_file = mutate_data_tar(build_fixture) do |writer|
+        copies.times do
+          writer.add_file_simple(path, 0o644, 1) { |io| io.write("x") }
+        end
+      end
+      err = StringIO.new
+      status = Verification.run(
+        [ gem_file, "surfguard", "0.1.0", "a" * 40 ], out: @out, err: err,
+        verification_for: factory
+      )
+
+      assert_equal 1, status
+      assert_equal 1, err.string.lines.size
+      diagnostic = err.string.delete_suffix("\n")
+      refute_match(/[\x00-\x1f\x7f]/, diagnostic)
+      refute_match(/\A::/, diagnostic)
+      assert_includes diagnostic, path.inspect
+    end
   end
 
   private
-    def verification(gem_file, runner: ->(_env, *) { true })
-      Verification.new(gem_file, name: "surfguard", version: "0.1.0", runner: runner, out: @out)
+    def tar_header(name:, size:)
+      Gem::Package::TarHeader.new(
+        name: name, mode: 0o644, size: size, prefix: "", mtime: 0, typeflag: "0", linkname: "",
+        magic: "ustar", version: "00", uname: "", gname: "", uid: 0, gid: 0,
+        devmajor: 0, devminor: 0, checksum: 0
+      ).to_s
+    end
+
+    def private_verifier(source_commit: nil, capture: Open3.method(:capture3))
+      Verification.new(File.join(@dir, "artifact.gem"), name: "surfguard", version: "0.1.0",
+        runner: ->(*) { true }, source_commit: source_commit, capture: capture, out: @out)
+    end
+
+    def assert_snapshot_change(label, message)
+      directory = File.join(@dir, label.to_s)
+      FileUtils.mkdir_p(directory)
+      bytes = "unchanged"
+      source_path = File.join(directory, "source.gem")
+      snapshot_path = File.join(directory, "snapshot.gem")
+      File.binwrite(source_path, bytes)
+      File.binwrite(snapshot_path, bytes)
+      source = File.open(source_path, "rb")
+      snapshot = {
+        path: snapshot_path,
+        digest: Digest::SHA256.hexdigest(bytes),
+        source: source,
+        source_identity: File.stat(source_path).then { |stat| [ stat.dev, stat.ino ] },
+        snapshot_identity: File.stat(snapshot_path).then { |stat| [ stat.dev, stat.ino ] }
+      }
+      yield({ source_path: source_path, snapshot_path: snapshot_path, bytes: bytes })
+      error = assert_raises(RuntimeError) do
+        Verification.new(source_path, name: "surfguard", version: "0.1.0", runner: ->(*) { true })
+          .send(:verify_snapshot_unchanged, snapshot)
+      end
+      assert_match message, error.message
+    ensure
+      source&.close
+    end
+
+    def with_singleton_method(object, name, replacement)
+      original = object.method(name)
+      object.define_singleton_method(name, replacement)
+      yield
+    ensure
+      object.define_singleton_method(name, original)
+    end
+
+    def mutate_data_tar(gem_file)
+      outer = tar_entries(File.binread(gem_file))
+      original_data = Zlib::GzipReader.wrap(StringIO.new(outer.fetch("data.tar.gz")[:data]), &:read)
+      data_entries = tar_entries(original_data)
+      rebuilt_data = StringIO.new
+      Gem::Package::TarWriter.new(rebuilt_data) do |writer|
+        data_entries.each do |path, entry|
+          writer.add_file_simple(path, entry[:mode], entry[:data].bytesize) { |io| io.write(entry[:data]) }
+        end
+        yield writer
+      end
+      outer["data.tar.gz"] = { data: gzip(rebuilt_data.string), mode: 0o644 }
+      write_outer(gem_file, outer)
+    end
+
+    def mutate_outer_member(gem_file, member)
+      outer = tar_entries(File.binread(gem_file))
+      entry = outer.fetch(member)
+      outer[member] = entry.merge(data: yield(entry.fetch(:data)))
+      write_outer(gem_file, outer)
+    end
+
+    def write_outer(gem_file, outer)
+      rebuilt = StringIO.new
+      Gem::Package::TarWriter.new(rebuilt) do |writer|
+        outer.each do |path, entry|
+          writer.add_file_simple(path, entry[:mode], entry[:data].bytesize) { |io| io.write(entry[:data]) }
+        end
+      end
+      File.binwrite(gem_file, rebuilt.string)
+      gem_file
+    end
+
+    def gzip(bytes)
+      compressed = StringIO.new(+"".b)
+      Zlib::GzipWriter.wrap(compressed) { |writer| writer.write(bytes) }
+      compressed.string
+    end
+
+    def gzip_with_size(bytes, size)
+      (0..size).each do |name_length|
+        compressed = StringIO.new(+"".b)
+        writer = Zlib::GzipWriter.new(compressed)
+        writer.orig_name = "A" * name_length
+        writer.write(bytes)
+        writer.close
+        return compressed.string if compressed.string.bytesize == size
+      end
+      raise "could not construct a #{size}-byte gzip member"
+    end
+
+    def tar_entries(bytes)
+      entries = {}
+      Gem::Package::TarReader.new(StringIO.new(bytes)) do |reader|
+        reader.each do |entry|
+          entries[entry.full_name] = { data: entry.read, mode: entry.header.mode }
+        end
+      end
+      entries
+    end
+
+    def verification(gem_file, runner: ->(_env, *) { true }, suite_root: ".")
+      Verification.new(gem_file, name: "surfguard", version: "0.1.0", runner: runner,
+        suite_root: suite_root, out: @out)
     end
 
     # Build a real gem from the given files in an isolated source dir and
@@ -163,8 +695,17 @@ class PackageVerificationTest < Minitest::Test
         spec = Gem::Specification.new do |s|
           s.name = name
           s.version = version
-          s.summary = "fixture"
-          s.authors = [ "test" ]
+          s.summary = name == "surfguard" ? Verification::SUMMARY : "fixture"
+          s.description = Verification::DESCRIPTION if name == "surfguard"
+          s.authors = name == "surfguard" ? [ "37signals" ] : [ "test" ]
+          s.license = "MIT" if name == "surfguard"
+          s.homepage = "https://github.com/basecamp/surfguard" if name == "surfguard"
+          s.required_ruby_version = ">= 3.4.5" if name == "surfguard"
+          s.metadata = {
+            "bug_tracker_uri" => "https://github.com/basecamp/surfguard/issues",
+            "changelog_uri" => "https://github.com/basecamp/surfguard/releases",
+            "rubygems_mfa_required" => "true"
+          } if name == "surfguard"
           s.files = files.keys
           dependencies.each { |dependency| s.add_dependency(dependency) }
         end

--- a/test/release/package_verification_test.rb
+++ b/test/release/package_verification_test.rb
@@ -399,6 +399,11 @@ class PackageVerificationTest < Minitest::Test
         spec.define_singleton_method(:require_paths) { [ "lib" ] }
       },
       /executables/ => ->(spec) { spec.executables = [ "surfguard" ] },
+      /autorequire/ => ->(spec) { spec.autorequire = "surfguard" },
+      /post-install message/ => ->(spec) { spec.post_install_message = "gotcha" },
+      /signing key/ => ->(spec) { spec.signing_key = "key.pem" },
+      /external requirements/ => ->(spec) { spec.requirements = [ "libcurl" ] },
+      /required RubyGems/ => ->(spec) { spec.required_rubygems_version = ">= 3.0" },
       /authors/ => ->(spec) { spec.authors = [ "attacker" ] },
       /summary/ => ->(spec) { spec.summary = "wrong" },
       /description/ => ->(spec) { spec.description = "wrong" },

--- a/test/release/rake_tasks_test.rb
+++ b/test/release/rake_tasks_test.rb
@@ -11,14 +11,22 @@ require "tmpdir"
 # offline. Every rejection must leave the tree untouched.
 class RakeTasksTest < Minitest::Test
   RAKEFILE = File.expand_path("../../Rakefile", __dir__)
+  BOOTSTRAP = File.expand_path("../support/rake_coverage_bootstrap", __dir__)
+  FAKE_GIT = File.expand_path("../support/fake_release_git.rb", __dir__)
+  REAL_GIT = ENV.fetch("PATH").split(File::PATH_SEPARATOR)
+    .map { |directory| File.join(directory, "git") }.find { |path| File.executable?(path) }
 
   def setup
     @dir = Dir.mktmpdir("rake-tasks-test")
     @work = File.join(@dir, "work")
     @origin = File.join(@dir, "origin.git")
+    @fake_bin = File.join(@dir, "bin")
 
     FileUtils.mkdir_p(File.join(@work, "lib/surfguard"))
-    FileUtils.cp(RAKEFILE, File.join(@work, "Rakefile"))
+    FileUtils.mkdir_p(@fake_bin)
+    FileUtils.copy_file(FAKE_GIT, File.join(@fake_bin, "git"))
+    File.chmod(0o755, File.join(@fake_bin, "git"))
+    FileUtils.copy_file(RAKEFILE, File.join(@work, "Rakefile"))
     write_version("0.1.0")
 
     git "init", "--quiet", "--initial-branch=main"
@@ -68,6 +76,17 @@ class RakeTasksTest < Minitest::Test
     assert_untouched
   end
 
+  def test_bump_rejects_a_malformed_repository_version
+    write_version("01.2.3")
+    git "add", "-A"
+    git "commit", "--quiet", "--message", "malformed repository version"
+
+    status, output = run_rake("bump[1.2.4]")
+    refute_predicate status, :success?
+    assert_match(/repository version is not exact semver/, output)
+    assert_equal "01.2.3", read_version
+  end
+
   def test_bump_rewrites_version_and_refreshes_the_lockfile
     add_bundler_fixture
 
@@ -75,6 +94,103 @@ class RakeTasksTest < Minitest::Test
     assert_predicate status, :success?, -> { output }
     assert_equal "0.2.0", read_version
     assert_includes File.read(File.join(@work, "Gemfile.lock")), "surfguard (0.2.0)"
+  end
+
+  def test_bump_ignores_inherited_bundler_configuration
+    add_bundler_fixture
+
+    status, output = run_rake("bump[0.2.0]", env: {
+      "BUNDLE_GEMFILE" => File.join(@dir, "missing-gemfile"),
+      "BUNDLE_PATH" => File.join(@dir, "attacker-bundle-path")
+    })
+    assert_predicate status, :success?, -> { output }
+    assert_equal "0.2.0", read_version
+  end
+
+  def test_bump_restores_version_and_lockfile_when_bundle_fails
+    add_bundler_fixture(fail_during_bump: true)
+    original_version = File.binread(File.join(@work, "lib/surfguard/version.rb"))
+    original_lock = File.binread(File.join(@work, "Gemfile.lock"))
+
+    status, output = run_rake("bump[0.2.0]", env: { "SURFGUARD_BUMP_FAILURE" => "1" })
+    refute_predicate status, :success?
+    assert_match(/simulated bump failure/, output)
+    assert_equal original_version, File.binread(File.join(@work, "lib/surfguard/version.rb"))
+    assert_equal original_lock, File.binread(File.join(@work, "Gemfile.lock"))
+  end
+
+  def test_bump_rejects_a_lockfile_inconsistent_with_the_current_version
+    add_bundler_fixture
+    lockfile = File.join(@work, "Gemfile.lock")
+    File.write(lockfile, File.read(lockfile).sub("surfguard (0.1.0)", "surfguard (9.9.9)"))
+    git "add", "-A"
+    git "commit", "--quiet", "--message", "inconsistent lockfile"
+    original_version = File.binread(File.join(@work, "lib/surfguard/version.rb"))
+    original_lock = File.binread(lockfile)
+
+    status, output = run_rake("bump[0.2.0]")
+
+    refute_predicate status, :success?
+    assert_match(/lockfile did not record exactly the current surfguard/, output)
+    assert_equal original_version, File.binread(File.join(@work, "lib/surfguard/version.rb"))
+    assert_equal original_lock, File.binread(lockfile)
+  end
+
+  def test_bump_rejects_a_nonliteral_version_declaration
+    add_bundler_fixture
+    File.write(File.join(@work, "lib/surfguard/version.rb"), <<~RUBY)
+      module Surfguard
+        VERSION = String.new("0.1.0")
+      end
+    RUBY
+    original = File.binread(File.join(@work, "lib/surfguard/version.rb"))
+    git "add", "-A"
+    git "commit", "--quiet", "--message", "nonliteral version"
+
+    status, output = run_rake("bump[0.2.0]")
+    refute_predicate status, :success?
+    assert_match(/version declaration was not exact/, output)
+    assert_equal original, File.binread(File.join(@work, "lib/surfguard/version.rb"))
+  end
+
+  def test_bump_rejects_a_staged_lockfile_that_did_not_take_the_new_version
+    add_bundler_fixture
+    gemspec = File.join(@work, "surfguard.gemspec")
+    File.write(gemspec, File.read(gemspec).sub("spec.version = Surfguard::VERSION", 'spec.version = "0.1.0"'))
+    git "add", "-A"
+    git "commit", "--quiet", "--message", "hardcoded gem version"
+
+    status, output = run_rake("bump[0.2.0]")
+    refute_predicate status, :success?
+    assert_match(/lockfile did not record exactly surfguard 0\.2\.0/, output)
+    assert_equal "0.1.0", read_version
+  end
+
+  def test_bump_rejects_unexpected_untracked_state_in_final_validation
+    add_bundler_fixture
+
+    status, output = run_rake("bump[0.2.0]", env: { "SURFGUARD_INJECT_UNTRACKED_ON_STATUS" => "1" })
+    refute_predicate status, :success?
+    assert_match(/unexpected working tree state/, output)
+    assert_equal "0.1.0", read_version
+    assert_path_exists File.join(@work, "unexpected-untracked")
+  end
+
+  def test_bump_rejects_a_version_file_that_changes_meaning_outside_the_staging_directory
+    add_bundler_fixture
+    File.write(File.join(@work, "lib/surfguard/version.rb"), <<~RUBY)
+      module Surfguard
+        VERSION = "0.1.0"
+        VERSION = "0.1.0" unless File.expand_path(__dir__).include?("surfguard-bump")
+      end
+    RUBY
+    git "add", "-A"
+    git "commit", "--quiet", "--message", "path-dependent version"
+
+    status, output = run_rake("bump[0.2.0]")
+    refute_predicate status, :success?
+    assert_match(/resulting version is invalid/, output)
+    assert_equal "0.1.0", read_version
   end
 
   # --- tag guards -------------------------------------------------------------
@@ -109,7 +225,7 @@ class RakeTasksTest < Minitest::Test
     git "tag", "v0.1.0"
     status, output = run_rake("tag")
     refute_predicate status, :success?
-    assert_match(/already exists locally/, output)
+    assert_match(/not the exact retryable annotated tag/, output)
     assert_empty tags_on_origin
   end
 
@@ -122,6 +238,54 @@ class RakeTasksTest < Minitest::Test
     assert_match(/already exists on origin/, output)
   end
 
+  def test_tag_rejects_a_noncanonical_or_mismatched_origin
+    git "remote", "set-url", "origin", "ext::sh -c exploit"
+    git "remote", "set-url", "--push", "origin", "ext::sh -c exploit"
+
+    status, output = run_rake("tag", env: { "SURFGUARD_EXPOSE_REMOTE" => "1" })
+    refute_predicate status, :success?
+    assert_match(/canonical basecamp\/surfguard/, output)
+    assert_no_tags
+  end
+
+  def test_tag_rejects_different_fetch_and_push_urls
+    status, output = run_rake("tag", env: { "SURFGUARD_MISMATCH_REMOTE" => "1" })
+
+    refute_predicate status, :success?
+    assert_match(/fetch\/push URLs differ/, output)
+    assert_no_tags
+  end
+
+  def test_tag_rejects_git_command_failure
+    status, output = run_rake("tag", env: { "SURFGUARD_FAIL_GIT_STATUS" => "1" })
+
+    refute_predicate status, :success?
+    assert_match(/git status failed/, output)
+    assert_no_tags
+  end
+
+  def test_tag_rejects_a_malformed_repository_version
+    write_version("01.2.3")
+    git "add", "-A"
+    git "commit", "--quiet", "--message", "malformed tag version"
+
+    status, output = run_rake("tag")
+    refute_predicate status, :success?
+    assert_match(/repository version is not exact semver/, output)
+    assert_no_tags
+  end
+
+  def test_hostile_preload_cannot_override_the_canonical_push_url
+    preload = File.join(@dir, "hostile-preload.rb")
+    File.write(preload, 'CANONICAL_PUSH_URL = "https://attacker.invalid"')
+    rubyopt = "-r#{BOOTSTRAP} -r#{preload}"
+
+    status, output = run_rake("tag", env: { "RUBYOPT" => rubyopt })
+    assert_predicate status, :success?, -> { output }
+    assert_includes tags_on_origin, "v0.1.0"
+    assert_match(/already initialized constant CANONICAL_PUSH_URL/, output)
+  end
+
   def test_tag_pushes_main_then_the_tag_on_success
     status, output = run_rake("tag")
     assert_predicate status, :success?, -> { output }
@@ -129,18 +293,71 @@ class RakeTasksTest < Minitest::Test
     assert_match(/release workflow takes it from here/, output)
   end
 
+  def test_tag_retries_an_exact_local_annotated_tag_when_remote_is_absent
+    git "tag", "--annotate", "v0.1.0", "--message", "surfguard v0.1.0"
+    status, output = run_rake("tag")
+    assert_predicate status, :success?, -> { output }
+    assert_includes tags_on_origin, "v0.1.0"
+  end
+
+  def test_tag_explicitly_creates_the_accepted_unsigned_tag_even_if_signing_is_configured
+    git "config", "tag.gpgSign", "true"
+
+    status, output = run_rake("tag")
+
+    assert_predicate status, :success?, -> { output }
+    object = capture_git("cat-file", "tag", "v0.1.0")
+    assert_includes object, "\nsurfguard v0.1.0\n"
+    refute_includes object, "BEGIN PGP SIGNATURE"
+  end
+
+  def test_tag_rejects_annotated_retry_with_extra_message_whitespace
+    git "tag", "--annotate", "v0.1.0", "--message", "surfguard v0.1.0", "--message", "extra"
+    status, output = run_rake("tag")
+    refute_predicate status, :success?
+    assert_match(/not the exact retryable annotated tag/, output)
+    assert_empty tags_on_origin
+  end
+
+  def test_rubocop_task_uses_the_argv_form_even_when_the_fixture_has_no_bundle
+    status, output = run_rake("rubocop")
+
+    refute_predicate status, :success?
+    assert_match(/bundle.*exec.*rubocop|Could not locate Gemfile/, output)
+  end
+
+  def test_rakefile_assignment_is_covered_without_the_test_override
+    had_original = Object.const_defined?(:CANONICAL_PUSH_URL)
+    original = Object.const_get(:CANONICAL_PUSH_URL) if had_original
+    Object.send(:remove_const, :CANONICAL_PUSH_URL) if had_original
+
+    load RAKEFILE
+    assert_equal "https://github.com/basecamp/surfguard", CANONICAL_PUSH_URL
+  ensure
+    Object.send(:remove_const, :CANONICAL_PUSH_URL) if Object.const_defined?(:CANONICAL_PUSH_URL)
+    Object.const_set(:CANONICAL_PUSH_URL, original) if had_original
+  end
+
   private
     def git(*args)
       system("git", "-C", @work, *args, exception: true, out: File::NULL)
     end
 
+    def capture_git(*args)
+      output, status = Open3.capture2e("git", "-C", @work, *args)
+      raise output unless status.success?
+
+      output
+    end
+
     # A minimal gemspec + Gemfile + lock so bump's `bundle install` has a
     # real lockfile to refresh. No remote dependencies, so this stays offline.
-    def add_bundler_fixture
+    def add_bundler_fixture(fail_during_bump: false)
       File.write(File.join(@work, "surfguard.gemspec"), <<~RUBY)
         # frozen_string_literal: true
 
         require_relative "lib/surfguard/version"
+        raise "simulated bump failure" if #{fail_during_bump} && ENV["SURFGUARD_BUMP_FAILURE"]
 
         Gem::Specification.new do |spec|
           spec.name    = "surfguard"
@@ -165,16 +382,21 @@ class RakeTasksTest < Minitest::Test
     # so subprocesses see the fixture repo the way a developer's shell would.
     def clean_env
       env = ENV.keys.grep(/\ABUNDLE/).to_h { |key| [ key, nil ] }
-      env.merge("RUBYOPT" => nil, "RUBYLIB" => nil, "RUBYGEMS_GEMDEPS" => nil)
+      env.merge(
+        "RUBYOPT" => "-r#{BOOTSTRAP}", "RUBYLIB" => nil, "RUBYGEMS_GEMDEPS" => nil,
+        "PATH" => "#{@fake_bin}#{File::PATH_SEPARATOR}#{ENV.fetch('PATH')}",
+        "SURFGUARD_REAL_GIT" => REAL_GIT, "SURFGUARD_TEST_ORIGIN" => @origin,
+        "SURFGUARD_COVERAGE_ROOT" => (File.expand_path("../..", __dir__) if ENV["COVERAGE"])
+      )
     end
 
-    def run_rake(task)
+    def run_rake(task, env: {})
       # Invoke rake as a library, not via its binstub: with the bundler
       # fixture's Gemfile.lock in place, RubyGems' binstub activation would
       # restrict `rake` to the fixture bundle (which has no rake).
       output, status = Open3.capture2e(
-        clean_env, Gem.ruby, "-rrake", "-e", "Rake.application.run",
-        "--", "--rakefile", "Rakefile", task, chdir: @work
+        clean_env.merge(env), Gem.ruby, "-rrake", "-e", "Rake.application.run",
+        "--", "--rakefile", RAKEFILE, task, chdir: @work
       )
       [ status, output ]
     end
@@ -195,15 +417,22 @@ class RakeTasksTest < Minitest::Test
 
     def assert_untouched
       assert_equal "0.1.0", read_version
-      assert_empty `git -C #{@work} status --porcelain`
+      output, status = Open3.capture2e("git", "-C", @work, "status", "--porcelain")
+      assert_predicate status, :success?
+      assert_empty output
     end
 
     def assert_no_tags
-      assert_empty `git -C #{@work} tag --list`
+      output, status = Open3.capture2e("git", "-C", @work, "tag", "--list")
+      assert_predicate status, :success?
+      assert_empty output
       assert_empty tags_on_origin
     end
 
     def tags_on_origin
-      `git -C #{@origin} tag --list`.split("\n")
+      output, status = Open3.capture2e("git", "-C", @origin, "tag", "--list")
+      raise output unless status.success?
+
+      output.split("\n")
     end
 end

--- a/test/release/rake_tasks_test.rb
+++ b/test/release/rake_tasks_test.rb
@@ -101,7 +101,8 @@ class RakeTasksTest < Minitest::Test
 
     status, output = run_rake("bump[0.2.0]", env: {
       "BUNDLE_GEMFILE" => File.join(@dir, "missing-gemfile"),
-      "BUNDLE_PATH" => File.join(@dir, "attacker-bundle-path")
+      "BUNDLE_PATH" => File.join(@dir, "attacker-bundle-path"),
+      "BUNDLER_VERSION" => "99.99.99"
     })
     assert_predicate status, :success?, -> { output }
     assert_equal "0.2.0", read_version

--- a/test/support/fake_release_git.rb
+++ b/test/support/fake_release_git.rb
@@ -1,0 +1,28 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+real_git = ENV.fetch("SURFGUARD_REAL_GIT")
+origin = ENV.fetch("SURFGUARD_TEST_ORIGIN")
+canonical = "https://github.com/basecamp/surfguard"
+
+if ARGV == %w[remote get-url --push origin] && !ENV["SURFGUARD_EXPOSE_REMOTE"]
+  puts canonical
+  exit 0
+end
+
+if ARGV == %w[remote get-url origin] && !ENV["SURFGUARD_EXPOSE_REMOTE"]
+  puts(ENV["SURFGUARD_MISMATCH_REMOTE"] ? "https://github.com/basecamp/not-surfguard" : canonical)
+  exit 0
+end
+
+if ARGV.first(2) == %w[status --porcelain] && ENV["SURFGUARD_FAIL_GIT_STATUS"]
+  warn "simulated git status failure"
+  exit 1
+end
+
+if ARGV.include?("--porcelain=v1") && ENV["SURFGUARD_INJECT_UNTRACKED_ON_STATUS"]
+  File.binwrite("unexpected-untracked", "injected during final validation")
+end
+
+mapped = ARGV.map { |argument| argument == canonical ? origin : argument }
+exec real_git, *mapped

--- a/test/support/rake_coverage_bootstrap.rb
+++ b/test/support/rake_coverage_bootstrap.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+if ENV["SURFGUARD_COVERAGE_ROOT"]
+  require "simplecov"
+
+  SimpleCov.root ENV.fetch("SURFGUARD_COVERAGE_ROOT")
+  SimpleCov.command_name "rake-task-#{Process.pid}"
+  SimpleCov.start do
+    # Subprocesses only persist their resultset fragments. The parent test
+    # process is the sole report writer, avoiding concurrent report clobbering.
+    formatter false
+    enable_coverage :branch
+    no_default_skips
+    cover "Rakefile"
+  end
+end


### PR DESCRIPTION
## Stack

2 of 5. Base: `security-hardening-01-runtime-iana`. Next: `security-hardening-03-registry-client`.

## Summary

- Validate the raw nested gem archive, exact specification, files, modes, and every packaged byte against an immutable commit.
- Install into an isolated GEM_HOME and run the complete core suite from installed bytes.
- Make bump and tag helpers transactional and argv-safe, add fresh-runner package CI, and keep the existing release workflow compatible with the four-argument verifier.
- Compare Git and archive data as encoding-independent bytes, including non-ASCII packaged documentation.

## Verification

- Full package adversarial-fixture and transactional Rake-helper suite, 0 failures
- Fresh-runner package build, isolated install suite, RuboCop, and actionlint

This is an intermediate hardening branch. Do not tag, publish, or dispatch release/recovery until the complete stack is merged.
