### PR TITLE
Constrain Dependabot auto-merge to verified lockfile updates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,11 +1,2 @@
-# Release- and security-sensitive paths require Jeremy's review. Deliberately
-# scoped — no `*` rule and no Gemfile.lock rule — so Dependabot's bundler
-# lockfile PRs don't deadlock on code-owner review. Tests remain gated by the
-# >= 1 approving review rule plus the required CI check.
-/.github/            @jeremy
-/lib/                @jeremy
-/Rakefile            @jeremy
-/surfguard.gemspec   @jeremy
-/Gemfile             @jeremy
-/RELEASING.md        @jeremy
-/script/release/     @jeremy
+* @jeremy
+/Gemfile.lock

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,14 +7,11 @@ updates:
       day: monday
       time: "06:00"
       timezone: America/Chicago
-    groups:
-      bundler:
-        patterns: [ "*" ]
     commit-message:
       prefix: "deps"
     labels: [ dependencies ]
     cooldown:
-      default-days: 10
+      default-days: 7
       semver-major-days: 7
       semver-minor-days: 3
       semver-patch-days: 2
@@ -34,4 +31,4 @@ updates:
     labels: [ dependencies, github-actions ]
     # github-actions supports only default-days (no semver-granular cooldown).
     cooldown:
-      default-days: 10
+      default-days: 7

--- a/.github/scripts/validate_dependabot_lockfile.rb
+++ b/.github/scripts/validate_dependabot_lockfile.rb
@@ -33,7 +33,9 @@ module Surfguard
       raise Error, "platform structure changed" unless base[:platforms] == head[:platforms]
       raise Error, "local path source changed" unless base[:path] == head[:path]
 
-      changed = base[:specs].keys.select { |name| base[:specs][name] != head[:specs][name] }
+      # Compare raw locked strings, not Gem::Version: equivalent respellings
+      # (1.0 vs 1.0.0) and platform flips must count as changes too.
+      changed = base[:specs].keys.select { |name| base[:raw_versions][name] != head[:raw_versions][name] }
       raise Error, "automatic update must change exactly one unambiguous dependency" unless changed.one?
 
       name = changed.first
@@ -123,11 +125,15 @@ module Surfguard
     def parse_specs(text)
       specs = {}
       raw_versions = {}
-      text.scan(/^    ([A-Za-z0-9_.-]+) \(([^ ()]+)(?:-[^ ()]+)?\)$/).each do |name, version|
+      # Bundler lockfile grammar: "name (version[-platform])", where the
+      # version never contains a dash (Gem::Version#to_s), so the platform is
+      # everything after the first dash. Raw versions keep the full inner
+      # string to match the CHECKSUMS spelling exactly.
+      text.scan(/^    ([A-Za-z0-9_.-]+) \((([^ ()-]+)(?:-[^ ()]+)?)\)$/).each do |name, raw, version|
         raise Error, "ambiguous duplicate dependency #{name}" if specs.key?(name)
 
         specs[name] = Gem::Version.new(version)
-        raw_versions[name] = version
+        raw_versions[name] = raw
       rescue ArgumentError
         raise Error, "invalid dependency version for #{name}"
       end
@@ -191,7 +197,10 @@ module Surfguard
     end
 
     def normalize(text)
-      text.lines.reject { |line| line.match?(/^CHECKSUMS\n|^  [A-Za-z0-9_.-]+ \([^\n]+\) sha256=/) }
+      # Omit checksum records only where they belong — the CHECKSUMS section —
+      # so checksum-shaped lines injected elsewhere still register as change.
+      text.sub(/^CHECKSUMS\n(?:  [A-Za-z0-9_.-]+ \([^\n]+\)(?: sha256=[0-9a-f]{64})?\n)*/, "")
+        .lines
         .map { |line| line.sub(/^(    [A-Za-z0-9_.-]+) \([^\n]+\)$/, '\1 (VERSION)') }
         .join
     end

--- a/.github/scripts/validate_dependabot_lockfile.rb
+++ b/.github/scripts/validate_dependabot_lockfile.rb
@@ -78,7 +78,7 @@ module Surfguard
       unless text.valid_encoding? && text.ascii_only? && !text.include?("\0")
         raise Error, "invalid lockfile encoding"
       end
-      if text.match?(/\A(?:GIT|PLUGIN)\n|\n(?:GIT|PLUGIN)\n/)
+      if text.match?(/(?:\A|\n)(?:GIT|PLUGIN)\n/)
         raise Error, "forbidden lockfile source section"
       end
       raise Error, "lockfile must contain exactly one GEM section" unless text.scan(/^GEM$/).one?

--- a/.github/scripts/validate_dependabot_lockfile.rb
+++ b/.github/scripts/validate_dependabot_lockfile.rb
@@ -39,6 +39,9 @@ module Surfguard
       raise Error, "automatic update must change exactly one unambiguous dependency" unless changed.one?
 
       name = changed.first
+      unless base[:spec_platforms][name] == head[:spec_platforms][name]
+        raise Error, "dependency platform changed"
+      end
       from = base[:specs].fetch(name)
       to = head[:specs].fetch(name)
       raise Error, "dependency did not increase" unless to > from
@@ -94,7 +97,7 @@ module Surfguard
         raise Error, "unexpected local path source"
       end
 
-      specs, raw_versions = parse_specs(gem_section)
+      specs, raw_versions, spec_platforms = parse_specs(gem_section)
       raise Error, "lockfile has no RubyGems specs" if specs.empty?
 
       dependencies = text[/^DEPENDENCIES\n(.*?)(?=\n[A-Z][A-Z ]+\n|\z)/m, 1]
@@ -112,6 +115,7 @@ module Surfguard
         text: text,
         specs: specs,
         raw_versions: raw_versions,
+        spec_platforms: spec_platforms,
         checksums: checksums,
         direct_dependencies: direct_dependencies,
         dependencies: dependencies,
@@ -125,19 +129,22 @@ module Surfguard
     def parse_specs(text)
       specs = {}
       raw_versions = {}
+      platforms = {}
       # Bundler lockfile grammar: "name (version[-platform])", where the
       # version never contains a dash (Gem::Version#to_s), so the platform is
       # everything after the first dash. Raw versions keep the full inner
-      # string to match the CHECKSUMS spelling exactly.
-      text.scan(/^    ([A-Za-z0-9_.-]+) \((([^ ()-]+)(?:-[^ ()]+)?)\)$/).each do |name, raw, version|
+      # string to match the CHECKSUMS spelling exactly; the platform is also
+      # tracked on its own so a version bump cannot smuggle a platform flip.
+      text.scan(/^    ([A-Za-z0-9_.-]+) \((([^ ()-]+)(?:-([^ ()]+))?)\)$/).each do |name, raw, version, platform|
         raise Error, "ambiguous duplicate dependency #{name}" if specs.key?(name)
 
         specs[name] = Gem::Version.new(version)
         raw_versions[name] = raw
+        platforms[name] = platform
       rescue ArgumentError
         raise Error, "invalid dependency version for #{name}"
       end
-      [ specs, raw_versions ]
+      [ specs, raw_versions, platforms ]
     end
 
     def parse_checksums(section)

