### PR TITLE
Pin and bound RubyGems registry reconciliation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,12 +116,16 @@ jobs:
           path: surfguard-${{ steps.version.outputs.version }}.gem
           if-no-files-found: error
       # The unprivileged confirm job runs these scripts without checking out
-      # the repo. The OIDC-capable publish job deliberately does not download
-      # or execute them.
+      # the repo, so the artifact carries the Surfguard library registry.rb
+      # loads for address classification, laid out at repo-relative paths.
+      # The OIDC-capable publish job deliberately does not download or
+      # execute them.
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-scripts
           path: |
+            lib/surfguard.rb
+            lib/surfguard/version.rb
             script/release/registry.rb
             script/release/registry_confirm.rb
           if-no-files-found: error
@@ -283,10 +287,11 @@ jobs:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: rubygem
+      # Spanning lib/ and script/, the artifact is rooted at the repo root:
+      # extracting into the workspace restores both trees in place.
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-scripts
-          path: script/release
       - name: Verify artifact identity (digest must match the build job's)
         run: |
           actual="$(sha256sum "surfguard-${VERSION}.gem" | awk '{ print $1 }')"

--- a/script/release/registry.rb
+++ b/script/release/registry.rb
@@ -583,7 +583,11 @@ module Surfguard
         end
 
         def version_uri(version)
-          raise Error, "invalid gem version" unless version.to_s.match?(/\A(?:0|[1-9]\d*)(?:\.(?:0|[1-9]\d*)){2}\z/)
+          # Exact semver plus optional RubyGems prerelease segments (0.2.0.rc1),
+          # the version domain the release workflows accept. Alphanumeric
+          # dot-separated segments only, so interpolation stays URI/path-safe.
+          raise Error, "invalid gem version" \
+            unless version.to_s.match?(/\A(?:0|[1-9]\d*)(?:\.(?:0|[1-9]\d*)){2}(?:\.[A-Za-z0-9]+)*\z/)
 
           URI("#{HOST}/api/v2/rubygems/#{@name}/versions/#{version}.json")
         end

--- a/script/release/registry.rb
+++ b/script/release/registry.rb
@@ -3,217 +3,662 @@
 require "digest"
 require "json"
 require "net/http"
+require "openssl"
+require "pathname"
+require "resolv"
+require "securerandom"
+require "tmpdir"
 require "uri"
+
+require_relative "../../lib/surfguard"
 
 module Surfguard
   module Release
-    # Talks to the RubyGems API about one gem version and answers with a total
-    # state machine: every response maps to push, skip, keep-waiting, or fail
-    # closed. No error-string matching anywhere — this reconciliation is the
-    # release pipeline's idempotency mechanism.
-    #
-    # Standard library only: the jobs that run it have no bundle and (publish/
-    # confirm) no checkout, receiving these scripts via a build artifact.
     class Registry
-      # Fail closed. Every path that is not one of the explicitly defined
-      # proceed/skip/keep-waiting transitions raises this.
       class Error < StandardError; end
-
-      # Internal: a condition worth retrying (429, 5xx, network fault) — never
-      # escapes; it either resolves within bounds or becomes an Error.
       class RetryableFault < StandardError; end
 
       HOST = "https://rubygems.org"
-      MAX_ATTEMPTS = 5      # bounded retries for 429/5xx/network faults
-      MALFORMED_LIMIT = 3   # consecutive malformed bodies tolerated while polling
-      BACKOFF_BASE = 2      # seconds; fault n backs off BACKOFF_BASE * n
-      POLL_INTERVAL = 5     # seconds between polls while the version is absent
-      CONFIRM_DEADLINE = 300
+      ORIGIN_HOST = "rubygems.org"
+      MAX_ATTEMPTS = 5
+      MALFORMED_LIMIT = 3
+      BACKOFF_BASE = 2
+      POLL_INTERVAL = 5
+      DEFAULT_BUDGET = 300
+      MIN_BUDGET = 1
+      MAX_BUDGET = 600
       MAX_REDIRECTS = 3
-      OPEN_TIMEOUT = 10
-      READ_TIMEOUT = 30
+      METADATA_LIMIT = 1 << 20
+      GEM_LIMIT = 16 << 20
 
-      Response = Struct.new(:status, :body, :location)
+      Response = Struct.new(:status, :body, :location, :declared_length, :actual_length)
 
-      # Live wiring, exercised only against the real registry; tests inject
-      # all three dependencies.
-      # simplecov:disable
-      def self.live(name)
-        new(
-          name,
-          http: lambda do |uri|
-            response = Net::HTTP.start(uri.host, uri.port, use_ssl: true,
-                                       open_timeout: OPEN_TIMEOUT, read_timeout: READ_TIMEOUT) do |http|
-              http.request(Net::HTTP::Get.new(uri))
-            end
-            Response.new(response.code.to_i, response.body.to_s, response["location"])
-          end,
-          sleeper: ->(seconds) { Kernel.sleep(seconds) },
-          clock: -> { Process.clock_gettime(Process::CLOCK_MONOTONIC) }
-        )
+      module BodyLength
+        module_function
+
+        def parse(value, limit)
+          return nil if value.nil?
+
+          text = value.to_s
+          raise Error, "invalid declared response length" unless text.match?(/\A\d+\z/)
+
+          length = Integer(text, 10)
+          raise Error, "declared response length exceeds #{limit} bytes" if length > limit
+
+          length
+        end
       end
-      # simplecov:enable
 
-      # CLI entry points, one per pipeline job; each returns a process exit
-      # status. The registry_* executables are one-line wrappers around these.
-      def self.run_check(argv, out: $stdout, err: $stderr, registry_for: method(:live))
-        name, version, sha256 = argv
-        if argv.size != 3
-          err.puts "usage: registry_check.rb NAME VERSION SHA256"
-          return 2
+      class Deadline
+        def initialize(clock, seconds)
+          @clock = clock
+          @expires_at = @clock.call + seconds
         end
 
-        out.puts registry_for.call(name).check(version, sha256)
+        def remaining
+          seconds = @expires_at - @clock.call
+          raise Error, "registry operation exceeded its monotonic budget" unless seconds.positive?
+
+          seconds
+        end
+
+        def check!
+          remaining
+          true
+        end
+
+        # A watchdog bounds operations such as DNS and a TLS read even if the
+        # underlying library's timeout is inactivity-based rather than absolute.
+        def run
+          wait = remaining
+          worker = Thread.new { yield }
+          worker.report_on_exception = false
+          begin
+            unless worker.join([ wait, remaining ].min)
+              worker.kill
+              worker.join(0.1)
+              raise Error, "registry operation exceeded its monotonic budget"
+            end
+            check!
+            worker.value
+          ensure
+            if worker.alive?
+              worker.kill
+              worker.join(0.1)
+            end
+          end
+        end
+      end
+
+      class DigestingSink
+        attr_reader :bytesize
+
+        def initialize(file, limit, deadline: nil)
+          @file = file
+          @limit = limit
+          @deadline = deadline
+          @digest = Digest::SHA256.new
+          @bytesize = 0
+        end
+
+        def write(chunk)
+          raise Error, "response body is not a byte string" unless chunk.is_a?(String)
+          raise Error, "response exceeds #{@limit} bytes" if @bytesize + chunk.bytesize > @limit
+
+          offset = 0
+          while offset < chunk.bytesize
+            written = checked_io { @file.write(chunk.byteslice(offset..)) }
+            raise Error, "temporary download write made no progress" unless written.positive?
+
+            offset += written
+          end
+          @digest.update(chunk)
+          @bytesize += chunk.bytesize
+        end
+
+        def reset!
+          checked_io { @file.flush }
+          checked_io { @file.rewind }
+          checked_io { @file.truncate(0) }
+          @digest = Digest::SHA256.new
+          @bytesize = 0
+        end
+
+        def hexdigest
+          @digest.hexdigest
+        end
+
+        def finish!
+          checked_io { @file.chmod(0o600) }
+          checked_io { @file.flush }
+          checked_io { @file.fsync }
+        end
+
+        private
+          def checked_io
+            @deadline&.check!
+            result = yield
+            @deadline&.check!
+            result
+          end
+      end
+
+      class LiveHTTP
+        NETWORK_ERRORS = [ Timeout::Error, OpenSSL::SSL::SSLError, SocketError,
+          SystemCallError, EOFError, IOError ].freeze
+        TRUSTED_INSTANCE_OF = Object.instance_method(:instance_of?)
+        TRUSTED_ARRAY_EACH = Array.instance_method(:each)
+        TRUSTED_ARRAY_LENGTH = Array.instance_method(:length)
+        TRUSTED_ARRAY_SLICE = Array.instance_method(:[])
+
+        def initialize(resolver: ->(host) { Resolv.getaddresses(host) }, http_class: Net::HTTP)
+          @resolver = resolver
+          @http_class = http_class
+          @address_cache = {}
+        end
+
+        def call(uri, deadline, limit, sink)
+          deadline.check!
+          addresses = addresses_for(uri.host, deadline)
+          last_error = nil
+          addresses.each do |address|
+            deadline.check!
+            begin
+              response = deadline.run { request(uri, address, deadline, limit, sink) }
+              deadline.check!
+              return response
+            rescue *NETWORK_ERRORS => error
+              last_error = error
+              sink&.reset!
+              deadline.check!
+            end
+          end
+          raise last_error
+        end
+
+        private
+          def addresses_for(host, deadline)
+            cached = @address_cache[host]
+            return cached.tap { deadline.check! } if cached
+
+            answers = deadline.run do
+              raw = @resolver.call(host)
+              unless trusted_instance_of?(raw, Array)
+                raise Error, "registry host returned an invalid answer collection"
+              end
+
+              raw_length = TRUSTED_ARRAY_LENGTH.bind_call(raw)
+              raise Error, "registry host returned too many addresses" if raw_length > Surfguard::MAX_ADDRESSES
+
+              owned_raw = TRUSTED_ARRAY_SLICE.bind_call(raw, 0, Surfguard::MAX_ADDRESSES + 1)
+              normalized = []
+              TRUSTED_ARRAY_EACH.bind_call(owned_raw) do |answer|
+                deadline.check!
+                unless trusted_instance_of?(answer, String)
+                  raise Error, "registry host returned a malformed address"
+                end
+
+                owned = String.new(answer)
+                unless owned.valid_encoding? && owned.ascii_only? &&
+                    !owned.include?("\0") && !owned.include?("/") && !owned.include?("%")
+                  raise Error, "registry host returned a malformed address"
+                end
+
+                owned.freeze
+                address = IPAddr.new(owned)
+                if Surfguard.blocked_address?(address, policy: :iana_special_use)
+                  raise Error, "registry host resolved to a blocked address"
+                end
+                normalized << address.to_s.dup.freeze
+                deadline.check!
+              rescue IPAddr::InvalidAddressError, ArgumentError, TypeError
+                raise Error, "registry host returned a malformed address"
+              end
+              normalized.uniq!
+              raise Error, "registry host resolved to no addresses" if normalized.empty?
+
+              deadline.check!
+              normalized.freeze
+            end
+
+            deadline.check!
+            @address_cache[host] = answers
+          rescue Resolv::ResolvError, Timeout::Error, SocketError, SystemCallError, EOFError, IOError
+            raise SocketError, "registry host resolution failed"
+          end
+
+          def trusted_instance_of?(value, klass)
+            TRUSTED_INSTANCE_OF.bind_call(value, klass)
+          end
+
+          def request(uri, address, deadline, limit, sink)
+            client = @http_class.new(uri.host, uri.port, nil)
+            client.use_ssl = true
+            client.verify_mode = OpenSSL::SSL::VERIFY_PEER
+            client.verify_hostname = true if client.respond_to?(:verify_hostname=)
+            client.ipaddr = address
+            client.open_timeout = [ deadline.remaining, 10 ].min
+            client.read_timeout = [ deadline.remaining, 30 ].min
+            request = Net::HTTP::Get.new(uri.request_uri)
+            request["Host"] = uri.host
+            request["Accept-Encoding"] = "identity"
+            result = nil
+
+            deadline.check!
+            client.start do |connection|
+              deadline.check!
+              connection.request(request) do |response|
+                deadline.check!
+                encoding = response["content-encoding"]
+                if encoding && !encoding.casecmp?("identity")
+                  raise Error, "refusing encoded registry response"
+                end
+                declared = BodyLength.parse(response["content-length"], limit)
+                if declared && response["transfer-encoding"]
+                  raise Error, "response has both Content-Length and Transfer-Encoding"
+                end
+
+                actual = 0
+                body = +""
+                target = response.code.to_i == 200 ? sink : nil
+                response.read_body do |chunk|
+                  deadline.check!
+                  actual += chunk.bytesize
+                  raise Error, "response exceeds #{limit} bytes" if actual > limit
+
+                  target ? target.write(chunk) : body << chunk
+                  client.read_timeout = [ deadline.remaining, 30 ].min
+                  deadline.check!
+                end
+                deadline.check!
+                if declared && declared != actual
+                  raise Error, "declared response length does not match received bytes"
+                end
+                result = Response.new(response.code.to_i, target ? nil : body,
+                  response["location"], declared, actual)
+              end
+              deadline.check!
+            end
+            deadline.check!
+            result
+          end
+      end
+
+      def self.live(name)
+        clock = -> { Process.clock_gettime(Process::CLOCK_MONOTONIC) }
+        adapter = LiveHTTP.new
+        new(name, http: adapter.method(:call), sleeper: ->(seconds) { Kernel.sleep(seconds) }, clock: clock)
+      end
+
+      def self.run_if_main(program_name, file_name, argv, runner:)
+        return unless program_name == file_name
+
+        exit runner.call(argv)
+      end
+
+      def self.run_check(argv, out: $stdout, err: $stderr, registry_for: method(:live))
+        name, version, sha256, budget = argv
+        valid = (argv.size == 3) || (argv.size == 4 && String === budget && budget.match?(/\A\d+\z/))
+        return usage(err, "registry_check.rb NAME VERSION SHA256 [BUDGET_SECONDS]") unless valid
+
+        out.puts registry_for.call(name).check(version, sha256, budget: budget || DEFAULT_BUDGET)
         0
-      rescue Error => e
-        err.puts "registry check failed: #{e.message}"
+      rescue Error => error
+        err.puts "registry check failed: #{error.message}"
         1
       end
 
       def self.run_confirm(argv, out: $stdout, err: $stderr, registry_for: method(:live))
-        name, version, sha256, deadline = argv
-        if argv.size < 3 || argv.size > 4 || (deadline && !deadline.match?(/\A\d+\z/))
-          err.puts "usage: registry_confirm.rb NAME VERSION SHA256 [DEADLINE_SECONDS]"
-          return 2
+        name, version, sha256, destination, budget = argv
+        if argv.size == 4 && String === destination && destination.match?(/\A\d+\z/)
+          budget = destination
+          destination = nil
         end
+        valid_destination = destination.nil? || (String === destination && destination.end_with?(".gem"))
+        valid_budget = budget.nil? || (String === budget && budget.match?(/\A\d+\z/))
+        valid = (3..5).cover?(argv.size) && valid_destination && valid_budget
+        return usage(err, "registry_confirm.rb NAME VERSION SHA256 [DESTINATION [BUDGET_SECONDS]]") unless valid
 
         registry = registry_for.call(name)
-        registry.confirm(version, sha256, deadline: (deadline || CONFIRM_DEADLINE).to_i)
+        if destination
+          registry.confirm_to(version, sha256, destination, budget: budget || DEFAULT_BUDGET)
+        else
+          registry.confirm(version, sha256, budget: budget || DEFAULT_BUDGET)
+        end
         out.puts "confirmed: #{name} #{version} is live with sha256 #{sha256.downcase}"
         0
-      rescue Error => e
-        err.puts "registry confirmation failed: #{e.message}"
+      rescue Error => error
+        err.puts "registry confirmation failed: #{error.message}"
         1
       end
 
       def self.run_download(argv, out: $stdout, err: $stderr, registry_for: method(:live))
-        name, version, destination = argv
-        if argv.size != 3
-          err.puts "usage: registry_download.rb NAME VERSION DESTINATION"
-          return 2
-        end
+        name, version, destination, budget = argv
+        valid = (argv.size == 3) || (argv.size == 4 && String === budget && budget.match?(/\A\d+\z/))
+        return usage(err, "registry_download.rb NAME VERSION DESTINATION [BUDGET_SECONDS]") unless valid
 
-        bytes, digest = registry_for.call(name).verified_download(version)
-        File.binwrite(destination, bytes)
+        digest = registry_for.call(name).verified_download_to(version, destination, budget: budget || DEFAULT_BUDGET)
         out.puts digest
         0
-      rescue Error => e
-        err.puts "registry download failed: #{e.message}"
+      rescue Error => error
+        err.puts "registry download failed: #{error.message}"
         1
       end
 
+      def self.usage(err, message)
+        err.puts "usage: #{message}"
+        2
+      end
+      private_class_method :usage
+
+      def self.atomic_publish(destination, bytes)
+        with_atomic_target(destination) { |sink| sink.write(bytes) }
+      end
+
+      def self.with_atomic_target(destination, deadline: nil)
+        raise Error, "destination is empty" if destination.nil? || destination.empty?
+
+        target = File.expand_path(destination)
+        parent = File.dirname(target)
+        validate_parent_chain!(parent, deadline: deadline)
+        parent_stat = deadline_operation(deadline) { File.lstat(parent) }
+        begin
+          deadline_operation(deadline) { File.lstat(target) }
+          raise Error, "destination already exists"
+        rescue Errno::ENOENT
+          nil
+        end
+
+        temporary = File.join(parent, ".#{File.basename(target)}.#{SecureRandom.hex(12)}.tmp")
+        temporary_identity = nil
+        publication_may_exist = false
+        committed = false
+        begin
+          yielded, expected_digest, expected_size = deadline_operation(deadline) do
+            File.open(temporary, File::WRONLY | File::CREAT | File::EXCL, 0o600) do |file|
+              file.binmode
+              temporary_identity = file.stat
+              sink = DigestingSink.new(file, GEM_LIMIT, deadline: deadline)
+              result = yield sink
+              sink.finish!
+              [ result, sink.hexdigest, sink.bytesize ]
+            end
+          end
+          verify_parent_identity!(parent, parent_stat, deadline)
+          verify_regular_identity!(temporary, temporary_identity, deadline,
+            message: "temporary download is not the expected mode-0600 regular file")
+
+          publication_may_exist = true
+          deadline_operation(deadline) { File.link(temporary, target) }
+          verify_parent_identity!(parent, parent_stat, deadline)
+          verify_linked_target!(target, temporary_identity, expected_size, expected_digest, deadline)
+          fsync_directory!(parent, deadline)
+          deadline_operation(deadline) { File.unlink(temporary) }
+          fsync_directory!(parent, deadline)
+          verify_parent_identity!(parent, parent_stat, deadline)
+          verify_linked_target!(target, temporary_identity, expected_size, expected_digest, deadline)
+          committed = true
+          [ yielded, expected_digest ]
+        rescue Errno::EEXIST
+          message = publication_may_exist ? "destination already exists" : "temporary path collision"
+          raise Error, message
+        ensure
+          if publication_may_exist && !committed && safe_unlink_expected(target, temporary_identity)
+            fsync_directory!(parent, nil)
+          end
+          safe_unlink_expected(temporary, temporary_identity)
+        end
+      rescue SystemCallError => error
+        raise Error, "atomic publication failed: #{error.message}"
+      end
+
+      def self.validate_parent_chain!(parent, deadline: nil)
+        Pathname.new(File.expand_path(parent)).ascend.to_a.reverse_each do |component|
+          stat = deadline_operation(deadline) { File.lstat(component.to_s) }
+          raise Error, "symlink parent is forbidden" if stat.symlink?
+          raise Error, "download parent is not a directory" unless stat.directory?
+        end
+      end
+      private_class_method :validate_parent_chain!
+
+      def self.verify_parent_identity!(parent, expected, deadline)
+        validate_parent_chain!(parent, deadline: deadline)
+        current = deadline_operation(deadline) { File.lstat(parent) }
+        unless [ current.dev, current.ino ] == [ expected.dev, expected.ino ]
+          raise Error, "download parent changed during publication"
+        end
+      end
+      private_class_method :verify_parent_identity!
+
+      def self.verify_regular_identity!(path, expected, deadline, message:)
+        stat = deadline_operation(deadline) { File.lstat(path) }
+        unless stat.file? && !stat.symlink? && [ stat.dev, stat.ino ] == [ expected.dev, expected.ino ] &&
+            (stat.mode & 0o777) == 0o600
+          raise Error, message
+        end
+        stat
+      end
+      private_class_method :verify_regular_identity!
+
+      def self.verify_linked_target!(path, identity, expected_size, expected_digest, deadline)
+        message = "published download is not the verified mode-0600 regular file"
+        stat = verify_regular_identity!(path, identity, deadline, message: message)
+        raise Error, "published download size changed" unless stat.size == expected_size
+
+        digest = digest_regular_file(path, identity, deadline)
+        raise Error, "published download digest changed" unless digest == expected_digest
+
+        verify_regular_identity!(path, identity, deadline, message: message)
+      end
+      private_class_method :verify_linked_target!
+
+      def self.digest_regular_file(path, identity, deadline)
+        deadline_operation(deadline) do
+          File.open(path, File::RDONLY) do |file|
+            stat = file.stat
+            unless stat.file? && [ stat.dev, stat.ino ] == [ identity.dev, identity.ino ]
+              raise Error, "published download changed while opening"
+            end
+
+            digest = Digest::SHA256.new
+            bytes = 0
+            loop do
+              chunk = deadline_operation(deadline) { file.read(16_384) }
+              break unless chunk
+
+              bytes += chunk.bytesize
+              raise Error, "published download exceeds #{GEM_LIMIT} bytes" if bytes > GEM_LIMIT
+              digest.update(chunk)
+            end
+            digest.hexdigest
+          end
+        end
+      end
+      private_class_method :digest_regular_file
+
+      def self.fsync_directory!(parent, deadline)
+        deadline_operation(deadline) { File.open(parent, File::RDONLY, &:fsync) }
+      end
+      private_class_method :fsync_directory!
+
+      def self.deadline_operation(deadline)
+        deadline&.check!
+        result = yield
+        deadline&.check!
+        result
+      end
+      private_class_method :deadline_operation
+
+      def self.safe_unlink_expected(path, identity)
+        return unless identity
+
+        stat = File.lstat(path)
+        return unless stat.file? && !stat.symlink? && [ stat.dev, stat.ino ] == [ identity.dev, identity.ino ]
+
+        File.unlink(path)
+        true
+      rescue Errno::ENOENT
+        false
+      end
+      private_class_method :safe_unlink_expected
+
       def initialize(name, http:, sleeper:, clock:)
-        @name = name
+        raise Error, "invalid gem name" unless name.to_s.match?(/\A[a-z0-9_-]+\z/)
+
+        @name = name.to_s.dup.freeze
         @http = http
         @sleeper = sleeper
         @clock = clock
+        @deadline = nil
       end
 
-      # The publish job's decision: may we push? Returns :push (version absent)
-      # or :skip (already published with exactly our bytes). Anything else
-      # fails closed.
-      #
-      # A 404 means only that this version is absent — it says nothing about
-      # whether the gem name is claimed.
-      def check(version, sha256)
-        sha256 = normalize_sha(sha256)
-        response = get_with_retries(version_uri(version))
+      def check(version, sha256, budget: DEFAULT_BUDGET)
+        within_budget(budget) do
+          sha256 = normalize_sha(sha256)
+          response = get_with_retries(version_uri(version), limit: METADATA_LIMIT)
+          case response.status
+          when 404 then :push
+          when 200
+            published = published_sha(response.body, version)
+            return :skip if published == sha256
 
-        case response.status
-        when 404
-          :push
-        when 200
-          published = published_sha(response.body, version)
-          if published == sha256
-            :skip
+            raise Error, "#{@name} #{version} is already published with sha256 #{published}; our artifact is #{sha256}"
           else
-            raise Error, "#{@name} #{version} is already published with sha256 #{published}; " \
-                         "our artifact is #{sha256} — refusing to touch it"
+            raise Error, "unexpected HTTP #{response.status} from registry metadata"
           end
-        else
-          raise Error, "unexpected HTTP #{response.status} from #{version_uri(version)}"
         end
       end
 
-      # The confirm job: wait (bounded) until the registry reports exactly our
-      # version with exactly our digest, then download the canonical bytes and
-      # verify those too. Returns the canonical bytes.
-      def confirm(version, sha256, deadline: CONFIRM_DEADLINE)
-        sha256 = normalize_sha(sha256)
-        poll(version, sha256, deadline: deadline)
-
-        bytes, digest = verified_download(version)
-        unless digest == sha256
-          raise Error, "canonical .gem digest #{digest} does not match our artifact digest #{sha256}"
+      def confirm(version, sha256, budget: DEFAULT_BUDGET, deadline: nil)
+        budget = deadline if deadline
+        within_budget(budget) do
+          sha256 = normalize_sha(sha256)
+          poll(version, sha256)
+          bytes, = verified_download_in_memory(version, required_sha: sha256)
+          bytes
         end
-        bytes
       end
 
-      # The recovery path: fetch the canonical bytes for a published version
-      # and verify them against the digest the registry itself reports.
-      # Returns [ bytes, digest ].
-      def verified_download(version)
-        response = get_with_retries(version_uri(version))
-        unless response.status == 200
-          raise Error, "expected #{@name} #{version} to be published; got HTTP #{response.status}"
+      def confirm_to(version, sha256, destination, budget: DEFAULT_BUDGET)
+        within_budget(budget) do
+          sha256 = normalize_sha(sha256)
+          poll(version, sha256)
+          stream_verified_download(version, destination, required_sha: sha256)
         end
+      end
 
-        published = published_sha(response.body, version)
-        bytes = download(version)
-        digest = Digest::SHA256.hexdigest(bytes)
-        unless digest == published
-          raise Error, "downloaded .gem digest #{digest} does not match registry-reported sha256 #{published}"
-        end
-        [ bytes, digest ]
+      def verified_download(version, budget: DEFAULT_BUDGET)
+        within_budget(budget) { verified_download_in_memory(version) }
+      end
+
+      def verified_download_to(version, destination, budget: DEFAULT_BUDGET)
+        within_budget(budget) { stream_verified_download(version, destination) }
       end
 
       private
+        def within_budget(value)
+          return yield if @deadline
+
+          text = value.to_s
+          raise Error, "budget must be 1..600 seconds" unless text.match?(/\A\d+\z/)
+
+          budget = Integer(text, 10)
+          raise Error, "budget must be 1..600 seconds" unless (MIN_BUDGET..MAX_BUDGET).cover?(budget)
+
+          @deadline = Deadline.new(@clock, budget)
+          yield
+        ensure
+          @deadline = nil if defined?(budget) && budget
+        end
+
+        def remaining
+          @deadline.remaining
+        end
+
+        def sleep_bounded(seconds)
+          raise Error, "registry operation exceeded its monotonic budget" if seconds >= remaining
+
+          @sleeper.call(seconds)
+          @deadline.check!
+        end
+
         def version_uri(version)
+          raise Error, "invalid gem version" unless version.to_s.match?(/\A(?:0|[1-9]\d*)(?:\.(?:0|[1-9]\d*)){2}\z/)
+
           URI("#{HOST}/api/v2/rubygems/#{@name}/versions/#{version}.json")
         end
 
-        def normalize_sha(sha256)
-          sha = sha256.to_s.downcase
-          raise Error, "not a sha256 hex digest: #{sha256.inspect}" unless sha.match?(/\A\h{64}\z/)
+        def normalize_sha(value)
+          sha = value.to_s.downcase
+          raise Error, "not a sha256 hex digest" unless sha.match?(/\A\h{64}\z/)
+
           sha
         end
 
-        # Parse the v2 version payload, failing closed on anything unexpected.
         def published_sha(body, version)
           data = JSON.parse(body)
-          raise Error, "unexpected response shape: #{data.class}" unless data.is_a?(Hash)
-          unless data["number"] == version
-            raise Error, "response is for version #{data['number'].inspect}, expected #{version.inspect}"
-          end
+          raise Error, "unexpected response shape" unless data.is_a?(Hash)
+          raise Error, "response is for a different version" unless data["number"] == version
           sha = data["sha"]
-          unless sha.is_a?(String) && sha.match?(/\A\h{64}\z/)
-            raise Error, "response has no usable sha256 (got #{sha.inspect})"
-          end
+          raise Error, "response has no usable sha256" unless sha.is_a?(String) && sha.match?(/\A\h{64}\z/)
+
           sha.downcase
-        rescue JSON::ParserError => e
-          raise Error, "malformed JSON from registry: #{e.message}"
+        rescue JSON::ParserError
+          raise Error, "malformed JSON from registry"
         end
 
-        # One GET; network-level faults become RetryableFault.
-        def get_once(uri)
-          @http.call(uri)
+        def get_once(uri, limit:, sink: nil)
+          validate_uri!(uri)
+          @deadline.check!
+          sink_before = sink&.bytesize
+          response = case @http.arity
+          when 1 then @http.call(uri)
+          when 2 then @http.call(uri, remaining)
+          else @http.call(uri, @deadline, limit, sink)
+          end
+          @deadline.check!
+          raise Error, "invalid registry response" unless response.respond_to?(:status) && response.respond_to?(:body)
+
+          status = Integer(response.status)
+          declared = BodyLength.parse(response.declared_length, limit)
+          body = response.body
+          raise Error, "response body is not a byte string" unless body.nil? || body.is_a?(String)
+
+          sink.write(body) if sink && status == 200 && body
+          observed = if sink && status == 200
+            sink.bytesize - sink_before
+          else
+            body.to_s.bytesize
+          end
+          actual = response.actual_length ? Integer(response.actual_length) : observed
+          if response.actual_length && actual != observed
+            raise Error, "reported actual response length does not match received bytes"
+          end
+          raise Error, "response exceeds #{limit} bytes" if actual > limit
+          if declared && declared != actual
+            raise Error, "declared response length does not match received bytes"
+          end
+
+          Response.new(status, body, response.location, declared, actual)
         rescue Timeout::Error, Net::OpenTimeout, Net::ReadTimeout, OpenSSL::SSL::SSLError,
-               SocketError, SystemCallError, EOFError, IOError => e
-          raise RetryableFault, "#{e.class}: #{e.message}"
+               SocketError, SystemCallError, EOFError, IOError => error
+          raise RetryableFault, error.class.to_s
+        rescue ArgumentError, TypeError
+          raise Error, "invalid registry response length or status"
         end
 
-        # GET with bounded backoff on 429/5xx/network faults. Returns the
-        # response for every other status; callers own the status decision.
-        def get_with_retries(uri)
+        def get_with_retries(uri, limit:, sink: nil)
           attempts = 0
           begin
             attempts += 1
-            response = get_once(uri)
+            response = get_once(uri, limit: limit, sink: sink)
             raise RetryableFault, "HTTP #{response.status}" if retryable_status?(response.status)
             response
-          rescue RetryableFault => e
-            raise Error, "#{uri} unavailable after #{attempts} attempts (#{e.message})" if attempts >= MAX_ATTEMPTS
-            @sleeper.call(BACKOFF_BASE * attempts)
+          rescue RetryableFault => error
+            raise Error, "registry unavailable after #{attempts} attempts (#{error.message})" if attempts >= MAX_ATTEMPTS
+            sink&.reset!
+            @deadline.check!
+            sleep_bounded(BACKOFF_BASE * attempts)
             retry
           end
         end
@@ -222,29 +667,19 @@ module Surfguard
           status == 429 || (500..599).cover?(status)
         end
 
-        # Poll until the registry reports exactly (version, sha256): 404 keeps
-        # polling, 429/5xx/network faults back off, malformed bodies retry a
-        # bounded number of times, a different sha fails immediately, and the
-        # deadline fails.
-        def poll(version, sha256, deadline:)
-          started = @clock.call
+        def poll(version, sha256)
           faults = 0
           malformed = 0
-
           loop do
-            if @clock.call - started >= deadline
-              raise Error, "gave up waiting for #{@name} #{version} after #{deadline}s"
-            end
-
+            @deadline.check!
             begin
-              response = get_once(version_uri(version))
+              response = get_once(version_uri(version), limit: METADATA_LIMIT)
             rescue RetryableFault
               malformed = 0
               faults += 1
-              @sleeper.call(BACKOFF_BASE * faults)
+              sleep_bounded(BACKOFF_BASE * faults)
               next
             end
-
             case response.status
             when 200
               begin
@@ -252,56 +687,85 @@ module Surfguard
               rescue Error
                 malformed += 1
                 raise if malformed >= MALFORMED_LIMIT
-                @sleeper.call(POLL_INTERVAL)
+                sleep_bounded(POLL_INTERVAL)
                 next
               end
-
               return if published == sha256
-              raise Error, "registry reports #{@name} #{version} with sha256 #{published}; " \
-                           "our artifact is #{sha256} — stopping for a human"
+              raise Error, "registry reports a different digest; stopping for a human"
             when 404
               malformed = 0
-              @sleeper.call(POLL_INTERVAL)
+              sleep_bounded(POLL_INTERVAL)
             when 429, 500..599
               malformed = 0
               faults += 1
-              @sleeper.call(BACKOFF_BASE * faults)
+              sleep_bounded(BACKOFF_BASE * faults)
             else
-              raise Error, "unexpected HTTP #{response.status} from #{version_uri(version)}"
+              raise Error, "unexpected HTTP #{response.status} from registry metadata"
             end
           end
         end
 
-        # Fetch the canonical .gem bytes, following at most MAX_REDIRECTS
-        # https-only redirects.
-        def download(version)
+        def download(version, sink:)
           uri = URI("#{HOST}/gems/#{@name}-#{version}.gem")
           redirects = 0
-
           loop do
-            response = get_with_retries(uri)
-
+            response = get_with_retries(uri, limit: GEM_LIMIT, sink: sink)
             case response.status
-            when 200
-              return response.body
+            when 200 then return
             when 301, 302, 303, 307, 308
               redirects += 1
-              raise Error, "too many redirects downloading #{@name}-#{version}.gem" if redirects > MAX_REDIRECTS
-              location = response.location
-              raise Error, "redirect without a Location header" if location.nil? || location.empty?
-              # Location may legitimately be relative or scheme-relative:
-              # resolve it against the current URI, then enforce https-only.
+              raise Error, "too many redirects downloading gem" if redirects > MAX_REDIRECTS
+              raise Error, "redirect without a Location header" if response.location.nil? || response.location.empty?
               begin
-                target = URI.join(uri.to_s, location)
-              rescue URI::Error => e
-                raise Error, "unusable redirect location #{location.inspect}: #{e.message}"
+                target = URI.join(uri.to_s, response.location)
+              rescue URI::Error
+                raise Error, "unusable redirect location"
               end
-              raise Error, "refusing non-https redirect to #{target}" unless target.is_a?(URI::HTTPS)
+              validate_uri!(target)
               uri = target
             else
-              raise Error, "unexpected HTTP #{response.status} downloading #{uri}"
+              raise Error, "unexpected HTTP #{response.status} downloading gem"
             end
           end
+        end
+
+        def stream_verified_download(version, destination, required_sha: nil)
+          response = get_with_retries(version_uri(version), limit: METADATA_LIMIT)
+          unless response.status == 200
+            raise Error, "expected #{@name} #{version} to be published; got HTTP #{response.status}"
+          end
+          published = published_sha(response.body, version)
+
+          result, = self.class.with_atomic_target(destination, deadline: @deadline) do |sink|
+            download(version, sink: sink)
+            digest = sink.hexdigest
+            unless digest == published
+              raise Error, "downloaded .gem digest #{digest} does not match registry-reported sha256 #{published}"
+            end
+            if required_sha && digest != required_sha
+              raise Error, "canonical .gem digest #{digest} does not match our artifact digest #{required_sha}"
+            end
+            digest
+          end
+          result
+        end
+
+        def verified_download_in_memory(version, required_sha: nil)
+          Dir.mktmpdir("surfguard-registry") do |directory|
+            destination = File.join(directory, "#{@name}-#{version}.gem")
+            digest = stream_verified_download(version, destination, required_sha: required_sha)
+            bytes = @deadline.run { File.binread(destination, GEM_LIMIT + 1) }
+            raise Error, "downloaded gem exceeds #{GEM_LIMIT} bytes" if bytes.bytesize > GEM_LIMIT
+            raise Error, "downloaded gem changed after verification" unless Digest::SHA256.hexdigest(bytes) == digest
+
+            [ bytes, digest ]
+          end
+        end
+
+        def validate_uri!(uri)
+          valid = uri.is_a?(URI::HTTPS) && uri.host == ORIGIN_HOST && uri.port == 443 &&
+            uri.userinfo.nil? && uri.fragment.nil?
+          raise Error, "refusing registry URL outside exact https://rubygems.org:443 origin" unless valid
         end
     end
   end

--- a/script/release/registry_check.rb
+++ b/script/release/registry_check.rb
@@ -3,4 +3,6 @@
 # Publish-job reconciliation: prints "push" or "skip", or fails closed.
 #   ruby script/release/registry_check.rb NAME VERSION SHA256
 require_relative "registry"
-exit Surfguard::Release::Registry.run_check(ARGV)
+Surfguard::Release::Registry.run_if_main(
+  $PROGRAM_NAME, __FILE__, ARGV, runner: Surfguard::Release::Registry.method(:run_check)
+)

--- a/script/release/registry_confirm.rb
+++ b/script/release/registry_confirm.rb
@@ -3,6 +3,8 @@
 # Confirm-job verification: bounded poll until the registry reports exactly
 # our version with exactly our digest, then downloads the canonical bytes and
 # verifies those too.
-#   ruby script/release/registry_confirm.rb NAME VERSION SHA256 [DEADLINE_SECONDS]
+#   ruby script/release/registry_confirm.rb NAME VERSION SHA256 [DESTINATION [BUDGET_SECONDS]]
 require_relative "registry"
-exit Surfguard::Release::Registry.run_confirm(ARGV)
+Surfguard::Release::Registry.run_if_main(
+  $PROGRAM_NAME, __FILE__, ARGV, runner: Surfguard::Release::Registry.method(:run_confirm)
+)

--- a/script/release/registry_download.rb
+++ b/script/release/registry_download.rb
@@ -3,6 +3,8 @@
 # Recovery-path download: fetches the canonical .gem bytes for a published
 # version, verifies them against the digest the registry itself reports,
 # writes them to DESTINATION, and prints the digest.
-#   ruby script/release/registry_download.rb NAME VERSION DESTINATION
+#   ruby script/release/registry_download.rb NAME VERSION DESTINATION [BUDGET_SECONDS]
 require_relative "registry"
-exit Surfguard::Release::Registry.run_download(ARGV)
+Surfguard::Release::Registry.run_if_main(
+  $PROGRAM_NAME, __FILE__, ARGV, runner: Surfguard::Release::Registry.method(:run_download)
+)

--- a/test/release/cli_entrypoints_test.rb
+++ b/test/release/cli_entrypoints_test.rb
@@ -1,9 +1,21 @@
 # frozen_string_literal: true
 
 require_relative "../test_helper"
+require_relative "../../script/release/registry_check"
+require_relative "../../script/release/registry_confirm"
+require_relative "../../script/release/registry_download"
 require_relative "../../script/release/verify_package"
 
 class CliEntrypointsTest < Minitest::Test
+  def test_registry_entrypoint_guard_propagates_the_selected_runner_status
+    runner = ->(argv) { argv == [ "argument" ] ? 7 : 8 }
+
+    error = assert_raises(SystemExit) do
+      Surfguard::Release::Registry.run_if_main("script", "script", [ "argument" ], runner: runner)
+    end
+    assert_equal 7, error.status
+  end
+
   def test_package_entrypoint_guard_propagates_the_selected_runner_status
     runner = ->(argv) { argv.empty? ? 6 : 8 }
 

--- a/test/release/registry_test.rb
+++ b/test/release/registry_test.rb
@@ -1001,6 +1001,16 @@ class RegistryTest < Minitest::Test
     end
   end
 
+  def test_version_validation_accepts_prerelease_segments_and_stays_path_safe
+    registry = scripted(res(404))
+    assert_equal :push, registry.check("0.2.0.rc1", DIGEST)
+    assert_equal [ "https://rubygems.org/api/v2/rubygems/surfguard/versions/0.2.0.rc1.json" ], @requests
+
+    %w[01.0.0 1.0 0.2.0. 0.2.0..rc1 0.2.0.rc-1 0.2.0/evil 0.2.0.rc1%2e ../0.2.0].each do |version|
+      assert_raises(Registry::Error, version) { scripted(res(404)).check(version, DIGEST) }
+    end
+  end
+
   def test_verified_download_in_memory_detects_oversize_and_post_verification_change
     registry = Registry.new(NAME, http: ->(*) { }, sleeper: ->(*) { }, clock: -> { 0.0 })
     registry.define_singleton_method(:stream_verified_download) do |_version, destination, required_sha: nil|

--- a/test/release/registry_test.rb
+++ b/test/release/registry_test.rb
@@ -23,6 +23,53 @@ class RegistryTest < Minitest::Test
   VERSION_URL = "https://rubygems.org/api/v2/rubygems/surfguard/versions/0.1.0.json"
   GEM_URL = "https://rubygems.org/gems/surfguard-0.1.0.gem"
 
+  class FakeNetResponse
+    attr_reader :code
+
+    def initialize(status, chunks = [], headers = {}, before_chunk: nil)
+      @code = status.to_s
+      @chunks = chunks
+      @headers = headers.transform_keys(&:downcase)
+      @before_chunk = before_chunk
+    end
+
+    def [](name)
+      @headers[name.downcase]
+    end
+
+    def read_body
+      @chunks.each do |chunk|
+        @before_chunk&.call
+        yield chunk
+      end
+    end
+  end
+
+  class FakeHTTPClient
+    attr_accessor :use_ssl, :verify_mode, :verify_hostname, :ipaddr, :open_timeout, :read_timeout
+    attr_reader :requests
+
+    def initialize(queue)
+      @queue = queue
+      @requests = []
+    end
+
+    def start
+      yield self
+    end
+
+    def request(request)
+      @requests << request
+      step = @queue.shift
+      raise "fake HTTP queue exhausted" unless step
+
+      step = step.call if step.respond_to?(:call)
+      raise step if step.is_a?(Exception)
+
+      yield step
+    end
+  end
+
   # --- check: the publish job's decision ------------------------------------
 
   def test_check_404_means_version_absent_so_push
@@ -113,6 +160,74 @@ class RegistryTest < Minitest::Test
     assert_equal 1, @requests.size
   end
 
+  def test_metadata_declared_and_actual_lengths_are_bounded
+    declared = Registry::Response.new(200, version_json, nil, (Registry::METADATA_LIMIT + 1).to_s)
+    assert_raises(Registry::Error) { scripted(declared).check(VERSION, DIGEST) }
+    oversized = res(200, "x" * (Registry::METADATA_LIMIT + 1))
+    assert_raises(Registry::Error) { scripted(oversized).check(VERSION, DIGEST) }
+  end
+
+  def test_declared_length_must_be_strict_digits_and_match_actual_bytes
+    body = version_json
+    [ "-1", "+1", " 1", "1, 1", "1x" ].each do |declared|
+      response = Registry::Response.new(200, body, nil, declared)
+      assert_raises(Registry::Error, declared) { scripted(response).check(VERSION, DIGEST) }
+    end
+
+    response = Registry::Response.new(200, body, nil, (body.bytesize + 1).to_s)
+    error = assert_raises(Registry::Error) { scripted(response).check(VERSION, DIGEST) }
+    assert_match(/does not match/, error.message)
+
+    response = Registry::Response.new(200, body, nil, nil, body.bytesize + 1)
+    error = assert_raises(Registry::Error) { scripted(response).check(VERSION, DIGEST) }
+    assert_match(/reported actual/, error.message)
+  end
+
+  def test_request_that_finishes_after_the_absolute_deadline_cannot_succeed
+    now = 0.0
+    registry = Registry.new(
+      NAME,
+      http: lambda { |_uri|
+        now = 2.0
+        res(404)
+      },
+      sleeper: ->(*) { },
+      clock: -> { now }
+    )
+
+    error = assert_raises(Registry::Error) { registry.check(VERSION, DIGEST, budget: 1) }
+    assert_match(/monotonic budget/, error.message)
+  end
+
+  def test_expired_deadline_does_not_spawn_an_orphan_worker
+    clock_calls = 0
+    clock = lambda do
+      clock_calls += 1
+      clock_calls == 1 ? 0.0 : 2.0
+    end
+    deadline = Registry::Deadline.new(clock, 1)
+    before = Thread.list
+    ran = false
+
+    assert_raises(Registry::Error) { deadline.run { ran = true } }
+    assert_equal false, ran
+    assert_empty Thread.list - before
+  end
+
+  def test_deadline_cleans_a_worker_if_expiry_is_observed_after_spawn
+    clock_calls = 0
+    clock = lambda do
+      clock_calls += 1
+      clock_calls <= 2 ? 0.0 : 2.0
+    end
+    deadline = Registry::Deadline.new(clock, 1)
+    before = Thread.list
+    gate = Queue.new
+
+    assert_raises(Registry::Error) { deadline.run { gate.pop } }
+    assert_empty Thread.list - before
+  end
+
   # --- confirm: bounded poll, then canonical-bytes verification -------------
 
   def test_confirm_polls_through_404_then_verifies_canonical_bytes
@@ -129,7 +244,7 @@ class RegistryTest < Minitest::Test
   def test_confirm_times_out_when_version_never_appears
     registry = scripted([ res(404) ] * 10)
     error = assert_raises(Registry::Error) { registry.confirm(VERSION, DIGEST, deadline: 12) }
-    assert_match(/gave up waiting/, error.message)
+    assert_match(/monotonic budget/, error.message)
   end
 
   def test_confirm_fails_immediately_on_different_published_sha
@@ -212,19 +327,18 @@ class RegistryTest < Minitest::Test
     assert_match(/does not match registry-reported/, error.message)
   end
 
-  def test_verified_download_follows_https_redirects
+  def test_verified_download_rejects_cross_origin_https_redirects
     registry = scripted(
       res(200, version_json),
-      res(302, "", location: "https://cdn.example/surfguard-0.1.0.gem"),
-      res(200, BYTES)
+      res(302, "", location: "https://cdn.example/surfguard-0.1.0.gem")
     )
-    assert_equal [ BYTES, DIGEST ], registry.verified_download(VERSION)
-    assert_equal "https://cdn.example/surfguard-0.1.0.gem", @requests.last
+    error = assert_raises(Registry::Error) { registry.verified_download(VERSION) }
+    assert_match(/exact https:\/\/rubygems\.org:443 origin/, error.message)
   end
 
   def test_verified_download_bounds_redirects
     hops = [ res(200, version_json) ]
-    (Registry::MAX_REDIRECTS + 1).times { hops << res(301, "", location: "https://cdn.example/hop") }
+    (Registry::MAX_REDIRECTS + 1).times { hops << res(301, "", location: "https://rubygems.org/hop") }
     registry = scripted(hops)
     error = assert_raises(Registry::Error) { registry.verified_download(VERSION) }
     assert_match(/too many redirects/, error.message)
@@ -240,14 +354,12 @@ class RegistryTest < Minitest::Test
     assert_equal "https://rubygems.org/downloads/surfguard-0.1.0.gem", @requests.last
   end
 
-  def test_verified_download_resolves_scheme_relative_redirects_as_https
+  def test_verified_download_rejects_cross_origin_scheme_relative_redirects
     registry = scripted(
       res(200, version_json),
-      res(302, "", location: "//cdn.example/surfguard-0.1.0.gem"),
-      res(200, BYTES)
+      res(302, "", location: "//cdn.example/surfguard-0.1.0.gem")
     )
-    assert_equal [ BYTES, DIGEST ], registry.verified_download(VERSION)
-    assert_equal "https://cdn.example/surfguard-0.1.0.gem", @requests.last
+    assert_raises(Registry::Error) { registry.verified_download(VERSION) }
   end
 
   def test_verified_download_rejects_unparseable_redirect_location
@@ -269,12 +381,228 @@ class RegistryTest < Minitest::Test
   def test_verified_download_rejects_non_https_redirect
     registry = scripted(res(200, version_json), res(302, "", location: "http://cdn.example/gem"))
     error = assert_raises(Registry::Error) { registry.verified_download(VERSION) }
-    assert_match(/non-https/, error.message)
+    assert_match(/exact https:\/\/rubygems\.org:443 origin/, error.message)
+  end
+
+  def test_verified_download_rejects_userinfo_fragment_and_alternate_port_redirects
+    [
+      "https://user@rubygems.org/gem",
+      "https://rubygems.org/gem#fragment",
+      "https://rubygems.org:444/gem"
+    ].each do |location|
+      registry = scripted(res(200, version_json), res(302, "", location: location))
+      assert_raises(Registry::Error) { registry.verified_download(VERSION) }
+    end
+  end
+
+  def test_gem_body_limit_is_enforced
+    registry = scripted(res(200, version_json), res(200, "x" * (Registry::GEM_LIMIT + 1)))
+    assert_raises(Registry::Error) { registry.verified_download(VERSION) }
   end
 
   def test_verified_download_fails_closed_on_unexpected_download_status
     registry = scripted(res(200, version_json), res(403))
     assert_raises(Registry::Error) { registry.verified_download(VERSION) }
+  end
+
+  # --- live Net::HTTP adapter -------------------------------------------------
+
+  def test_live_adapter_disables_proxies_pins_the_ip_and_preserves_tls_identity
+    response = live_response(200, version_json)
+    registry, trace = live_registry(response)
+
+    assert_equal :skip, registry.check(VERSION, DIGEST)
+    assert_equal 1, trace[:resolver_calls]
+    assert_equal [ [ "rubygems.org", 443, nil ] ], trace[:new_arguments]
+    client = trace[:clients].fetch(0)
+    assert_equal true, client.use_ssl
+    assert_equal OpenSSL::SSL::VERIFY_PEER, client.verify_mode
+    assert_equal true, client.verify_hostname
+    assert_equal "93.184.216.34", client.ipaddr
+    request = client.requests.fetch(0)
+    assert_equal "rubygems.org", request["Host"]
+    assert_equal "identity", request["Accept-Encoding"]
+  end
+
+  def test_live_adapter_caches_only_fully_validated_strict_dns_answers
+    responses = [ live_response(404, ""), live_response(404, "") ]
+    registry, trace = live_registry(*responses)
+
+    2.times { assert_equal :push, registry.check(VERSION, DIGEST) }
+    assert_equal 1, trace[:resolver_calls]
+
+    [ [ "127.0.0.1" ], [ "93.184.216.34/24" ], [ "not-an-address" ], [] ].each do |answers|
+      blocked, blocked_trace = live_registry(live_response(404, ""), answers: answers)
+      assert_raises(Registry::Error) { blocked.check(VERSION, DIGEST) }
+      assert_empty blocked_trace[:clients]
+    end
+  end
+
+  def test_live_adapter_owns_cached_dns_answer_strings
+    answer = +"93.184.216.34"
+    registry, trace = live_registry(live_response(404, ""), live_response(404, ""), answers: [ answer ])
+
+    assert_equal :push, registry.check(VERSION, DIGEST)
+    answer.replace("127.0.0.1")
+    assert_equal :push, registry.check(VERSION, DIGEST)
+    assert_equal 1, trace[:resolver_calls]
+    assert_equal [ "93.184.216.34", "93.184.216.34" ], trace[:clients].map(&:ipaddr)
+  end
+
+  def test_live_adapter_rejects_lazy_answer_collections_without_enumerating_them
+    enumerated = false
+    answers = Enumerator.new do |yielder|
+      enumerated = true
+      yielder << "93.184.216.34"
+    end
+    registry, trace = live_registry(live_response(404, ""), answers: answers)
+
+    error = assert_raises(Registry::Error) { registry.check(VERSION, DIGEST) }
+    assert_match(/invalid answer collection/, error.message)
+    refute enumerated
+    assert_empty trace[:clients]
+  end
+
+  def test_live_adapter_uses_a_trusted_answer_type_predicate
+    coerced = false
+    answer = Object.new
+    answer.define_singleton_method(:is_a?) { |_klass| true }
+    answer.define_singleton_method(:instance_of?) { |_klass| true }
+    answer.define_singleton_method(:to_str) do
+      coerced = true
+      "93.184.216.34"
+    end
+    registry, trace = live_registry(live_response(404, ""), answers: [ answer ])
+
+    error = assert_raises(Registry::Error) { registry.check(VERSION, DIGEST) }
+    assert_match(/malformed address/, error.message)
+    refute coerced
+    assert_empty trace[:clients]
+  end
+
+  def test_live_adapter_copies_real_arrays_and_strings_through_trusted_core_methods
+    hooks = []
+    answer = +"93.184.216.34"
+    answer.define_singleton_method(:is_a?) { |_klass| false }
+    answer.define_singleton_method(:instance_of?) { |_klass| false }
+    answer.define_singleton_method(:valid_encoding?) do
+      hooks << :answer_validation
+      raise "resolver-owned string hook must not run"
+    end
+    answers = [ answer ]
+    answers.define_singleton_method(:dup) do
+      hooks << :array_dup
+      raise "resolver-owned array hook must not run"
+    end
+    answers.define_singleton_method(:[]) do |*_arguments|
+      hooks << :array_slice
+      raise "resolver-owned array hook must not run"
+    end
+    answers.define_singleton_method(:each) do |*_arguments|
+      hooks << :array_each
+      raise "resolver-owned array hook must not run"
+    end
+    registry, trace = live_registry(live_response(404, ""), answers: answers)
+
+    assert_equal :push, registry.check(VERSION, DIGEST)
+    assert_empty hooks
+    assert_equal [ "93.184.216.34" ], trace[:clients].map(&:ipaddr)
+  end
+
+  def test_live_adapter_rechecks_the_deadline_after_dns_and_each_chunk
+    now = 0.0
+    registry, trace = live_registry(live_response(404, ""), now: -> { now }, resolver_hook: -> { now = 2.0 })
+    assert_raises(Registry::Error) { registry.check(VERSION, DIGEST, budget: 1) }
+    assert_empty trace[:clients]
+
+    now = 0.0
+    response = live_response(200, version_json, before_chunk: -> { now = 2.0 })
+    registry, = live_registry(response, now: -> { now })
+    error = assert_raises(Registry::Error) { registry.check(VERSION, DIGEST, budget: 1) }
+    assert_match(/monotonic budget/, error.message)
+  end
+
+  def test_live_adapter_rechecks_the_deadline_before_trying_another_address
+    now = 0.0
+    first_address = lambda do
+      now = 2.0
+      raise SocketError, "first address failed"
+    end
+    registry, trace = live_registry(first_address, live_response(404, ""),
+      answers: [ "93.184.216.34", "8.8.8.8" ], now: -> { now })
+
+    error = assert_raises(Registry::Error) { registry.check(VERSION, DIGEST, budget: 1) }
+    assert_match(/monotonic budget/, error.message)
+    assert_equal 1, trace[:clients].size
+  end
+
+  def test_live_adapter_rechecks_the_deadline_while_validating_each_answer
+    clock_calls = 0
+    cutoff = 24
+    clock = lambda do
+      clock_calls += 1
+      clock_calls >= cutoff ? 2.0 : 0.0
+    end
+    answers = Array.new(Surfguard::MAX_ADDRESSES, "93.184.216.34")
+    registry, trace = live_registry(live_response(404, ""), answers: answers, now: clock)
+
+    error = assert_raises(Registry::Error) { registry.check(VERSION, DIGEST, budget: 1) }
+    assert_match(/monotonic budget/, error.message)
+    assert_operator clock_calls, :>=, cutoff
+    assert_empty trace[:clients]
+  end
+
+  def test_live_adapter_rejects_encoded_ambiguous_and_length_mismatched_responses
+    cases = [
+      FakeNetResponse.new(200, [ version_json ], { "content-encoding" => "gzip" }),
+      FakeNetResponse.new(200, [ version_json ], {
+        "content-length" => version_json.bytesize.to_s, "transfer-encoding" => "chunked"
+      }),
+      FakeNetResponse.new(200, [ version_json ], { "content-length" => (version_json.bytesize + 1).to_s })
+    ]
+    cases.each do |response|
+      registry, = live_registry(response)
+      assert_raises(Registry::Error) { registry.check(VERSION, DIGEST) }
+    end
+  end
+
+  def test_live_adapter_streams_gem_chunks_to_the_atomic_mode_0600_destination
+    metadata = live_response(200, version_json)
+    gem = FakeNetResponse.new(200, [ "canonical ", "gem bytes" ], { "content-length" => BYTES.bytesize.to_s })
+    registry, trace = live_registry(metadata, gem)
+
+    Dir.mktmpdir do |dir|
+      destination = File.join(dir, "canonical.gem")
+      assert_equal DIGEST, registry.verified_download_to(VERSION, destination)
+      assert_equal BYTES, File.binread(destination)
+      assert_equal 0o600, File.stat(destination).mode & 0o777
+      assert_empty Dir.children(dir).grep(/\.tmp\z/)
+    end
+    assert_equal 1, trace[:resolver_calls]
+    assert_equal 2, trace[:clients].size
+  end
+
+  def test_streaming_retry_discards_partial_bytes_before_trying_again
+    now = 0.0
+    steps = [
+      res(200, version_json),
+      lambda { |_uri, _deadline, _limit, sink|
+        sink.write("partial")
+        raise Net::ReadTimeout
+      },
+      res(200, BYTES)
+    ]
+    http = lambda do |uri, deadline, limit, sink|
+      step = steps.shift
+      step.respond_to?(:call) ? step.call(uri, deadline, limit, sink) : step
+    end
+    registry = Registry.new(NAME, http: http, sleeper: ->(seconds) { now += seconds }, clock: -> { now })
+
+    Dir.mktmpdir do |dir|
+      destination = File.join(dir, "retry.gem")
+      assert_equal DIGEST, registry.verified_download_to(VERSION, destination)
+      assert_equal BYTES, File.binread(destination)
+    end
   end
 
   # --- CLI entry points ------------------------------------------------------
@@ -368,7 +696,378 @@ class RegistryTest < Minitest::Test
     end
   end
 
+  def test_atomic_download_refuses_existing_destination_without_overwriting
+    registry = scripted(res(200, version_json), res(200, BYTES))
+    out, err = capture
+    Dir.mktmpdir do |dir|
+      destination = File.join(dir, "existing.gem")
+      File.write(destination, "keep")
+      status = Registry.run_download([ NAME, VERSION, destination ], out: out, err: err,
+        registry_for: for_name(registry))
+      assert_equal 1, status
+      assert_equal "keep", File.read(destination)
+    end
+  end
+
+  def test_atomic_download_refuses_symlink_parent
+    registry = scripted(res(200, version_json), res(200, BYTES))
+    out, err = capture
+    Dir.mktmpdir do |dir|
+      real = File.join(dir, "real")
+      link = File.join(dir, "link")
+      Dir.mkdir(real)
+      File.symlink(real, link)
+      status = Registry.run_download([ NAME, VERSION, File.join(link, "new.gem") ], out: out, err: err,
+        registry_for: for_name(registry))
+      assert_equal 1, status
+      refute_path_exists File.join(real, "new.gem")
+    end
+  end
+
+  def test_atomic_download_rolls_back_if_the_verified_temp_changes_before_link
+    registry = scripted(res(200, version_json), res(200, BYTES))
+    original_link = File.method(:link)
+    replacement = "X" * BYTES.bytesize
+    replace_before_link = lambda do |source, target|
+      File.binwrite(source, replacement)
+      File.chmod(0o600, source)
+      original_link.call(source, target)
+    end
+
+    Dir.mktmpdir do |dir|
+      destination = File.join(dir, "changed.gem")
+      error = with_file_link_stub(replace_before_link) do
+        assert_raises(Registry::Error) { registry.verified_download_to(VERSION, destination) }
+      end
+      assert_match(/published download digest changed/, error.message)
+      refute_path_exists destination
+      assert_empty Dir.children(dir)
+    end
+  end
+
+  def test_atomic_download_rolls_back_if_link_finishes_after_the_deadline
+    now = 0.0
+    responses = [ res(200, version_json), res(200, BYTES) ]
+    registry = Registry.new(NAME, http: ->(_uri) { responses.shift }, sleeper: ->(*) { }, clock: -> { now })
+    original_link = File.method(:link)
+    expire_after_link = lambda do |source, target|
+      result = original_link.call(source, target)
+      now = 2.0
+      result
+    end
+
+    Dir.mktmpdir do |dir|
+      destination = File.join(dir, "expired.gem")
+      error = with_file_link_stub(expire_after_link) do
+        assert_raises(Registry::Error) { registry.verified_download_to(VERSION, destination, budget: 1) }
+      end
+      assert_match(/monotonic budget/, error.message)
+      refute_path_exists destination
+      assert_empty Dir.children(dir)
+    end
+  end
+
+  def test_confirm_can_atomically_save_the_canonical_registry_gem
+    registry = scripted(res(200, version_json), res(200, version_json), res(200, BYTES))
+    out, err = capture
+    Dir.mktmpdir do |dir|
+      destination = File.join(dir, "canonical.gem")
+      status = Registry.run_confirm([ NAME, VERSION, DIGEST, destination, "60" ], out: out, err: err,
+        registry_for: for_name(registry))
+      assert_equal 0, status
+      assert_equal BYTES, File.binread(destination)
+      assert_equal 0o600, File.stat(destination).mode & 0o777
+    end
+  end
+
+  def test_streamed_confirmation_never_publishes_unverified_partial_or_wrong_bytes
+    registry = scripted(res(200, version_json), res(200, version_json), res(200, "tampered"))
+    Dir.mktmpdir do |dir|
+      destination = File.join(dir, "canonical.gem")
+      assert_raises(Registry::Error) { registry.confirm_to(VERSION, DIGEST, destination) }
+      refute_path_exists destination
+      assert_empty Dir.children(dir)
+    end
+  end
+
+  def test_budget_must_be_within_one_and_six_hundred_seconds
+    [ 0, 601, "not-a-number" ].each do |budget|
+      assert_raises(Registry::Error) { scripted.check(VERSION, DIGEST, budget: budget) }
+    end
+  end
+
+  def test_deadline_watchdog_kills_a_worker_that_does_not_finish
+    deadline = Registry::Deadline.new(-> { Process.clock_gettime(Process::CLOCK_MONOTONIC) }, 0.01)
+
+    error = assert_raises(Registry::Error) { deadline.run { sleep 1 } }
+    assert_match(/monotonic budget/, error.message)
+  end
+
+  def test_digesting_sink_checks_types_limits_progress_and_optional_deadline
+    output = StringIO.new
+    sink = Registry::DigestingSink.new(output, 3)
+    assert_equal 1, sink.write("a")
+    assert_equal Digest::SHA256.hexdigest("a"), sink.hexdigest
+    assert_raises(Registry::Error) { sink.write(Object.new) }
+    assert_raises(Registry::Error) { sink.write("too long") }
+
+    stalled = Object.new
+    stalled.define_singleton_method(:write) { |_bytes| 0 }
+    sink = Registry::DigestingSink.new(stalled, 3)
+    assert_match(/made no progress/, assert_raises(Registry::Error) { sink.write("a") }.message)
+  end
+
+  def test_live_adapter_bounds_raw_answers_and_exhausts_network_addresses_without_a_sink
+    too_many, = live_registry(live_response(404, ""),
+      answers: Array.new(Surfguard::MAX_ADDRESSES + 1, "93.184.216.34"))
+    assert_match(/too many addresses/, assert_raises(Registry::Error) {
+      too_many.check(VERSION, DIGEST)
+    }.message)
+
+    queue = [ SocketError.new("network failed") ]
+    http_class = Class.new
+    http_class.define_singleton_method(:new) { |*| FakeHTTPClient.new(queue) }
+    adapter = Registry::LiveHTTP.new(resolver: ->(_host) { [ "93.184.216.34" ] }, http_class: http_class)
+    deadline = Registry::Deadline.new(-> { 0.0 }, 300)
+    error = assert_raises(SocketError) do
+      adapter.call(URI(VERSION_URL), deadline, Registry::METADATA_LIMIT, nil)
+    end
+    assert_match(/network failed/, error.message)
+
+    file = StringIO.new
+    sink = Registry::DigestingSink.new(file, 100)
+    sink.write("partial")
+    queue = [ SocketError.new("reset me") ]
+    adapter = Registry::LiveHTTP.new(resolver: ->(_host) { [ "93.184.216.34" ] }, http_class: http_class)
+    assert_raises(SocketError) { adapter.call(URI(VERSION_URL), deadline, Registry::METADATA_LIMIT, sink) }
+    assert_equal 0, sink.bytesize
+
+    resolver = ->(_host) { raise Resolv::ResolvError }
+    adapter = Registry::LiveHTTP.new(resolver: resolver, http_class: http_class)
+    assert_match(/resolution failed/, assert_raises(SocketError) {
+      adapter.send(:addresses_for, "rubygems.org", deadline)
+    }.message)
+  end
+
+  def test_live_adapter_supports_clients_without_verify_hostname_writer_and_bounds_streams
+    response = live_response(404, "")
+    queue = [ response ]
+    client_class = Class.new(FakeHTTPClient) { undef_method :verify_hostname= }
+    http_class = Class.new
+    http_class.define_singleton_method(:new) { |*| client_class.new(queue) }
+    adapter = Registry::LiveHTTP.new(resolver: ->(_host) { [ "93.184.216.34" ] }, http_class: http_class)
+    registry = Registry.new(NAME, http: adapter.method(:call), sleeper: ->(*) { }, clock: -> { 0.0 })
+    assert_equal :push, registry.check(VERSION, DIGEST)
+
+    oversized = FakeNetResponse.new(200, [ "x" * 11 ], {})
+    queue = [ oversized ]
+    adapter = Registry::LiveHTTP.new(resolver: ->(_host) { [ "93.184.216.34" ] }, http_class: http_class)
+    deadline = Registry::Deadline.new(-> { 0.0 }, 300)
+    assert_match(/response exceeds/, assert_raises(Registry::Error) {
+      adapter.call(URI(VERSION_URL), deadline, 10, nil)
+    }.message)
+  end
+
+  def test_live_factory_builds_monotonic_clock_and_sleeper
+    registry = Registry.live(NAME)
+    assert_kind_of Numeric, registry.instance_variable_get(:@clock).call
+    assert_equal 0, registry.instance_variable_get(:@sleeper).call(0)
+    assert_instance_of Registry::LiveHTTP, registry.instance_variable_get(:@http).receiver
+  end
+
+  def test_atomic_target_rejects_empty_bad_parent_and_both_collision_phases
+    [ nil, "" ].each do |destination|
+      assert_match(/destination is empty/, assert_raises(Registry::Error) {
+        Registry.atomic_publish(destination, "bytes")
+      }.message)
+    end
+
+    missing = File.join(Dir.tmpdir, "surfguard-missing-parent-#{Process.pid}", "artifact.gem")
+    refute_path_exists File.dirname(missing)
+    assert_match(/atomic publication failed/, assert_raises(Registry::Error) {
+      Registry.atomic_publish(missing, "bytes")
+    }.message)
+
+    Dir.mktmpdir do |directory|
+      parent_file = File.join(directory, "parent-file")
+      File.binwrite(parent_file, "not a directory")
+      destination = File.join(parent_file, "artifact.gem")
+      assert_match(/not a directory/, assert_raises(Registry::Error) {
+        Registry.atomic_publish(destination, "bytes")
+      }.message)
+    end
+
+    Dir.mktmpdir do |directory|
+      destination = File.join(directory, "artifact.gem")
+      temporary = File.join(directory, ".artifact.gem.fixed.tmp")
+      File.binwrite(temporary, "occupied")
+      with_singleton_method(SecureRandom, :hex, ->(_length) { "fixed" }) do
+        assert_match(/temporary path collision/, assert_raises(Registry::Error) {
+          Registry.atomic_publish(destination, "bytes")
+        }.message)
+      end
+    end
+
+    Dir.mktmpdir do |directory|
+      destination = File.join(directory, "artifact.gem")
+      with_singleton_method(File, :link, ->(*) { raise Errno::EEXIST }) do
+        assert_match(/destination already exists/, assert_raises(Registry::Error) {
+          Registry.atomic_publish(destination, "bytes")
+        }.message)
+      end
+      assert_empty Dir.children(directory)
+    end
+  end
+
+  def test_atomic_identity_helpers_reject_changed_parent_file_mode_size_digest_and_open_identity
+    Dir.mktmpdir do |directory|
+      other = Dir.mktmpdir
+      assert_match(/parent changed/, assert_raises(Registry::Error) {
+        Registry.send(:verify_parent_identity!, directory, File.stat(other), nil)
+      }.message)
+
+      path = File.join(directory, "artifact.gem")
+      File.binwrite(path, BYTES)
+      File.chmod(0o600, path)
+      other_path = File.join(directory, "other.gem")
+      File.binwrite(other_path, BYTES)
+      File.chmod(0o600, other_path)
+      assert_raises(Registry::Error) do
+        Registry.send(:verify_regular_identity!, path, File.stat(other_path), nil, message: "identity failed")
+      end
+      assert_match(/size changed/, assert_raises(Registry::Error) {
+        Registry.send(:verify_linked_target!, path, File.stat(path), BYTES.bytesize + 1, DIGEST, nil)
+      }.message)
+      assert_match(/digest changed/, assert_raises(Registry::Error) {
+        Registry.send(:verify_linked_target!, path, File.stat(path), BYTES.bytesize, OTHER_SHA, nil)
+      }.message)
+      assert_match(/changed while opening/, assert_raises(Registry::Error) {
+        Registry.send(:digest_regular_file, path, File.stat(other_path), nil)
+      }.message)
+    ensure
+      FileUtils.remove_entry(other) if other && File.directory?(other)
+    end
+  end
+
+  def test_digest_reader_enforces_limit_and_safe_unlink_requires_exact_identity
+    identity = Struct.new(:dev, :ino).new(1, 2)
+    identity.define_singleton_method(:file?) { true }
+    fake = Object.new
+    fake.define_singleton_method(:stat) { identity }
+    chunks = [ "x" * (Registry::GEM_LIMIT + 1), nil ]
+    fake.define_singleton_method(:read) { |_length| chunks.shift }
+    with_singleton_method(File, :open, ->(_path, _flags, &block) { block.call(fake) }) do
+      assert_match(/exceeds/, assert_raises(Registry::Error) {
+        Registry.send(:digest_regular_file, "fake", identity, nil)
+      }.message)
+    end
+
+    Dir.mktmpdir do |directory|
+      path = File.join(directory, "artifact")
+      File.binwrite(path, "bytes")
+      assert_nil Registry.send(:safe_unlink_expected, path, nil)
+      assert_nil Registry.send(:safe_unlink_expected, path, File.stat(directory))
+      assert_path_exists path
+    end
+  end
+
+  def test_constructor_nested_budget_version_and_http_response_guards
+    assert_raises(Registry::Error) do
+      Registry.new("Invalid.Name", http: ->(*) { }, sleeper: ->(*) { }, clock: -> { 0.0 })
+    end
+
+    registry = scripted(res(404))
+    active = Registry::Deadline.new(-> { 0.0 }, 300)
+    registry.instance_variable_set(:@deadline, active)
+    assert_equal :nested, registry.send(:within_budget, 1) { :nested }
+    registry.instance_variable_set(:@deadline, nil)
+    assert_raises(Registry::Error) { registry.check("01.0.0", DIGEST) }
+
+    two_argument_http = ->(_uri, remaining) {
+      assert_operator remaining, :>, 0
+      res(404)
+    }
+    registry = Registry.new(NAME, http: two_argument_http, sleeper: ->(*) { }, clock: -> { 0.0 })
+    assert_equal :push, registry.check(VERSION, DIGEST)
+
+    [
+      Object.new,
+      res(200, Object.new),
+      Registry::Response.new(404, "", nil, nil, -1),
+      Registry::Response.new("not-an-integer", "", nil)
+    ].each do |response|
+      registry = Registry.new(NAME, http: ->(*) { response }, sleeper: ->(*) { }, clock: -> { 0.0 })
+      assert_raises(Registry::Error) { registry.check(VERSION, DIGEST) }
+    end
+  end
+
+  def test_verified_download_in_memory_detects_oversize_and_post_verification_change
+    registry = Registry.new(NAME, http: ->(*) { }, sleeper: ->(*) { }, clock: -> { 0.0 })
+    registry.define_singleton_method(:stream_verified_download) do |_version, destination, required_sha: nil|
+      File.binwrite(destination, "x" * (Registry::GEM_LIMIT + 1))
+      required_sha || DIGEST
+    end
+    assert_match(/exceeds/, assert_raises(Registry::Error) {
+      registry.verified_download(VERSION)
+    }.message)
+
+    registry.define_singleton_method(:stream_verified_download) do |_version, destination, required_sha: nil|
+      File.binwrite(destination, "changed")
+      required_sha || DIGEST
+    end
+    assert_match(/changed after verification/, assert_raises(Registry::Error) {
+      registry.verified_download(VERSION)
+    }.message)
+  end
+
+  def test_cli_argument_type_guards_fail_closed
+    out, err = capture
+    assert_equal 2, Registry.run_check([ NAME, VERSION, DIGEST, nil ], out: out, err: err)
+    assert_equal 2, Registry.run_download([ NAME, VERSION, "x.gem", nil ], out: out, err: err)
+    assert_equal 2, Registry.run_confirm([ NAME, VERSION, DIGEST, Object.new ], out: out, err: err)
+  end
+
   private
+    def with_singleton_method(object, name, replacement)
+      original = object.method(name)
+      object.define_singleton_method(name, replacement)
+      yield
+    ensure
+      object.define_singleton_method(name, original)
+    end
+
+    def with_file_link_stub(replacement)
+      singleton = File.singleton_class
+      original = File.method(:link)
+      singleton.send(:define_method, :link, replacement)
+      yield
+    ensure
+      singleton&.send(:define_method, :link, original) if original
+    end
+
+    def live_response(status, body, before_chunk: nil)
+      FakeNetResponse.new(status, [ body ], { "content-length" => body.bytesize.to_s },
+        before_chunk: before_chunk)
+    end
+
+    def live_registry(*responses, answers: [ "93.184.216.34" ], now: -> { 0.0 }, resolver_hook: nil)
+      queue = responses.dup
+      trace = { resolver_calls: 0, new_arguments: [], clients: [] }
+      http_class = Class.new
+      http_class.define_singleton_method(:new) do |*arguments|
+        trace[:new_arguments] << arguments
+        FakeHTTPClient.new(queue).tap { |client| trace[:clients] << client }
+      end
+      resolver = lambda do |_host|
+        trace[:resolver_calls] += 1
+        resolver_hook&.call
+        answers
+      end
+      adapter = Registry::LiveHTTP.new(resolver: resolver, http_class: http_class)
+      registry = Registry.new(NAME, http: adapter.method(:call), sleeper: ->(*) { }, clock: now)
+      [ registry, trace ]
+    end
+
     # Build a registry whose HTTP layer replays exactly these steps: a
     # Response is returned, an Exception is raised. Sleeps advance the fake
     # clock so deadline behavior is testable.


### PR DESCRIPTION
## Stack

3 of 5. Base: `security-hardening-02-package-assurance`. Next: `security-hardening-04-dependabot`.

## Summary

- Stream and bound RubyGems metadata and artifacts under one validated monotonic deadline.
- Disable proxies, enforce exact-origin HTTPS redirects, resolve with strict address policy, and pin TLS requests while retaining hostname identity.
- Publish downloads through mode-0600 same-directory temporary files with fsync, identity verification, atomic no-overwrite publication, and rollback on post-link failure.

## Verification

- Full registry state-machine, redirect, TLS/SNI, deadline, streaming, and adversarial atomic-write suite, 0 failures
- Loadable CLI entrypoint coverage and RuboCop

This is an intermediate hardening branch. Do not tag, publish, or dispatch release/recovery until the complete stack is merged.