--- a/.github/scripts/validate_dependabot_lockfile.rb
+++ b/.github/scripts/validate_dependabot_lockfile.rb
@@ -1,0 +1,207 @@
+# frozen_string_literal: true
+
+require "rubygems"
+
+module Surfguard
+  module DependabotLockfileValidator
+    class Error < StandardError; end
+
+    module_function
+
+    def run(argv, out: $stdout, err: $stderr)
+      unless argv.length == 4
+        err.puts "usage: validator BASE_LOCK HEAD_LOCK ECOSYSTEM UPDATE_TYPE"
+        return 2
+      end
+
+      out.puts validate(*argv)
+      0
+    rescue Error => error
+      err.puts error.message
+      1
+    end
+
+    def validate(base_path, head_path, ecosystem, expected_update)
+      raise Error, "ecosystem must be bundler" unless ecosystem == "bundler"
+
+      base = parse_lock(base_path)
+      head = parse_lock(head_path)
+      unless base[:specs].keys.sort == head[:specs].keys.sort
+        raise Error, "dependency identities were added or removed"
+      end
+      raise Error, "top-level dependency structure changed" unless base[:dependencies] == head[:dependencies]
+      raise Error, "platform structure changed" unless base[:platforms] == head[:platforms]
+      raise Error, "local path source changed" unless base[:path] == head[:path]
+
+      changed = base[:specs].keys.select { |name| base[:specs][name] != head[:specs][name] }
+      raise Error, "automatic update must change exactly one unambiguous dependency" unless changed.one?
+
+      name = changed.first
+      from = base[:specs].fetch(name)
+      to = head[:specs].fetch(name)
+      raise Error, "dependency did not increase" unless to > from
+      raise Error, "prerelease updates require human review" if from.prerelease? || to.prerelease?
+      unless from.segments.fetch(0, 0) == to.segments.fetch(0, 0)
+        raise Error, "major updates require human review"
+      end
+
+      verify_checksums(base, head, name)
+
+      actual_update = if from.segments.fetch(1, 0) == to.segments.fetch(1, 0)
+        "version-update:semver-patch"
+      else
+        "version-update:semver-minor"
+      end
+      unless expected_update == actual_update
+        raise Error, "metadata update type mismatch: #{expected_update} != #{actual_update}"
+      end
+
+      # Apart from versions and checksum records, the lockfile grammar must
+      # remain byte-identical. This rejects dependency-edge and structural changes.
+      unless normalize(base[:text]) == normalize(head[:text])
+        raise Error, "lockfile changed outside version/checksum records"
+      end
+      unless base[:direct_dependencies].include?(name)
+        raise Error, "transitive dependency updates require human review"
+      end
+
+      "validated bundler #{actual_update}: #{name} #{from} -> #{to}"
+    end
+
+    def parse_lock(path)
+      text = File.binread(path)
+      unless text.valid_encoding? && text.ascii_only? && !text.include?("\0")
+        raise Error, "invalid lockfile encoding"
+      end
+      if text.match?(/\A(?:GIT|PLUGIN)\n|\n(?:GIT|PLUGIN)\n/)
+        raise Error, "forbidden lockfile source section"
+      end
+      raise Error, "lockfile must contain exactly one GEM section" unless text.scan(/^GEM$/).one?
+      raise Error, "lockfile must contain exactly one PATH section" unless text.scan(/^PATH$/).one?
+      unless text.scan(/^CHECKSUMS$/).one?
+        raise Error, "lockfile must contain exactly one CHECKSUMS section"
+      end
+
+      gem_section = text[/^GEM\n(.*?)(?=\n[A-Z][A-Z ]+\n|\z)/m, 1]
+      remotes = gem_section.scan(/^  remote: (.+)$/).flatten
+      unless remotes == [ "https://rubygems.org/" ]
+        raise Error, "lockfile must use only canonical RubyGems HTTPS source"
+      end
+      path_section = text[/^PATH\n(.*?)(?=\n[A-Z][A-Z ]+\n|\z)/m, 1]
+      unless path_section.match?(/\A  remote: \.\n  specs:\n    surfguard \([^\n]+\)\n\z/)
+        raise Error, "unexpected local path source"
+      end
+
+      specs, raw_versions = parse_specs(gem_section)
+      raise Error, "lockfile has no RubyGems specs" if specs.empty?
+
+      dependencies = text[/^DEPENDENCIES\n(.*?)(?=\n[A-Z][A-Z ]+\n|\z)/m, 1]
+      platforms = text[/^PLATFORMS\n(.*?)(?=\n[A-Z][A-Z ]+\n|\z)/m, 1]
+      checksum_section = text[/^CHECKSUMS\n(.*?)(?=\n[A-Z][A-Z ]+\n|\z)/m, 1]
+      unless dependencies && platforms
+        raise Error, "missing structural section"
+      end
+
+      checksums = parse_checksums(checksum_section)
+      raise Error, "lockfile has no checksum records" if checksums.empty?
+      direct_dependencies = parse_direct_dependencies(dependencies)
+
+      {
+        text: text,
+        specs: specs,
+        raw_versions: raw_versions,
+        checksums: checksums,
+        direct_dependencies: direct_dependencies,
+        dependencies: dependencies,
+        platforms: platforms,
+        path: path_section
+      }
+    rescue SystemCallError => error
+      raise Error, "lockfile could not be read: #{error.message}"
+    end
+
+    def parse_specs(text)
+      specs = {}
+      raw_versions = {}
+      text.scan(/^    ([A-Za-z0-9_.-]+) \(([^ ()]+)(?:-[^ ()]+)?\)$/).each do |name, version|
+        raise Error, "ambiguous duplicate dependency #{name}" if specs.key?(name)
+
+        specs[name] = Gem::Version.new(version)
+        raw_versions[name] = version
+      rescue ArgumentError
+        raise Error, "invalid dependency version for #{name}"
+      end
+      [ specs, raw_versions ]
+    end
+
+    def parse_checksums(section)
+      checksums = {}
+      section.lines.each do |line|
+        next if line == "\n"
+
+        match = line.match(/\A  ([A-Za-z0-9_.-]+) \(([^ ()]+)\)(?: sha256=([0-9a-f]{64}))?\n?\z/)
+        raise Error, "malformed checksum record" unless match
+
+        name, version, digest = match.captures
+        key = [ name, version ]
+        raise Error, "ambiguous duplicate checksum #{name} #{version}" if checksums.key?(key)
+
+        checksums[key] = digest
+      end
+      checksums
+    end
+
+    def parse_direct_dependencies(section)
+      dependencies = section.lines.map do |line|
+        next if line == "\n"
+
+        match = line.match(/\A  ([A-Za-z0-9_.-]+)(?: \([^\n]+\))?(!)?\n?\z/)
+        raise Error, "malformed top-level dependency record" unless match
+
+        match[2] ? nil : match[1]
+      end.compact
+      unless dependencies.uniq == dependencies
+        raise Error, "ambiguous duplicate top-level dependency"
+      end
+
+      dependencies.freeze
+    end
+
+    def verify_checksums(base, head, name)
+      base_changed = base[:checksums].select { |(dependency, _version), _digest| dependency == name }
+      head_changed = head[:checksums].select { |(dependency, _version), _digest| dependency == name }
+      expected_base_key = [ name, base[:raw_versions].fetch(name) ]
+      expected_head_key = [ name, head[:raw_versions].fetch(name) ]
+      unless base_changed.keys == [ expected_base_key ]
+        raise Error, "changed dependency must have exactly one matching base checksum"
+      end
+      unless head_changed.keys == [ expected_head_key ]
+        raise Error, "changed dependency must have exactly one matching head checksum"
+      end
+      if (base_changed.values + head_changed.values).any?(&:nil?)
+        raise Error, "changed dependency checksum is missing"
+      end
+      if base_changed.values == head_changed.values
+        raise Error, "changed dependency checksum did not change"
+      end
+
+      base_unchanged = base[:checksums].reject { |(dependency, _version), _digest| dependency == name }
+      head_unchanged = head[:checksums].reject { |(dependency, _version), _digest| dependency == name }
+      raise Error, "unrelated checksum records changed" unless base_unchanged == head_unchanged
+    end
+
+    def normalize(text)
+      text.lines.reject { |line| line.match?(/^CHECKSUMS\n|^  [A-Za-z0-9_.-]+ \([^\n]+\) sha256=/) }
+        .map { |line| line.sub(/^(    [A-Za-z0-9_.-]+) \([^\n]+\)$/, '\1 (VERSION)') }
+        .join
+    end
+
+    def main(program_name: $PROGRAM_NAME, file: __FILE__, argv: ARGV)
+      return unless program_name == file
+
+      exit run(argv)
+    end
+  end
+end
+
+Surfguard::DependabotLockfileValidator.main

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -175,9 +175,15 @@ jobs:
 
           # Narrow the validate->approve window, then pin the approval itself
           # to the validated commit via the API (gh pr review has no
-          # head-binding flag). The merge is additionally pinned with
-          # --match-head-commit, and the revoke job below plus the
-          # dismiss-stale-reviews branch rule cover later head movement.
+          # head-binding flag). --auto defers the actual merge until required
+          # checks finish, so the merge boundary is enforced server-side at
+          # merge time, not by this script: --match-head-commit restricts the
+          # merge to exactly the validated head; the strict (up-to-date)
+          # required-status rule forces any base advance through a new head,
+          # which dismiss-stale-reviews strips of its approval and the revoke
+          # job strips of pending auto-merge. There is no merge queue, so no
+          # merge_group hook exists to revalidate in; these branch-rule gates
+          # are the merge-time revalidation.
           revalidate_current_pr "before approval"
           gh api --method POST "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
             -f commit_id="$EVENT_HEAD_SHA" \

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -21,10 +21,11 @@ concurrency:
 jobs:
   metadata:
     name: Dependabot metadata
-    if: github.actor == 'dependabot[bot]' && github.triggering_actor == 'dependabot[bot]' && github.event.pull_request.user.login == 'dependabot[bot]' && startsWith(github.event.pull_request.head.ref, 'dependabot/bundler/') # zizmor: ignore[bot-conditions] -- the actor checks are deliberately paired with the unspoofable pull_request.user.login check; actor + triggering_actor stop a human-triggered event from re-entering this path
+    if: github.actor == 'dependabot[bot]' && github.triggering_actor == 'dependabot[bot]' && github.event.pull_request.state == 'open' && github.event.pull_request.draft == false && github.event.pull_request.user.login == 'dependabot[bot]' && github.event.pull_request.base.repo.full_name == github.repository && github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.repo.full_name == github.repository && startsWith(github.event.pull_request.head.ref, 'dependabot/bundler/') # zizmor: ignore[bot-conditions] -- actor + triggering_actor are paired with GitHub-owned PR identity, protected-main base, and same-repository head checks; the privileged job repeats these checks through the API
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read # fetch-metadata only reads the PR
+    timeout-minutes: 10
     outputs:
       update-type: ${{ steps.metadata.outputs.update-type }}
       package-ecosystem: ${{ steps.metadata.outputs.package-ecosystem }}
@@ -51,8 +52,10 @@ jobs:
     permissions:
       contents: write # gh pr merge --auto needs the merge permission
       pull-requests: write # gh pr review --approve and auto-merge state
+    timeout-minutes: 10
     steps:
       - name: Re-validate the PR via the API (nothing checked out, nothing executed)
+        id: validation
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
@@ -60,6 +63,8 @@ jobs:
           EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           EVENT_ACTOR: ${{ github.actor }}
           EVENT_TRIGGERING_ACTOR: ${{ github.triggering_actor }}
+          METADATA_ECOSYSTEM: ${{ needs.metadata.outputs.package-ecosystem }}
+          METADATA_UPDATE_TYPE: ${{ needs.metadata.outputs.update-type }}
         run: |
           fail() { echo "::error::$1"; exit 1; }
 
@@ -67,11 +72,18 @@ jobs:
           [ "$EVENT_TRIGGERING_ACTOR" = "dependabot[bot]" ] || fail "triggering actor is ${EVENT_TRIGGERING_ACTOR}"
 
           pr="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}")"
+          state="$(jq -r .state <<<"$pr")"
+          draft="$(jq -r .draft <<<"$pr")"
           author="$(jq -r .user.login <<<"$pr")"
           head_ref="$(jq -r .head.ref <<<"$pr")"
           head_sha="$(jq -r .head.sha <<<"$pr")"
           head_repo="$(jq -r .head.repo.full_name <<<"$pr")"
+          base_ref="$(jq -r .base.ref <<<"$pr")"
+          base_sha="$(jq -r .base.sha <<<"$pr")"
+          base_repo="$(jq -r .base.repo.full_name <<<"$pr")"
 
+          [ "$state" = "open" ] || fail "PR state is ${state}"
+          [ "$draft" = "false" ] || fail "PR is a draft"
           [ "$author" = "dependabot[bot]" ] || fail "author is ${author}"
           case "$head_ref" in
             dependabot/bundler/*) ;;
@@ -79,28 +91,48 @@ jobs:
           esac
           # TOCTOU guard: the head we validated is the head we merge (also
           # enforced at merge time with --match-head-commit).
+          [[ "$head_sha" =~ ^[0-9a-f]{40}$ ]] || fail "head SHA is malformed"
+          [[ "$base_sha" =~ ^[0-9a-f]{40}$ ]] || fail "base SHA is malformed"
           [ "$head_sha" = "$EVENT_HEAD_SHA" ] || fail "head moved: ${head_sha} != ${EVENT_HEAD_SHA}"
           # The branch must live in this repo (Dependabot's own branch, which
           # maintainers control) — fork heads are never auto-merged.
           [ "$head_repo" = "$REPO" ] || fail "head repo is ${head_repo}"
+          # The validator is executable trusted-base code. Pin its authority to
+          # this repository's protected main branch, never an editable PR base.
+          [ "$base_repo" = "$REPO" ] || fail "base repo is ${base_repo}"
+          [ "$base_ref" = "main" ] || fail "base ref is ${base_ref}"
 
-          # Changed-file allowlist: a bundler update may touch only the
-          # Gemfile and its lock.
+          # Automatic changes are lockfile-only. Gemfile changes always need
+          # human review.
           files="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/files" --paginate --jq '.[].filename')"
           [ -n "$files" ] || fail "no changed files reported"
           while IFS= read -r file; do
             case "$file" in
-              Gemfile|Gemfile.lock) ;;
+              Gemfile.lock) ;;
               *) fail "unexpected changed file: ${file}" ;;
             esac
           done <<<"$files"
 
           # Every commit must be Dependabot's and signature-verified.
           commits="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/commits" --paginate --slurp | jq 'add')"
-          jq --exit-status 'length > 0' <<<"$commits" >/dev/null || fail "no commits"
-          jq --exit-status 'all(.[]; .author.login == "dependabot[bot]" and .commit.verification.verified == true)' <<<"$commits" >/dev/null \
+          jq --exit-status --arg sha "$head_sha" '
+            length > 0 and .[-1].sha == $sha and
+            all(.[]; .author.login == "dependabot[bot]" and .committer.login == "dependabot[bot]" and .commit.verification.verified == true)
+          ' <<<"$commits" >/dev/null \
             || fail "unverified or non-Dependabot commits present"
 
+          # Fetch the validator from the trusted base and both lockfiles at
+          # exact SHAs through the API. No PR code is checked out or executed.
+          fetch_file() {
+            path="$1"; sha="$2"; destination="$3"
+            gh api "repos/${REPO}/contents/${path}?ref=${sha}" --jq .content | tr -d '\n' | base64 --decode > "$destination"
+          }
+          fetch_file .github/scripts/validate_dependabot_lockfile.rb "$base_sha" validator.rb
+          fetch_file Gemfile.lock "$base_sha" base.lock
+          fetch_file Gemfile.lock "$head_sha" head.lock
+          ruby validator.rb base.lock head.lock "$METADATA_ECOSYSTEM" "$METADATA_UPDATE_TYPE"
+
+          echo "base_sha=${base_sha}" >> "$GITHUB_OUTPUT"
           echo "PR #${PR_NUMBER} re-validated at ${EVENT_HEAD_SHA}"
       - name: Approve at the validated head and enable auto-merge (squash)
         env:
@@ -109,21 +141,49 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_URL: ${{ github.event.pull_request.html_url }}
           EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          VALIDATED_BASE_SHA: ${{ steps.validation.outputs.base_sha }}
         run: |
+          fail() { echo "::error::$1"; exit 1; }
+
+          # This is called at both privilege boundaries. A stable head alone is
+          # insufficient: the PR must still be open/non-draft, authored by
+          # Dependabot, based on this repository's protected main branch, and
+          # composed entirely of current Dependabot-signed commits.
+          revalidate_current_pr() {
+            phase="$1"
+            pr="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}")"
+            jq --exit-status '
+                .state == "open" and .draft == false and
+                .user.login == "dependabot[bot]" and
+                (.head.ref | startswith("dependabot/bundler/"))
+              ' <<<"$pr" >/dev/null || fail "PR state or author changed ${phase}"
+            jq --exit-status \
+              --arg repo "$REPO" \
+              --arg head "$EVENT_HEAD_SHA" \
+              --arg base "$VALIDATED_BASE_SHA" '
+                .head.sha == $head and .head.repo.full_name == $repo and
+                .base.sha == $base and .base.ref == "main" and
+                .base.repo.full_name == $repo
+              ' <<<"$pr" >/dev/null || fail "PR base or head identity changed ${phase}"
+
+            commits="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/commits" --paginate --slurp | jq 'add')"
+            jq --exit-status --arg sha "$EVENT_HEAD_SHA" '
+              length > 0 and .[-1].sha == $sha and
+              all(.[]; .author.login == "dependabot[bot]" and .committer.login == "dependabot[bot]" and .commit.verification.verified == true)
+            ' <<<"$commits" >/dev/null || fail "commit identity or signature changed ${phase}"
+          }
+
           # Narrow the validate->approve window, then pin the approval itself
           # to the validated commit via the API (gh pr review has no
           # head-binding flag). The merge is additionally pinned with
           # --match-head-commit, and the revoke job below plus the
           # dismiss-stale-reviews branch rule cover later head movement.
-          current="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq .head.sha)"
-          if [ "$current" != "$EVENT_HEAD_SHA" ]; then
-            echo "::error::Head moved to ${current} after validation; refusing to approve"
-            exit 1
-          fi
+          revalidate_current_pr "before approval"
           gh api --method POST "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
             -f commit_id="$EVENT_HEAD_SHA" \
             -f event=APPROVE \
             -f body="Auto-approving a Dependabot bundler patch/minor update at ${EVENT_HEAD_SHA}. The required CI check still gates the merge."
+          revalidate_current_pr "before merge"
           gh pr merge "$PR_URL" --auto --squash --match-head-commit "$EVENT_HEAD_SHA"
 
   # Auto-merge enablement survives pushes by users with write access, and
@@ -137,6 +197,7 @@ jobs:
     permissions:
       contents: write # disabling auto-merge requires merge authority
       pull-requests: write # auto-merge state lives on the PR
+    timeout-minutes: 10
     steps:
       - name: Disable any pending auto-merge
         env:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -113,11 +113,13 @@ jobs:
             esac
           done <<<"$files"
 
-          # Every commit must be Dependabot's and signature-verified.
+          # Every commit must be authored by Dependabot, committed by GitHub's
+          # signer (web-flow — Dependabot commits are created and signed
+          # server-side), and signature-verified.
           commits="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/commits" --paginate --slurp | jq 'add')"
           jq --exit-status --arg sha "$head_sha" '
             length > 0 and .[-1].sha == $sha and
-            all(.[]; .author.login == "dependabot[bot]" and .committer.login == "dependabot[bot]" and .commit.verification.verified == true)
+            all(.[]; .author.login == "dependabot[bot]" and .committer.login == "web-flow" and .commit.verification.verified == true)
           ' <<<"$commits" >/dev/null \
             || fail "unverified or non-Dependabot commits present"
 
@@ -169,7 +171,7 @@ jobs:
             commits="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/commits" --paginate --slurp | jq 'add')"
             jq --exit-status --arg sha "$EVENT_HEAD_SHA" '
               length > 0 and .[-1].sha == $sha and
-              all(.[]; .author.login == "dependabot[bot]" and .committer.login == "dependabot[bot]" and .commit.verification.verified == true)
+              all(.[]; .author.login == "dependabot[bot]" and .committer.login == "web-flow" and .commit.verification.verified == true)
             ' <<<"$commits" >/dev/null || fail "commit identity or signature changed ${phase}"
           }
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -220,6 +220,8 @@ created through the API pinned to the validated head commit, the merge is
 pinned with `--match-head-commit`, and a human push to a Dependabot PR
 triggers a revoke job that disables any pending auto-merge (the
 dismiss-stale-reviews branch rule retracts the bot approval at the same
-time). CODEOWNERS is deliberately scoped (no `*` rule, no `Gemfile.lock`
-rule) so lockfile-only Dependabot PRs don't deadlock on code-owner review;
-the required `CI` check still gates every merge.
+time). CODEOWNERS pairs a blanket `* @jeremy` rule with an ownerless
+`/Gemfile.lock` override: every path requires code-owner review except the
+lockfile, so lockfile-only Dependabot PRs don't deadlock on code-owner
+review while any PR touching anything else stays human-gated; the required
+`CI` check still gates every merge.

--- a/test/release/dependabot_validator_test.rb
+++ b/test/release/dependabot_validator_test.rb
@@ -1,0 +1,292 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+require_relative "../../.github/scripts/validate_dependabot_lockfile"
+
+require "stringio"
+require "tempfile"
+
+class DependabotValidatorTest < Minitest::Test
+  VALIDATOR = File.expand_path("../../.github/scripts/validate_dependabot_lockfile.rb", __dir__)
+  LOCK = File.expand_path("../../Gemfile.lock", __dir__)
+  CHECK = Surfguard::DependabotLockfileValidator
+  Status = Data.define(:exitstatus) do
+    def success? = exitstatus.zero?
+  end
+
+  def validate(head, update = "version-update:semver-patch", ecosystem: "bundler")
+    validate_pair(File.binread(LOCK), head, update, ecosystem: ecosystem)
+  end
+
+  def validate_pair(base, head, update = "version-update:semver-patch", ecosystem: "bundler")
+    Tempfile.create("base.lock") do |base_file|
+      base_file.binmode
+      base_file.write(base)
+      base_file.flush
+      Tempfile.create("head.lock") do |file|
+        file.binmode
+        file.write(head)
+        file.flush
+        out = StringIO.new
+        err = StringIO.new
+        status = CHECK.run([ base_file.path, file.path, ecosystem, update ], out: out, err: err)
+        [ out.string, err.string, Status.new(status) ]
+      end
+    end
+  end
+
+  def updated(name, from, to)
+    File.read(LOCK).gsub("    #{name} (#{from})", "    #{name} (#{to})")
+      .gsub("  #{name} (#{from}) sha256=", "  #{name} (#{to}) sha256=")
+      .sub(/(  #{Regexp.escape(name)} \(#{Regexp.escape(to)}\) sha256=)[0-9a-f]{64}/, "\\1#{'a' * 64}")
+  end
+
+  def test_accepts_one_patch_and_independently_checks_update_type
+    _out, _err, status = validate(updated("rake", "13.4.2", "13.4.3"))
+    assert_predicate status, :success?
+  end
+
+  def test_accepts_one_minor_update
+    out, err, status = validate(updated("rake", "13.4.2", "13.5.0"), "version-update:semver-minor")
+
+    assert_predicate status, :success?, err
+    assert_match(/semver-minor/, out)
+  end
+
+  def test_rejects_major_prerelease_source_and_structural_changes
+    cases = [
+      updated("ast", "2.4.3", "3.0.0"),
+      updated("ast", "2.4.3", "2.4.4.rc1"),
+      updated("ast", "2.4.3", "2.4.4").sub("remote: https://rubygems.org/", "remote: http://rubygems.org/"),
+      updated("ast", "2.4.3", "2.4.4").sub("GEM\n", "GIT\n")
+    ]
+    cases.each do |head|
+      _out, _err, status = validate(head)
+      refute_predicate status, :success?
+    end
+  end
+
+  def test_rejects_grouped_or_transitive_changes_and_metadata_mismatch
+    grouped = updated("ast", "2.4.3", "2.4.4")
+      .gsub("    rainbow (3.1.1)", "    rainbow (3.1.2)")
+      .gsub("  rainbow (3.1.1) sha256=", "  rainbow (3.1.2) sha256=")
+    _out, _err, status = validate(grouped)
+    refute_predicate status, :success?
+
+    _out, _err, status = validate(updated("ast", "2.4.3", "2.4.4"), "version-update:semver-minor")
+    refute_predicate status, :success?
+  end
+
+  def test_rejects_stale_changed_checksum_and_unrelated_checksum_mutation
+    stale = File.read(LOCK).gsub("    ast (2.4.3)", "    ast (2.4.4)")
+    _out, err, status = validate(stale)
+    refute_predicate status, :success?
+    assert_match(/matching head checksum/, err)
+
+    unrelated = updated("ast", "2.4.3", "2.4.4")
+      .sub(/(  rack \(3\.2\.6\) sha256=)[0-9a-f]{64}/, "\\1#{'b' * 64}")
+    _out, err, status = validate(unrelated)
+    refute_predicate status, :success?
+    assert_match(/unrelated checksum/, err)
+  end
+
+  def test_rejects_duplicate_or_malformed_checksum_records
+    valid = updated("ast", "2.4.3", "2.4.4")
+    record = valid[/^  ast \(.+$/]
+    duplicate = valid.sub("\nBUNDLED WITH", "\n#{record}\nBUNDLED WITH")
+    _out, err, status = validate(duplicate)
+    refute_predicate status, :success?
+    assert_match(/checksum/, err)
+
+    malformed = updated("ast", "2.4.3", "2.4.4").sub(/sha256=[0-9a-f]{64}/, "sha256=xyz")
+    _out, err, status = validate(malformed)
+    refute_predicate status, :success?
+    assert_match(/checksum/, err)
+  end
+
+  def test_rejects_git_plugin_path_and_alternate_registry_sources
+    valid = updated("ast", "2.4.3", "2.4.4")
+    cases = [
+      [ "forbidden lockfile source", valid.sub("GEM\n", "GIT\n") ],
+      [ "forbidden lockfile source", valid.sub("GEM\n", "PLUGIN\n") ],
+      [ "unexpected local path", valid.sub("  remote: .\n", "  remote: ../attacker\n") ],
+      [ "canonical RubyGems", valid.sub("https://rubygems.org/", "https://gems.example/") ]
+    ]
+    cases.each do |message, head|
+      _out, err, status = validate(head)
+      refute_predicate status, :success?
+      assert_match(/#{Regexp.escape(message)}/, err)
+    end
+  end
+
+  def test_rejects_added_removed_ambiguous_and_dependency_edge_changes
+    valid = updated("ast", "2.4.3", "2.4.4")
+    added = valid.sub("    ast (2.4.4)\n", "    ast (2.4.4)\n    attacker (1.0.0)\n")
+      .sub("CHECKSUMS\n", "CHECKSUMS\n  attacker (1.0.0) sha256=#{'c' * 64}\n")
+    removed = valid.sub(/^    rainbow \(3\.1\.1\)\n/, "")
+    duplicate = valid.sub("    ast (2.4.4)\n", "    ast (2.4.4)\n    ast (2.4.4)\n")
+    edge = valid.sub("      json (~> 2.3)", "      json (~> 2.4)")
+
+    [ added, removed, duplicate, edge ].each do |head|
+      _out, _err, status = validate(head)
+      refute_predicate status, :success?
+    end
+  end
+
+  def test_rejects_wrong_ecosystem_and_missing_or_duplicate_structural_sections
+    head = updated("ast", "2.4.3", "2.4.4")
+    _out, err, status = validate(head, ecosystem: "npm")
+    refute_predicate status, :success?
+    assert_match(/ecosystem/, err)
+
+    [
+      head.sub("CHECKSUMS\n", ""),
+      head.sub("CHECKSUMS\n", "CHECKSUMS\n\nCHECKSUMS\n")
+    ].each do |structurally_invalid|
+      _out, _err, status = validate(structurally_invalid)
+      refute_predicate status, :success?
+    end
+  end
+
+  def test_rejects_an_otherwise_valid_transitive_update
+    _out, err, status = validate(updated("ast", "2.4.3", "2.4.4"))
+
+    refute_predicate status, :success?
+    assert_match(/transitive dependency/, err)
+  end
+
+  def test_rejects_malformed_and_duplicate_top_level_dependency_records
+    valid = updated("rake", "13.4.2", "13.4.3")
+    malformed = valid.sub("  minitest\n", " invalid dependency\n")
+    duplicate = valid.sub("  minitest\n", "  minitest\n  minitest\n")
+
+    [ malformed, duplicate ].each do |head|
+      _out, _err, status = validate(head)
+      refute_predicate status, :success?
+    end
+  end
+
+  def test_top_level_dependency_parser_ignores_blank_records_and_excludes_path_dependencies
+    dependencies = CHECK.send(:parse_direct_dependencies, "\n  minitest\n  surfguard!\n")
+
+    assert_equal [ "minitest" ], dependencies
+    assert_predicate dependencies, :frozen?
+  end
+
+  def test_run_rejects_wrong_arity_and_unreadable_files
+    out = StringIO.new
+    err = StringIO.new
+    assert_equal 2, CHECK.run([], out: out, err: err)
+    assert_empty out.string
+    assert_match(/usage:/, err.string)
+
+    missing = File.join(Dir.tmpdir, "surfguard-missing-#{Process.pid}")
+    refute_path_exists missing
+    err = StringIO.new
+    assert_equal 1, CHECK.run([ missing, missing, "bundler", "version-update:semver-patch" ],
+      out: StringIO.new, err: err)
+    assert_match(/could not be read/, err.string)
+  end
+
+  def test_rejects_top_level_platform_path_and_dependency_edge_changes
+    valid = updated("ast", "2.4.3", "2.4.4")
+    cases = {
+      "top-level dependency" => valid.sub("  minitest\n", "  minitest (= 6.0.6)\n"),
+      "platform structure" => valid.sub("  ruby\n", "  ruby\n  arm64-darwin\n"),
+      "local path source" => valid.sub("surfguard (0.1.3)", "surfguard (0.1.4)"),
+      "outside version/checksum" => valid.sub("      base64\n", "      base64 (>= 0)\n")
+    }
+
+    cases.each do |message, head|
+      _out, err, status = validate(head)
+      refute_predicate status, :success?
+      assert_match(/#{Regexp.escape(message)}/, err)
+    end
+  end
+
+  def test_rejects_no_change_decrease_and_prerelease_base
+    base = File.binread(LOCK)
+    _out, err, status = validate(base)
+    refute_predicate status, :success?
+    assert_match(/exactly one/, err)
+
+    _out, err, status = validate(updated("ast", "2.4.3", "2.4.2"))
+    refute_predicate status, :success?
+    assert_match(/did not increase/, err)
+
+    prerelease_base = base.gsub("    ast (2.4.3)", "    ast (2.4.3.pre)")
+      .gsub("  ast (2.4.3) sha256=", "  ast (2.4.3.pre) sha256=")
+    release_head = prerelease_base.gsub("    ast (2.4.3.pre)", "    ast (2.4.4)")
+      .gsub("  ast (2.4.3.pre) sha256=", "  ast (2.4.4) sha256=")
+      .sub(/(  ast \(2\.4\.4\) sha256=)[0-9a-f]{64}/, "\\1#{'d' * 64}")
+    _out, err, status = validate_pair(prerelease_base, release_head)
+    refute_predicate status, :success?
+    assert_match(/prerelease/, err)
+  end
+
+  def test_rejects_invalid_encoding_and_malformed_section_cardinality
+    valid = updated("ast", "2.4.3", "2.4.4")
+    invalid_encoding = valid.b + "\xFF".b
+    cases = [
+      invalid_encoding,
+      valid.sub("GEM\n", ""),
+      valid.sub("GEM\n", "GEM\n\nGEM\n"),
+      valid.sub("PATH\n", ""),
+      valid.sub("PATH\n", "PATH\n\nPATH\n")
+    ]
+
+    cases.each do |head|
+      _out, _err, status = validate(head)
+      refute_predicate status, :success?
+    end
+  end
+
+  def test_rejects_empty_specs_checksums_and_missing_structural_sections
+    valid = updated("ast", "2.4.3", "2.4.4")
+    empty_specs = valid.sub(/(GEM\n  remote: https:\/\/rubygems\.org\/\n  specs:)\n.*?(?=\nPLATFORMS\n)/m, '\\1\n')
+    empty_checksums = valid.sub(/CHECKSUMS\n.*?(?=\nBUNDLED WITH\n)/m, "CHECKSUMS\n")
+    cases = [
+      empty_specs,
+      empty_checksums,
+      valid.sub(/DEPENDENCIES\n.*?(?=\nCHECKSUMS\n)/m, ""),
+      valid.sub(/PLATFORMS\n.*?(?=\nDEPENDENCIES\n)/m, "")
+    ]
+
+    cases.each do |head|
+      _out, _err, status = validate(head)
+      refute_predicate status, :success?
+    end
+  end
+
+  def test_rejects_invalid_dependency_versions_and_every_changed_checksum_failure
+    valid = updated("ast", "2.4.3", "2.4.4")
+    invalid_version = valid.gsub("ast (2.4.4)", "ast (!)")
+    no_base_checksum = File.binread(LOCK).sub(/^  ast .+\n/, "")
+    no_head_checksum = valid.sub(/^  ast .+\n/, "")
+    missing_digest = valid.sub(/(  ast \(2\.4\.4\)) sha256=[0-9a-f]{64}/, '\\1')
+    old_digest = File.binread(LOCK)[/^  ast \(2\.4\.3\) sha256=([0-9a-f]{64})$/, 1]
+    unchanged_digest = valid.sub(/(  ast \(2\.4\.4\) sha256=)[0-9a-f]{64}/, "\\1#{old_digest}")
+
+    [
+      [ File.binread(LOCK), invalid_version, /invalid dependency version/ ],
+      [ no_base_checksum, valid, /matching base checksum/ ],
+      [ File.binread(LOCK), no_head_checksum, /matching head checksum/ ],
+      [ File.binread(LOCK), missing_digest, /checksum is missing/ ],
+      [ File.binread(LOCK), unchanged_digest, /did not change/ ]
+    ].each do |base, head, message|
+      _out, err, status = validate_pair(base, head)
+      refute_predicate status, :success?
+      assert_match message, err
+    end
+  end
+
+  def test_cli_guard_exits_with_run_status
+    _out, err = capture_io do
+      error = assert_raises(SystemExit) do
+        CHECK.main(program_name: VALIDATOR, file: VALIDATOR, argv: [])
+      end
+      assert_equal 2, error.status
+    end
+    assert_match(/usage:/, err)
+  end
+end

--- a/test/release/dependabot_validator_test.rb
+++ b/test/release/dependabot_validator_test.rb
@@ -155,7 +155,15 @@ class DependabotValidatorTest < Minitest::Test
     platform_flip = platformed.call(File.binread(LOCK))
     _out, err, status = validate(platform_flip)
     refute_predicate status, :success?
-    assert_match(/did not increase/, err)
+    assert_match(/platform changed/, err)
+
+    bump_with_flip = File.read(LOCK)
+      .sub("    rake (13.4.2)", "    rake (13.4.3-x86_64-linux)")
+      .sub("  rake (13.4.2) sha256=", "  rake (13.4.3-x86_64-linux) sha256=")
+      .sub(/(  rake \(13\.4\.3-x86_64-linux\) sha256=)[0-9a-f]{64}/, "\\1#{'a' * 64}")
+    _out, err, status = validate(bump_with_flip)
+    refute_predicate status, :success?
+    assert_match(/platform changed/, err)
   end
 
   def test_rejects_checksum_shaped_lines_outside_the_checksums_section

--- a/test/release/dependabot_validator_test.rb
+++ b/test/release/dependabot_validator_test.rb
@@ -133,6 +133,41 @@ class DependabotValidatorTest < Minitest::Test
     end
   end
 
+  def test_rejects_equivalent_version_respelling_of_a_second_dependency
+    respelled = updated("rake", "13.4.2", "13.4.3")
+      .sub("    rainbow (3.1.1)", "    rainbow (3.1.1.0)")
+    _out, err, status = validate(respelled)
+
+    refute_predicate status, :success?
+    assert_match(/exactly one/, err)
+  end
+
+  def test_parses_platform_qualified_specs_per_bundler_lockfile_grammar
+    platformed = lambda do |text|
+      text.sub("    racc (1.8.1)", "    racc (1.8.1-x86_64-linux)")
+        .sub("  racc (1.8.1) sha256=", "  racc (1.8.1-x86_64-linux) sha256=")
+    end
+    base = platformed.call(File.binread(LOCK))
+    head = platformed.call(updated("rake", "13.4.2", "13.4.3"))
+    _out, err, status = validate_pair(base, head)
+    assert_predicate status, :success?, err
+
+    platform_flip = platformed.call(File.binread(LOCK))
+    _out, err, status = validate(platform_flip)
+    refute_predicate status, :success?
+    assert_match(/did not increase/, err)
+  end
+
+  def test_rejects_checksum_shaped_lines_outside_the_checksums_section
+    injected = updated("rake", "13.4.2", "13.4.3")
+      .sub("  specs:\n    activesupport",
+        "  specs:\n  attacker (1.0.0) sha256=#{'e' * 64}\n    activesupport")
+    _out, err, status = validate(injected)
+
+    refute_predicate status, :success?
+    assert_match(/outside version\/checksum/, err)
+  end
+
   def test_rejects_wrong_ecosystem_and_missing_or_duplicate_structural_sections
     head = updated("ast", "2.4.3", "2.4.4")
     _out, err, status = validate(head, ecosystem: "npm")

--- a/test/release/dependabot_workflow_harness_test.rb
+++ b/test/release/dependabot_workflow_harness_test.rb
@@ -48,9 +48,27 @@ class DependabotWorkflowHarnessTest < Minitest::Test
         puts JSON.generate([ take.call("commits") ])
       when %r{/pulls/\d+/files\z}
         puts fixture.fetch("files").join("\n")
-      when %r{/contents/(.+)\?ref=}
+      when %r{/contents/(.+)\?ref=(.+)\z}
+        # Exact-ref fetching is the trust boundary: serve only the validator at
+        # the base SHA and the two lockfiles at their own SHAs, each with a
+        # distinguishable body the served validator itself asserts, so a
+        # workflow that fetched from the wrong ref or swapped base/head fails.
         path = Regexp.last_match(1)
-        content = path.end_with?("validate_dependabot_lockfile.rb") ? "exit 0\n" : "fixture lock\n"
+        ref = Regexp.last_match(2)
+        base_sha = "b" * 40
+        head_sha = "a" * 40
+        content = case [ path, ref ]
+        when [ ".github/scripts/validate_dependabot_lockfile.rb", base_sha ]
+          "abort 'unexpected validator arguments' unless ARGV.length == 4\n" \
+          "abort 'wrong base lockfile bytes' unless File.read(ARGV[0]) == \"base lock@#{base_sha}\\n\"\n" \
+          "abort 'wrong head lockfile bytes' unless File.read(ARGV[1]) == \"head lock@#{head_sha}\\n\"\n"
+        when [ "Gemfile.lock", base_sha ]
+          "base lock@#{base_sha}\n"
+        when [ "Gemfile.lock", head_sha ]
+          "head lock@#{head_sha}\n"
+        else
+          abort "unexpected contents fetch: #{path} at #{ref}"
+        end
         puts Base64.strict_encode64(content)
       when %r{/pulls/\d+/reviews\z}
         puts '{"id":1}'

--- a/test/release/dependabot_workflow_harness_test.rb
+++ b/test/release/dependabot_workflow_harness_test.rb
@@ -1,0 +1,294 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+require "base64"
+require "fileutils"
+require "json"
+require "open3"
+require "tmpdir"
+require "yaml"
+
+class DependabotWorkflowHarnessTest < Minitest::Test
+  ROOT = File.expand_path("../..", __dir__)
+  WORKFLOW = File.join(ROOT, ".github/workflows/dependabot-auto-merge.yml")
+  HEAD_SHA = "a" * 40
+  BASE_SHA = "b" * 40
+  REPOSITORY = "basecamp/surfguard"
+  PR_NUMBER = "17"
+
+  FAKE_GH = <<~'RUBY'
+    #!/usr/bin/env ruby
+    # frozen_string_literal: true
+
+    require "base64"
+    require "json"
+
+    begin
+    fixture = JSON.parse(File.binread(ENV.fetch("GH_FIXTURE")))
+    state_path = ENV.fetch("GH_STATE")
+    state = File.exist?(state_path) ? JSON.parse(File.binread(state_path)) : {}
+    File.open(ENV.fetch("GH_LOG"), "ab") { |file| file.puts(JSON.generate(ARGV)) }
+
+    take = lambda do |key|
+      values = fixture.fetch(key)
+      index = state.fetch(key, 0)
+      state[key] = index + 1
+      values.fetch([ index, values.length - 1 ].min)
+    end
+
+    if ARGV.first == "api"
+      endpoint = ARGV.find { |argument| argument.start_with?("repos/") }
+      abort "missing API endpoint" unless endpoint
+
+      case endpoint
+      when %r{/pulls/\d+\z}
+        puts JSON.generate(take.call("prs"))
+      when %r{/pulls/\d+/commits\z}
+        puts JSON.generate([ take.call("commits") ])
+      when %r{/pulls/\d+/files\z}
+        puts fixture.fetch("files").join("\n")
+      when %r{/contents/(.+)\?ref=}
+        path = Regexp.last_match(1)
+        content = path.end_with?("validate_dependabot_lockfile.rb") ? "exit 0\n" : "fixture lock\n"
+        puts Base64.strict_encode64(content)
+      when %r{/pulls/\d+/reviews\z}
+        puts '{"id":1}'
+      else
+        abort "unexpected API endpoint: #{endpoint}"
+      end
+    elsif ARGV.first(2) == [ "pr", "merge" ]
+      puts "merge enabled"
+    else
+      abort "unexpected gh invocation: #{ARGV.inspect}"
+    end
+    ensure
+      File.binwrite(state_path, JSON.generate(state)) if state_path && state
+    end
+  RUBY
+
+  def setup
+    @directory = Dir.mktmpdir("dependabot-workflow-harness")
+    @bin = File.join(@directory, "bin")
+    FileUtils.mkdir(@bin)
+    fake_gh = File.join(@bin, "gh")
+    File.binwrite(fake_gh, FAKE_GH)
+    File.chmod(0o755, fake_gh)
+
+    steps = YAML.safe_load_file(WORKFLOW, aliases: false).fetch("jobs").fetch("automerge").fetch("steps")
+    @initial_script = steps.find { |step| step["name"]&.start_with?("Re-validate the PR") }.fetch("run")
+    @boundary_script = steps.find { |step| step["name"]&.start_with?("Approve at the validated head") }.fetch("run")
+    @fixture_path = File.join(@directory, "fixture.json")
+    @state_path = File.join(@directory, "state.json")
+    @log_path = File.join(@directory, "gh.jsonl")
+    @github_output = File.join(@directory, "github-output")
+  end
+
+  def teardown
+    FileUtils.remove_entry(@directory)
+  end
+
+  def test_initial_validation_accepts_only_the_exact_trusted_shape
+    write_fixture
+    _stdout, stderr, status = run_script(@initial_script)
+
+    assert_predicate status, :success?, stderr
+    assert_includes File.binread(@github_output), "base_sha=#{BASE_SHA}\n"
+  end
+
+  def test_initial_validation_rejects_untrusted_pr_and_base_identities
+    mutations = {
+      closed: ->(pr) { pr["state"] = "closed" },
+      draft: ->(pr) { pr["draft"] = true },
+      author: ->(pr) { pr.dig("user")["login"] = "attacker" },
+      base_repository: ->(pr) { pr.dig("base", "repo")["full_name"] = "attacker/fork" },
+      base_ref: ->(pr) { pr.dig("base")["ref"] = "unprotected" },
+      head_repository: ->(pr) { pr.dig("head", "repo")["full_name"] = "attacker/fork" },
+      head_ref: ->(pr) { pr.dig("head")["ref"] = "feature/not-dependabot" },
+      moved_head: ->(pr) { pr.dig("head")["sha"] = "c" * 40 },
+      malformed_base_sha: ->(pr) { pr.dig("base")["sha"] = "b" * 40 + "\nINJECTED=1" }
+    }
+
+    mutations.each do |name, mutate|
+      pr = valid_pr
+      mutate.call(pr)
+      write_fixture(prs: [ pr ])
+      _stdout, _stderr, status = run_script(@initial_script)
+      refute_predicate status, :success?, name
+      refute privileged_call_logged?, name
+    end
+  end
+
+  def test_initial_validation_rejects_file_and_commit_identity_failures
+    commit_mutations = {
+      wrong_tip: ->(commit) { commit["sha"] = "c" * 40 },
+      author: ->(commit) { commit.dig("author")["login"] = "attacker" },
+      committer: ->(commit) { commit.dig("committer")["login"] = "attacker" },
+      signature: ->(commit) { commit.dig("commit", "verification")["verified"] = false }
+    }
+
+    commit_mutations.each do |name, mutate|
+      commit = valid_commit
+      mutate.call(commit)
+      write_fixture(commits: [ [ commit ] ])
+      _stdout, _stderr, status = run_script(@initial_script)
+      refute_predicate status, :success?, name
+      refute privileged_call_logged?, name
+    end
+
+    write_fixture(files: [ "Gemfile.lock", "Gemfile" ])
+    _stdout, _stderr, status = run_script(@initial_script)
+    refute_predicate status, :success?
+    refute privileged_call_logged?
+  end
+
+  def test_valid_identity_is_rechecked_before_approval_and_merge
+    write_fixture(prs: [ valid_pr, valid_pr ], commits: [ [ valid_commit ], [ valid_commit ] ])
+    _stdout, stderr, status = run_script(@boundary_script, "VALIDATED_BASE_SHA" => BASE_SHA)
+
+    assert_predicate status, :success?, stderr
+    calls = logged_calls
+    assert_equal 2, calls.count { |call| pull_request_read?(call) }
+    assert_equal 2, calls.count { |call| commits_read?(call) }
+    assert_equal 1, calls.count { |call| review_created?(call) }
+    assert_equal 1, calls.count { |call| call.first(2) == [ "pr", "merge" ] }
+  end
+
+  def test_each_identity_guard_fails_closed_before_approval
+    mutations = {
+      closed: ->(pr) { pr["state"] = "closed" },
+      draft: ->(pr) { pr["draft"] = true },
+      author: ->(pr) { pr.dig("user")["login"] = "attacker" },
+      base_repository: ->(pr) { pr.dig("base", "repo")["full_name"] = "attacker/fork" },
+      base_ref: ->(pr) { pr.dig("base")["ref"] = "unprotected" },
+      base_sha: ->(pr) { pr.dig("base")["sha"] = "c" * 40 },
+      head_repository: ->(pr) { pr.dig("head", "repo")["full_name"] = "attacker/fork" },
+      head_ref: ->(pr) { pr.dig("head")["ref"] = "feature/not-dependabot" },
+      head_sha: ->(pr) { pr.dig("head")["sha"] = "c" * 40 }
+    }
+
+    mutations.each do |name, mutate|
+      pr = valid_pr
+      mutate.call(pr)
+      write_fixture(prs: [ pr ])
+      _stdout, _stderr, status = run_script(@boundary_script, "VALIDATED_BASE_SHA" => BASE_SHA)
+      refute_predicate status, :success?, name
+      refute privileged_call_logged?, name
+    end
+  end
+
+  def test_commit_identity_guards_fail_closed_before_approval
+    mutations = {
+      wrong_tip: ->(commit) { commit["sha"] = "c" * 40 },
+      author: ->(commit) { commit.dig("author")["login"] = "attacker" },
+      committer: ->(commit) { commit.dig("committer")["login"] = "attacker" },
+      signature: ->(commit) { commit.dig("commit", "verification")["verified"] = false }
+    }
+
+    mutations.each do |name, mutate|
+      commit = valid_commit
+      mutate.call(commit)
+      write_fixture(commits: [ [ commit ] ])
+      _stdout, _stderr, status = run_script(@boundary_script, "VALIDATED_BASE_SHA" => BASE_SHA)
+      refute_predicate status, :success?, name
+      refute privileged_call_logged?, name
+    end
+  end
+
+  def test_identity_or_signature_change_after_approval_prevents_merge
+    second_pr = valid_pr
+    second_pr.dig("base")["ref"] = "unprotected"
+    second_commit = valid_commit
+    second_commit.dig("commit", "verification")["verified"] = false
+
+    fixtures = [
+      { prs: [ valid_pr, second_pr ], commits: [ [ valid_commit ] ] },
+      { prs: [ valid_pr, valid_pr ], commits: [ [ valid_commit ], [ second_commit ] ] }
+    ]
+    fixtures.each do |fixture|
+      write_fixture(**fixture)
+      _stdout, _stderr, status = run_script(@boundary_script, "VALIDATED_BASE_SHA" => BASE_SHA)
+      refute_predicate status, :success?
+      assert logged_calls.any? { |call| review_created?(call) }
+      refute logged_calls.any? { |call| call.first(2) == [ "pr", "merge" ] }
+    end
+  end
+
+  private
+    def valid_pr
+      {
+        "state" => "open",
+        "draft" => false,
+        "user" => { "login" => "dependabot[bot]" },
+        "head" => {
+          "ref" => "dependabot/bundler/rack-3.2.7",
+          "sha" => HEAD_SHA,
+          "repo" => { "full_name" => REPOSITORY }
+        },
+        "base" => {
+          "ref" => "main",
+          "sha" => BASE_SHA,
+          "repo" => { "full_name" => REPOSITORY }
+        }
+      }
+    end
+
+    def valid_commit
+      {
+        "sha" => HEAD_SHA,
+        "author" => { "login" => "dependabot[bot]" },
+        "committer" => { "login" => "dependabot[bot]" },
+        "commit" => { "verification" => { "verified" => true } }
+      }
+    end
+
+    def write_fixture(prs: [ valid_pr ], commits: [ [ valid_commit ] ], files: [ "Gemfile.lock" ])
+      File.binwrite(@fixture_path, JSON.generate("prs" => prs, "commits" => commits, "files" => files))
+      [ @state_path, @log_path, @github_output ].each { |path| FileUtils.rm_f(path) }
+      File.binwrite(@github_output, "")
+    end
+
+    def run_script(script, extra_environment = {})
+      environment = {
+        "PATH" => "#{@bin}#{File::PATH_SEPARATOR}#{ENV.fetch('PATH')}",
+        "GH_FIXTURE" => @fixture_path,
+        "GH_STATE" => @state_path,
+        "GH_LOG" => @log_path,
+        "GITHUB_OUTPUT" => @github_output,
+        "GH_TOKEN" => "fixture",
+        "REPO" => REPOSITORY,
+        "PR_NUMBER" => PR_NUMBER,
+        "PR_URL" => "https://github.com/#{REPOSITORY}/pull/#{PR_NUMBER}",
+        "EVENT_HEAD_SHA" => HEAD_SHA,
+        "EVENT_ACTOR" => "dependabot[bot]",
+        "EVENT_TRIGGERING_ACTOR" => "dependabot[bot]",
+        "METADATA_ECOSYSTEM" => "bundler",
+        "METADATA_UPDATE_TYPE" => "version-update:semver-patch"
+      }.merge(extra_environment)
+      Open3.capture3(environment, "bash", "--noprofile", "--norc", "-e", "-o", "pipefail", "-c", script,
+        chdir: @directory)
+    end
+
+    def logged_calls
+      return [] unless File.exist?(@log_path)
+
+      File.readlines(@log_path, chomp: true).map { |line| JSON.parse(line) }
+    end
+
+    def pull_request_read?(call)
+      call.first == "api" && call.any? { |argument| argument.end_with?("/pulls/#{PR_NUMBER}") }
+    end
+
+    def commits_read?(call)
+      call.first == "api" && call.any? { |argument| argument.end_with?("/pulls/#{PR_NUMBER}/commits") }
+    end
+
+    def review_created?(call)
+      call.first == "api" && call.include?("POST") &&
+        call.any? { |argument| argument.end_with?("/pulls/#{PR_NUMBER}/reviews") }
+    end
+
+    def privileged_call_logged?
+      logged_calls.any? { |call| review_created?(call) || call.first(2) == [ "pr", "merge" ] }
+    end
+end

--- a/test/release/dependabot_workflow_harness_test.rb
+++ b/test/release/dependabot_workflow_harness_test.rb
@@ -142,6 +142,7 @@ class DependabotWorkflowHarnessTest < Minitest::Test
       wrong_tip: ->(commit) { commit["sha"] = "c" * 40 },
       author: ->(commit) { commit.dig("author")["login"] = "attacker" },
       committer: ->(commit) { commit.dig("committer")["login"] = "attacker" },
+      committer_not_github_signer: ->(commit) { commit.dig("committer")["login"] = "dependabot[bot]" },
       signature: ->(commit) { commit.dig("commit", "verification")["verified"] = false }
     }
 
@@ -252,10 +253,12 @@ class DependabotWorkflowHarnessTest < Minitest::Test
     end
 
     def valid_commit
+      # Live Dependabot commits are authored by the bot but committed by
+      # GitHub's signer (web-flow); the workflow requires exactly that shape.
       {
         "sha" => HEAD_SHA,
         "author" => { "login" => "dependabot[bot]" },
-        "committer" => { "login" => "dependabot[bot]" },
+        "committer" => { "login" => "web-flow" },
         "commit" => { "verification" => { "verified" => true } }
       }
     end


### PR DESCRIPTION
## Stack

4 of 5. Base: `security-hardening-03-registry-client`. Next: `security-hardening-05-release-pipeline`.

## Summary

- Permit only one direct RubyGems patch or minor update in Gemfile.lock; every manifest, source, structure, identity, transitive, prerelease, major, or ambiguous change requires human review.
- Fetch the trusted validator and base/head lockfiles at exact API SHAs without checking out or executing PR code.
- Revalidate protected-base identity, head SHA, Dependabot author and committer, and every commit signature immediately before approval and again before merge.

## Verification

- Full validator suite and executable fake-GitHub-API identity, signature, and TOCTOU harness, 0 failures
- actionlint and offline pedantic Zizmor

This is an intermediate hardening branch. Do not tag, publish, or dispatch release/recovery until the complete stack is merged.
