### PR TITLE
Attest canonical registry bytes with split release authority

### DIFF
--- a/.github/workflows/release-recovery.yml
+++ b/.github/workflows/release-recovery.yml
@@ -38,7 +38,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Published version to recover (e.g. 0.1.0)"
+        description: "Published version to recover (0.2.0 or later; earlier releases are complete and out of recovery's scope)"
         required: true
         type: string
 
@@ -124,6 +124,16 @@ jobs:
           # is our own file with exactly this shape, so anchored sed suffices
           # — and the extracted values are validated before use.
           pins=tagged-src/.github/workflows/release.yml
+          # Recovery finishes only releases cut by the 0.2.0+ pipeline, whose
+          # tags carry these pins plus RELEASE_NOTES_X.Y.Z.md and the exact
+          # package contract the dispatch-revision verifier asserts. Earlier
+          # (0.1.x) releases are already complete — there is nothing for
+          # recovery to finish — and a defective published release ships a new
+          # patch version instead (RELEASING.md).
+          if [ "$(grep --count '^  RUBYGEMS_UPDATE_SHA256: ' "$pins")" -eq 0 ]; then
+            echo "::error::Tag v${VERSION} predates the recovery-capable release pipeline; recovery applies to 0.2.0+ tags only. See RELEASING.md: earlier releases are complete, and a defective release ships a new patch version."
+            exit 1
+          fi
           [ "$(grep --count '^  RUBY_VERSION: ' "$pins")" -eq 1 ]
           [ "$(grep --count '^  RUBYGEMS_VERSION: ' "$pins")" -eq 1 ]
           [ "$(grep --count '^  RUBYGEMS_UPDATE_SHA256: ' "$pins")" -eq 1 ]
@@ -319,6 +329,32 @@ jobs:
           if [ "$type" = tag ]; then object="$(gh api "repos/${REPO}/git/tags/${sha}" --jq '.object.type + " " + .object.sha')"; type="${object%% *}"; sha="${object#* }"; fi
           [ "$type" = commit ] && [ "$sha" = "$TAG_SHA" ]
           echo "sha=${sha}" >> "$GITHUB_OUTPUT"
+          # overwrite_files: false silently retains a same-named asset, so an
+          # asset left by an earlier partial run must be proven byte-identical
+          # to the verified canonical gem before recovery can succeed. Only a
+          # missing release (HTTP 404) may skip the comparison; any other
+          # query failure fails closed.
+          set +e
+          asset_names="$(gh api "repos/${REPO}/releases/tags/v${VERSION}" --jq '[.assets[].name]' 2>release-query-error.txt)"
+          query_status=$?
+          set -e
+          if [ "$query_status" -ne 0 ]; then
+            if ! grep --quiet "HTTP 404" release-query-error.txt; then
+              cat release-query-error.txt
+              echo "::error::Could not determine whether a release asset already exists"
+              exit 1
+            fi
+            asset_names="[]"
+          fi
+          if jq --exit-status --arg name "surfguard-${VERSION}.gem" 'index($name) != null' <<<"$asset_names" >/dev/null; then
+            gh release download "v${VERSION}" --repo "$REPO" --pattern "surfguard-${VERSION}.gem" --output existing-asset.gem
+            existing="$(sha256sum existing-asset.gem | awk '{print $1}')"
+            rm existing-asset.gem
+            if [ "$existing" != "$GEM_SHA256" ]; then
+              echo "::error::Existing release asset digest ${existing} does not match canonical ${GEM_SHA256}; refusing to finish a recovery that serves different bytes"
+              exit 1
+            fi
+          fi
       - name: Create the GitHub Release from the canonical bytes # zizmor: ignore[superfluous-actions] -- the pinned action provides fail-on-unmatched-files, reviewed release-note handling, prerelease handling, target_commitish, and overwrite control as one operation
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:

--- a/.github/workflows/release-recovery.yml
+++ b/.github/workflows/release-recovery.yml
@@ -4,17 +4,25 @@ name: Release recovery
 # the tagged workflow itself is defective (re-running the tag can't fix it,
 # and the tag must never move).
 #
-# Two jobs, mirroring the release pipeline's privilege separation:
+# Four jobs, mirroring the release pipeline's privilege separation and keeping
+# registry bytes away from a runner that executed the tagged gemspec:
 #
-#   verify (unprivileged) — proves the release tag exists and points into
+#   rebuild (unprivileged) — proves the release tag exists and points into
 #   main; extracts the TAGGED source into a side directory with `git archive`
 #   (so the recovery helpers keep running from the dispatch revision, not the
-#   possibly-defective tag); REBUILDS the gem from that source with the tag's
-#   own toolchain pins; downloads the canonical .gem from RubyGems (verified
-#   against the registry-reported SHA-256); and proves rebuilt == canonical.
+#   possibly-defective tag); and REBUILDS the gem from that source with the
+#   tag's own toolchain pins.
 #
-#   finish (reviewer-gated, no checkout) — re-asserts the digest, then
-#   attests and creates the GitHub Release from the canonical bytes.
+#   verify (fresh, unprivileged) — downloads the immutable rebuild artifact,
+#   captures and uploads canonical RubyGems bytes before executing package
+#   code, verifies the rebuild against tagged source/installed bytes, and
+#   proves rebuilt == canonical.
+#
+#   attest (reviewer-gated, no checkout) — re-asserts the digest and holds only
+#   OIDC/attestation authority.
+#
+#   github-release (separately reviewer-gated, no checkout) — independently
+#   re-asserts the digest/tag and holds only contents:write.
 #
 # The digest equality is what makes the build-provenance attestation honest:
 # the attested bytes are demonstrably the product of the tagged source, not
@@ -44,23 +52,26 @@ concurrency:
 jobs:
   # Executes repo-controlled code (the tagged gemspec), so it deliberately
   # holds no credentials and no privileged permissions.
-  verify:
-    name: Rebuild from the tag and verify canonical bytes
+  rebuild:
+    name: Rebuild from the release tag
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read # checkout + git archive of the tagged source
     env:
       VERSION: ${{ inputs.version }}
     outputs:
-      gem_sha256: ${{ steps.canonical.outputs.gem_sha256 }}
+      rebuilt_sha256: ${{ steps.rebuild.outputs.rebuilt_sha256 }}
       prerelease: ${{ steps.flags.outputs.prerelease }}
+      tag_sha: ${{ steps.tag.outputs.tag_sha }}
+      ruby_version: ${{ steps.pins.outputs.ruby }}
     steps:
       - name: Validate the version input against the dispatch ref
         env:
           REF: ${{ github.ref }}
         run: |
-          if ! printf '%s' "$VERSION" | grep --extended-regexp --quiet '^[0-9]+(\.[A-Za-z0-9]+)*$'; then
-            echo "::error::Not a plausible gem version: ${VERSION}"
+          if ! printf '%s' "$VERSION" | grep --extended-regexp --quiet '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'; then
+            echo "::error::Version must be exact SemVer X.Y.Z: ${VERSION}"
             exit 1
           fi
           # Dispatched on a tag? It must be THE release tag for this version.
@@ -71,6 +82,11 @@ jobs:
                 exit 1
               fi
               ;;
+            refs/heads/main) ;;
+            *)
+              echo "::error::Recovery must be dispatched on v${VERSION} or main, not ${REF}"
+              exit 1
+              ;;
           esac
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -78,6 +94,7 @@ jobs:
           fetch-tags: true
           persist-credentials: false
       - name: Require the release tag to exist on main; extract its source to the side
+        id: tag
         run: |
           if ! git rev-parse --quiet --verify "refs/tags/v${VERSION}^{commit}" >/dev/null; then
             echo "::error::Tag v${VERSION} does not exist. Recovery only finishes releases that were actually tagged; without this guard a typo would attest an arbitrary registry version and mint a fresh tag at the default branch tip."
@@ -87,6 +104,14 @@ jobs:
             echo "::error::Tag v${VERSION} is not an ancestor of origin/main"
             exit 1
           fi
+          if [ "$(git cat-file -t "refs/tags/v${VERSION}")" != tag ] ||
+             [ "$(git for-each-ref --format='%(contents:subject)' "refs/tags/v${VERSION}")" != "surfguard v${VERSION}" ] ||
+             [ -n "$(git for-each-ref --format='%(contents:body)' "refs/tags/v${VERSION}")" ]; then
+            echo "::error::Tag v${VERSION} is not the exact annotated release tag"
+            exit 1
+          fi
+          tag_sha="$(git rev-parse "refs/tags/v${VERSION}^{commit}")"
+          echo "tag_sha=${tag_sha}" >> "$GITHUB_OUTPUT"
           # git archive, not checkout: the tagged tree becomes build INPUT in
           # tagged-src/ while the recovery helpers (script/release) keep
           # running from the revision this workflow was dispatched on.
@@ -98,49 +123,50 @@ jobs:
           # No YAML library needed before setup-ruby: the tagged release.yml
           # is our own file with exactly this shape, so anchored sed suffices
           # — and the extracted values are validated before use.
-          ruby_version="$(sed -n 's/^  RUBY_VERSION: "\([0-9][0-9.]*\)"$/\1/p' tagged-src/.github/workflows/release.yml | head -1)"
-          rubygems_version="$(sed -n 's/^  RUBYGEMS_VERSION: "\([0-9][0-9.]*\)"$/\1/p' tagged-src/.github/workflows/release.yml | head -1)"
-          if [ -z "$ruby_version" ] || [ -z "$rubygems_version" ]; then
+          pins=tagged-src/.github/workflows/release.yml
+          [ "$(grep --count '^  RUBY_VERSION: ' "$pins")" -eq 1 ]
+          [ "$(grep --count '^  RUBYGEMS_VERSION: ' "$pins")" -eq 1 ]
+          [ "$(grep --count '^  RUBYGEMS_UPDATE_SHA256: ' "$pins")" -eq 1 ]
+          ruby_version="$(sed -n 's/^  RUBY_VERSION: "\([0-9][0-9.]*\)"$/\1/p' "$pins")"
+          rubygems_version="$(sed -n 's/^  RUBYGEMS_VERSION: "\([0-9][0-9.]*\)"$/\1/p' "$pins")"
+          rubygems_sha256="$(sed -n 's/^  RUBYGEMS_UPDATE_SHA256: "\([0-9a-f]\{64\}\)"$/\1/p' "$pins")"
+          if printf '%s\n%s\n' "$ruby_version" "$rubygems_version" |
+             grep --extended-regexp --quiet --invert-match '^[0-9]+\.[0-9]+\.[0-9]+$' ||
+             [ "${#rubygems_sha256}" -ne 64 ]; then
             echo "::error::Could not read RUBY_VERSION/RUBYGEMS_VERSION pins from the tagged release.yml"
             exit 1
           fi
           {
             echo "ruby=${ruby_version}"
             echo "rubygems=${rubygems_version}"
+            echo "rubygems_sha256=${rubygems_sha256}"
           } >> "$GITHUB_OUTPUT"
           echo "tagged toolchain pins: ruby ${ruby_version}, rubygems ${rubygems_version}"
       - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           ruby-version: ${{ steps.pins.outputs.ruby }}
           bundler-cache: false
-      - name: Pin the packaging toolchain to the tag's pins
+      - name: Pin the packaging toolchain to the tag's pins # zizmor: ignore[adhoc-packages] -- unprivileged recovery verifies the tagged exact rubygems-update SHA-256 before local installation
         env:
           RUBYGEMS_VERSION: ${{ steps.pins.outputs.rubygems }}
-        run: gem update --system "$RUBYGEMS_VERSION"
+          RUBYGEMS_UPDATE_SHA256: ${{ steps.pins.outputs.rubygems_sha256 }}
+        run: |
+          gem fetch rubygems-update --version "$RUBYGEMS_VERSION" --clear-sources --source https://rubygems.org
+          echo "$RUBYGEMS_UPDATE_SHA256  rubygems-update-${RUBYGEMS_VERSION}.gem" | sha256sum --check
+          gem install --local --no-document "rubygems-update-${RUBYGEMS_VERSION}.gem"
+          update_rubygems --no-document
+          [ "$(gem --version)" = "$RUBYGEMS_VERSION" ]
       - name: Rebuild the gem from the tagged source (reproducibly)
         id: rebuild
+        env:
+          TAG_SHA: ${{ steps.tag.outputs.tag_sha }}
         run: |
           epoch="$(git log -1 --format=%ct "refs/tags/v${VERSION}")"
+          (cd tagged-src && bundle install --jobs 4 --retry 3)
           (cd tagged-src && SOURCE_DATE_EPOCH="$epoch" gem build --strict surfguard.gemspec --output "../rebuilt-${VERSION}.gem")
           rebuilt_sha256="$(sha256sum "rebuilt-${VERSION}.gem" | awk '{ print $1 }')"
           echo "rebuilt_sha256=${rebuilt_sha256}" >> "$GITHUB_OUTPUT"
           echo "rebuilt-${VERSION}.gem sha256=${rebuilt_sha256}"
-      - name: Download the canonical bytes from RubyGems (verified against the registry-reported digest)
-        id: canonical
-        run: |
-          digest="$(ruby script/release/registry_download.rb surfguard "$VERSION" "surfguard-${VERSION}.gem")"
-          echo "gem_sha256=${digest}" >> "$GITHUB_OUTPUT"
-          echo "canonical surfguard-${VERSION}.gem sha256=${digest}"
-      - name: Prove the canonical bytes were built from the tagged source
-        env:
-          REBUILT_SHA256: ${{ steps.rebuild.outputs.rebuilt_sha256 }}
-          CANONICAL_SHA256: ${{ steps.canonical.outputs.gem_sha256 }}
-        run: |
-          if [ "$REBUILT_SHA256" != "$CANONICAL_SHA256" ]; then
-            echo "::error::Rebuilt digest ${REBUILT_SHA256} does not match canonical registry digest ${CANONICAL_SHA256}. Do NOT attest. Stop for a human: either the toolchain pins drifted or the registry is serving bytes that did not come from this tag."
-            exit 1
-          fi
-          echo "rebuilt == canonical: ${CANONICAL_SHA256}"
       - name: Compute the prerelease flag (RubyGems semantics)
         id: flags
         run: |
@@ -148,23 +174,99 @@ jobs:
           echo "prerelease=${prerelease}" >> "$GITHUB_OUTPUT"
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
+          name: rebuilt-gem
+          path: rebuilt-${{ inputs.version }}.gem
+          if-no-files-found: error
+
+  verify:
+    name: Fresh-runner verification of rebuilt and canonical bytes
+    needs: rebuild
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    env:
+      VERSION: ${{ inputs.version }}
+    outputs:
+      gem_sha256: ${{ steps.canonical.outputs.gem_sha256 }}
+      notes_sha256: ${{ steps.notes.outputs.notes_sha256 }}
+      prerelease: ${{ needs.rebuild.outputs.prerelease }}
+      tag_sha: ${{ needs.rebuild.outputs.tag_sha }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+      - name: Revalidate the immutable tag and extract its test/source inputs
+        env:
+          EXPECTED_TAG_SHA: ${{ needs.rebuild.outputs.tag_sha }}
+        run: |
+          [ "$(git cat-file -t "refs/tags/v${VERSION}")" = tag ]
+          [ "$(git for-each-ref --format='%(contents:subject)' "refs/tags/v${VERSION}")" = "surfguard v${VERSION}" ]
+          [ -z "$(git for-each-ref --format='%(contents:body)' "refs/tags/v${VERSION}")" ]
+          [ "$(git rev-parse "refs/tags/v${VERSION}^{commit}")" = "$EXPECTED_TAG_SHA" ]
+          git merge-base --is-ancestor "$EXPECTED_TAG_SHA" origin/main
+          mkdir tagged-src
+          git archive "refs/tags/v${VERSION}" | tar --extract --directory tagged-src
+      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
+        with:
+          ruby-version: ${{ needs.rebuild.outputs.ruby_version }}
+          bundler-cache: false
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: rebuilt-gem
+      - name: Download canonical bytes before executing package code
+        id: canonical
+        run: |
+          digest="$(ruby script/release/registry_download.rb surfguard "$VERSION" "surfguard-${VERSION}.gem" 300)"
+          echo "gem_sha256=${digest}" >> "$GITHUB_OUTPUT"
+          echo "canonical surfguard-${VERSION}.gem sha256=${digest}"
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
           name: canonical-gem
           path: surfguard-${{ inputs.version }}.gem
           if-no-files-found: error
+      - name: Capture reviewed release notes from the immutable tag
+        id: notes
+        run: |
+          notes="RELEASE_NOTES_${VERSION}.md"
+          [ -f "tagged-src/${notes}" ] && [ ! -L "tagged-src/${notes}" ]
+          cp "tagged-src/${notes}" "$notes"
+          echo "notes_sha256=$(sha256sum "$notes" | awk '{print $1}')" >> "$GITHUB_OUTPUT"
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-notes
+          path: RELEASE_NOTES_${{ inputs.version }}.md
+          if-no-files-found: error
+      - name: Verify rebuilt package and prove rebuilt equals canonical
+        env:
+          EXPECTED_REBUILT_SHA256: ${{ needs.rebuild.outputs.rebuilt_sha256 }}
+          CANONICAL_SHA256: ${{ steps.canonical.outputs.gem_sha256 }}
+          TAG_SHA: ${{ needs.rebuild.outputs.tag_sha }}
+        run: |
+          rebuilt_sha256="$(sha256sum "rebuilt-${VERSION}.gem" | awk '{print $1}')"
+          [ "$rebuilt_sha256" = "$EXPECTED_REBUILT_SHA256" ]
+          SURFGUARD_SUITE_ROOT=tagged-src ruby script/release/verify_package.rb "rebuilt-${VERSION}.gem" surfguard "$VERSION" "$TAG_SHA"
+          [ "$(sha256sum "rebuilt-${VERSION}.gem" | awk '{print $1}')" = "$EXPECTED_REBUILT_SHA256" ]
+          if [ "$EXPECTED_REBUILT_SHA256" != "$CANONICAL_SHA256" ]; then
+            echo "::error::Rebuilt digest ${EXPECTED_REBUILT_SHA256} does not match canonical registry digest ${CANONICAL_SHA256}. Do NOT attest; stop for a human."
+            exit 1
+          fi
+          echo "rebuilt == canonical: ${CANONICAL_SHA256}"
 
-  # The privileged half: reviewer-gated, no checkout, nothing repo-controlled
-  # executes. Acts only on artifact bytes whose digest the verify job proved.
-  finish:
-    name: Attest and release the verified bytes
+  attest:
+    name: Attest the verified canonical bytes
     needs: verify
     runs-on: ubuntu-latest
-    # Same reviewer gate as publishing: attestation + Release creation are
-    # release authority, not general write-collaborator authority.
+    timeout-minutes: 10
+    # Recovery attestation has its own reviewer gate; GitHub Release creation
+    # is separately gated by the github-release environment below.
     environment: release-recovery
     permissions:
       id-token: write # Sigstore signing needs the OIDC identity
       attestations: write # the attestation is stored via the attestations API
-      contents: write # creating the GitHub Release writes to the repo
+      artifact-metadata: write # actions/attest records the subject in artifact metadata
     env:
       VERSION: ${{ inputs.version }}
       GEM_SHA256: ${{ needs.verify.outputs.gem_sha256 }}
@@ -183,11 +285,47 @@ jobs:
         uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
         with:
           subject-path: surfguard-${{ inputs.version }}.gem
-      - name: Create the GitHub Release from the canonical bytes
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # zizmor: ignore[superfluous-actions,ref-version-mismatch] -- pinned at v3.0.2; deliberate: fail_on_unmatched_files + generate_release_notes + prerelease handling in one reviewed, pinned action beats reimplementing them in shell
+
+  github-release:
+    name: Create the GitHub Release from canonical bytes
+    needs: [ verify, attest ]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: github-release
+    permissions:
+      contents: write # softprops creates the release and uploads its canonical gem asset
+    env:
+      VERSION: ${{ inputs.version }}
+      GEM_SHA256: ${{ needs.verify.outputs.gem_sha256 }}
+      TAG_SHA: ${{ needs.verify.outputs.tag_sha }}
+      NOTES_SHA256: ${{ needs.verify.outputs.notes_sha256 }}
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: canonical-gem
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-notes
+      - name: Independently recheck digest and tag immediately before release
+        id: tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          [ "$(sha256sum "surfguard-${VERSION}.gem" | awk '{print $1}')" = "$GEM_SHA256" ]
+          [ "$(sha256sum "RELEASE_NOTES_${VERSION}.md" | awk '{print $1}')" = "$NOTES_SHA256" ]
+          object="$(gh api "repos/${REPO}/git/ref/tags/v${VERSION}" --jq '.object.type + " " + .object.sha')"
+          type="${object%% *}"; sha="${object#* }"
+          if [ "$type" = tag ]; then object="$(gh api "repos/${REPO}/git/tags/${sha}" --jq '.object.type + " " + .object.sha')"; type="${object%% *}"; sha="${object#* }"; fi
+          [ "$type" = commit ] && [ "$sha" = "$TAG_SHA" ]
+          echo "sha=${sha}" >> "$GITHUB_OUTPUT"
+      - name: Create the GitHub Release from the canonical bytes # zizmor: ignore[superfluous-actions] -- the pinned action provides fail-on-unmatched-files, reviewed release-note handling, prerelease handling, target_commitish, and overwrite control as one operation
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           tag_name: v${{ inputs.version }}
-          generate_release_notes: true
+          target_commitish: ${{ steps.tag.outputs.sha }}
+          body_path: RELEASE_NOTES_${{ inputs.version }}.md
           files: surfguard-${{ inputs.version }}.gem
           fail_on_unmatched_files: true
+          overwrite_files: false
           prerelease: ${{ needs.verify.outputs.prerelease == 'true' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,5 @@
 name: Release
 
-# Tag push (v*) runs the full pipeline: test -> build -> publish -> confirm ->
-# attest -> github-release. workflow_dispatch is always a no-publish rehearsal:
-# test -> build only, no environment prompt, no credentials, no attestation.
-#
-# Artifact identity flows forward by digest: build emits the gem's SHA-256 as a
-# job output, and every downstream job re-downloads the artifact and asserts
-# that digest before acting. Only canonical, registry-confirmed bytes are ever
-# attested or attached to the GitHub Release.
 on:
   push:
     tags: [ "v*" ]
@@ -15,352 +7,395 @@ on:
 
 permissions: {}
 
-# GitHub retains only ONE pending run per concurrency group. Rapid successive
-# release tags are prohibited — cut one release at a time, or the middle run
-# gets silently dropped.
+# GitHub retains one pending run in this group. A newer pending release can
+# replace an older pending run, so releases are cut one at a time.
 concurrency:
   group: release-publishing
   cancel-in-progress: false
 
 env:
-  # The packaging toolchain is pinned exactly: identical source must produce
-  # identical bytes, and RubyGems version changes change gem digests.
   RUBY_VERSION: "3.4.10"
   RUBYGEMS_VERSION: "4.0.18"
+  RUBYGEMS_UPDATE_SHA256: "a6a8653069b81b7977d4d341b3ba9f0212f14aa9756f0143dca2dcc3e793db97"
 
 jobs:
   test:
-    name: Test and lint
+    name: Test, lint, and registry drift
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # zizmor: ignore[cache-poisoning,ref-version-mismatch] -- pinned at v1.321.0; this test job only lints and runs the suite, and the artifact is built in the separate build job with bundler-cache disabled, so a poisoned bundler cache cannot reach the packaged bytes
+      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           ruby-version: ${{ env.RUBY_VERSION }}
-          bundler-cache: true
+          bundler-cache: false
+      - run: ruby script/check_resolv_version.rb
+      - run: bundle install --jobs 4 --retry 3
+      - run: bundle exec ruby script/check_resolv_version.rb
       - run: bundle exec rubocop
       - run: bundle exec rake test
         env:
           COVERAGE: "1"
+      - run: ruby script/generate_iana_data.rb --check
+      - run: ruby script/check_iana_drift.rb
 
-  # Executes the repo-controlled gemspec, so it deliberately holds no
-  # credentials and no privileged permissions.
-  build:
-    name: Build and verify the gem
+  source:
+    name: Capture immutable source inputs
     needs: test
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
     outputs:
-      version: ${{ steps.version.outputs.version }}
-      prerelease: ${{ steps.version.outputs.prerelease }}
+      version: ${{ steps.manifest.outputs.version }}
+      commit_sha: ${{ steps.manifest.outputs.commit_sha }}
+      prerelease: ${{ steps.manifest.outputs.prerelease }}
+      registry_sha256: ${{ steps.manifest.outputs.registry_sha256 }}
+      check_sha256: ${{ steps.manifest.outputs.check_sha256 }}
+      confirm_sha256: ${{ steps.manifest.outputs.confirm_sha256 }}
+      surfguard_sha256: ${{ steps.manifest.outputs.surfguard_sha256 }}
+      version_sha256: ${{ steps.manifest.outputs.version_sha256 }}
+      notes_sha256: ${{ steps.manifest.outputs.notes_sha256 }}
+    steps:
+      # This job deliberately runs no repository code. It is the trusted
+      # producer for release helpers and human-authored release notes.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Validate tag and capture source manifest
+        id: manifest
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          version="$(sed -n 's/^  VERSION = "\([^"]*\)"$/\1/p' lib/surfguard/version.rb)"
+          if ! printf '%s' "$version" | grep --extended-regexp --quiet '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'; then
+            echo "::error::Repository version must be exact SemVer X.Y.Z"
+            exit 1
+          fi
+          [ "$(grep --count '^  VERSION = ' lib/surfguard/version.rb)" -eq 1 ]
+          commit_sha="$(git rev-parse HEAD)"
+          if ! printf '%s' "$commit_sha" | grep --extended-regexp --quiet '^([0-9a-f]{40}|[0-9a-f]{64})$'; then
+            echo "::error::Source commit is not a full object ID"
+            exit 1
+          fi
+          [ "$(git cat-file -t "$commit_sha")" = commit ]
+          if [ "$EVENT_NAME" = push ]; then
+            [ "v${version}" = "$REF_NAME" ]
+            [ "$(git cat-file -t "refs/tags/${REF_NAME}")" = tag ]
+            [ "$(git for-each-ref --format='%(contents:subject)' "refs/tags/${REF_NAME}")" = "surfguard ${REF_NAME}" ]
+            [ -z "$(git for-each-ref --format='%(contents:body)' "refs/tags/${REF_NAME}")" ]
+            [ "$(git rev-parse "refs/tags/${REF_NAME}^{commit}")" = "$commit_sha" ]
+            git merge-base --is-ancestor "$commit_sha" origin/main
+          fi
+          notes="RELEASE_NOTES_${version}.md"
+          [ -f "$notes" ] && [ ! -L "$notes" ]
+          {
+            echo "version=${version}"
+            echo "commit_sha=${commit_sha}"
+            echo "prerelease=false"
+            echo "registry_sha256=$(sha256sum script/release/registry.rb | awk '{print $1}')"
+            echo "check_sha256=$(sha256sum script/release/registry_check.rb | awk '{print $1}')"
+            echo "confirm_sha256=$(sha256sum script/release/registry_confirm.rb | awk '{print $1}')"
+            echo "surfguard_sha256=$(sha256sum lib/surfguard.rb | awk '{print $1}')"
+            echo "version_sha256=$(sha256sum lib/surfguard/version.rb | awk '{print $1}')"
+            echo "notes_sha256=$(sha256sum "$notes" | awk '{print $1}')"
+          } >> "$GITHUB_OUTPUT"
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-scripts
+          path: |
+            script/release/registry.rb
+            script/release/registry_check.rb
+            script/release/registry_confirm.rb
+            lib/surfguard.rb
+            lib/surfguard/version.rb
+          if-no-files-found: error
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-notes
+          path: RELEASE_NOTES_${{ steps.manifest.outputs.version }}.md
+          if-no-files-found: error
+
+  build:
+    name: Build candidate gem
+    needs: source
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
+        with:
+          ruby-version: ${{ env.RUBY_VERSION }}
+          bundler-cache: false
+      - name: Install byte-pinned RubyGems toolchain # zizmor: ignore[adhoc-packages] -- unprivileged build job verifies the exact rubygems-update gem SHA-256 before local installation
+        run: |
+          gem fetch rubygems-update --version "$RUBYGEMS_VERSION" --clear-sources --source https://rubygems.org
+          echo "$RUBYGEMS_UPDATE_SHA256  rubygems-update-${RUBYGEMS_VERSION}.gem" | sha256sum --check
+          gem install --local --no-document "rubygems-update-${RUBYGEMS_VERSION}.gem"
+          update_rubygems --no-document
+          [ "$(gem --version)" = "$RUBYGEMS_VERSION" ]
+      - name: Reproducibly build candidate
+        env:
+          VERSION: ${{ needs.source.outputs.version }}
+        run: |
+          bundle install --jobs 4 --retry 3
+          SOURCE_DATE_EPOCH="$(git log -1 --format=%ct)" gem build --strict surfguard.gemspec
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: rubygem
+          path: surfguard-${{ needs.source.outputs.version }}.gem
+          if-no-files-found: error
+
+  package:
+    name: Fresh-runner package verification
+    needs: [ source, build ]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    outputs:
       gem_sha256: ${{ steps.digest.outputs.gem_sha256 }}
+    steps:
+      # Nothing before download evaluates the gemspec or candidate package.
+      # The build artifact is immutable once uploaded, so code exercised by
+      # the installed suite cannot swap the bytes later consumed by publish.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
+        with:
+          ruby-version: ${{ env.RUBY_VERSION }}
+          bundler-cache: false
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: rubygem
+      - name: Capture immutable artifact digest
+        id: digest
+        env:
+          VERSION: ${{ needs.source.outputs.version }}
+        run: echo "gem_sha256=$(sha256sum "surfguard-${VERSION}.gem" | awk '{print $1}')" >> "$GITHUB_OUTPUT"
+      - name: Verify immutable candidate against source and installed bytes
+        env:
+          VERSION: ${{ needs.source.outputs.version }}
+          EXPECTED_DIGEST: ${{ steps.digest.outputs.gem_sha256 }}
+          SOURCE_COMMIT: ${{ needs.source.outputs.commit_sha }}
+        run: |
+          ruby script/release/verify_package.rb "surfguard-${VERSION}.gem" surfguard "$VERSION" "$SOURCE_COMMIT"
+          [ "$(sha256sum "surfguard-${VERSION}.gem" | awk '{print $1}')" = "$EXPECTED_DIGEST" ]
+
+  rebuild:
+    name: Independent fresh-runner rebuild
+    needs: [ source, package ]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: Require the tagged commit to be on origin/main
-        if: github.event_name == 'push'
-        run: |
-          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
-            echo "::error::Tagged commit ${GITHUB_SHA} is not an ancestor of origin/main"
-            exit 1
-          fi
       - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           ruby-version: ${{ env.RUBY_VERSION }}
           bundler-cache: false
-      - name: Pin the packaging toolchain
+      - name: Install the same byte-pinned RubyGems toolchain # zizmor: ignore[adhoc-packages] -- unprivileged rebuild verifies the exact rubygems-update gem SHA-256 before local installation
         run: |
-          gem update --system "$RUBYGEMS_VERSION"
-          gem --version
-      - name: Determine the version (tag must match Surfguard::VERSION on tag pushes)
-        id: version
+          gem fetch rubygems-update --version "$RUBYGEMS_VERSION" --clear-sources --source https://rubygems.org
+          echo "$RUBYGEMS_UPDATE_SHA256  rubygems-update-${RUBYGEMS_VERSION}.gem" | sha256sum --check
+          gem install --local --no-document "rubygems-update-${RUBYGEMS_VERSION}.gem"
+          update_rubygems --no-document
+          [ "$(gem --version)" = "$RUBYGEMS_VERSION" ]
+      - name: Rebuild, verify, and require digest equality
         env:
-          EVENT_NAME: ${{ github.event_name }}
-          REF_NAME: ${{ github.ref_name }}
+          VERSION: ${{ needs.source.outputs.version }}
+          EXPECTED: ${{ needs.package.outputs.gem_sha256 }}
+          SOURCE_COMMIT: ${{ needs.source.outputs.commit_sha }}
         run: |
-          version="$(ruby -Ilib -rsurfguard/version -e 'puts Surfguard::VERSION')"
-          if [ "$EVENT_NAME" = "push" ] && [ "v${version}" != "$REF_NAME" ]; then
-            echo "::error::Tag ${REF_NAME} does not match Surfguard::VERSION ${version}"
-            exit 1
-          fi
-          echo "version=${version}" >> "$GITHUB_OUTPUT"
-          # RubyGems prerelease semantics (letter-bearing versions like
-          # 0.2.0.rc1), not a naive hyphen check.
-          prerelease="$(ruby -e 'puts Gem::Version.new(ARGV[0]).prerelease?' "$version")"
-          echo "prerelease=${prerelease}" >> "$GITHUB_OUTPUT"
-      - name: Build the gem (reproducibly — timestamps come from the commit)
-        run: |
+          bundle install --jobs 4 --retry 3
           SOURCE_DATE_EPOCH="$(git log -1 --format=%ct)" gem build --strict surfguard.gemspec
-      - name: Verify the packaged gem (rehearsals included)
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
-        run: ruby script/release/verify_package.rb "surfguard-${VERSION}.gem" surfguard "$VERSION" "$(git rev-parse HEAD)"
-      - name: Record the artifact digest
-        id: digest
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          gem_sha256="$(sha256sum "surfguard-${VERSION}.gem" | awk '{ print $1 }')"
-          echo "gem_sha256=${gem_sha256}" >> "$GITHUB_OUTPUT"
-          echo "surfguard-${VERSION}.gem sha256=${gem_sha256}"
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: rubygem
-          path: surfguard-${{ steps.version.outputs.version }}.gem
-          if-no-files-found: error
-      # The unprivileged confirm job runs these scripts without checking out
-      # the repo, so the artifact carries the Surfguard library registry.rb
-      # loads for address classification, laid out at repo-relative paths.
-      # The OIDC-capable publish job deliberately does not download or
-      # execute them.
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+          ruby script/release/verify_package.rb "surfguard-${VERSION}.gem" surfguard "$VERSION" "$SOURCE_COMMIT"
+          actual="$(sha256sum "surfguard-${VERSION}.gem" | awk '{print $1}')"
+          [ "$actual" = "$EXPECTED" ]
+
+  reconcile:
+    name: Unprivileged registry reconciliation
+    if: github.event_name == 'push'
+    needs: [ source, package, rebuild ]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions: {}
+    outputs:
+      decision: ${{ steps.check.outputs.decision }}
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-scripts
-          path: |
-            lib/surfguard.rb
-            lib/surfguard/version.rb
-            script/release/registry.rb
-            script/release/registry_confirm.rb
-          if-no-files-found: error
+      - name: Verify scripts before execution
+        env:
+          REGISTRY_SHA: ${{ needs.source.outputs.registry_sha256 }}
+          CHECK_SHA: ${{ needs.source.outputs.check_sha256 }}
+          SURFGUARD_SHA: ${{ needs.source.outputs.surfguard_sha256 }}
+          VERSION_SHA: ${{ needs.source.outputs.version_sha256 }}
+        run: |
+          [ "$(sha256sum script/release/registry.rb | awk '{print $1}')" = "$REGISTRY_SHA" ]
+          [ "$(sha256sum script/release/registry_check.rb | awk '{print $1}')" = "$CHECK_SHA" ]
+          [ "$(sha256sum lib/surfguard.rb | awk '{print $1}')" = "$SURFGUARD_SHA" ]
+          [ "$(sha256sum lib/surfguard/version.rb | awk '{print $1}')" = "$VERSION_SHA" ]
+      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
+        with:
+          ruby-version: ${{ env.RUBY_VERSION }}
+          bundler-cache: false
+      - id: check
+        env:
+          VERSION: ${{ needs.source.outputs.version }}
+          GEM_SHA: ${{ needs.package.outputs.gem_sha256 }}
+        run: echo "decision=$(ruby script/release/registry_check.rb surfguard "$VERSION" "$GEM_SHA" 300)" >> "$GITHUB_OUTPUT"
 
-  # The only job that can mint RubyGems credentials. Gated by the
-  # release-rubygems environment (required reviewer + OIDC trusted publishing).
-  # No checkout and no build-produced executable code: only the .gem artifact
-  # enters this job. Registry reconciliation is workflow-owned shell below.
   publish:
-    name: Publish to RubyGems
+    name: Publish with hosted RubyGems
     if: github.event_name == 'push'
-    needs: build
+    needs: [ source, package, reconcile ]
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     environment: release-rubygems
     permissions:
-      id-token: write # OIDC token exchange for RubyGems trusted publishing; nothing else
+      id-token: write # RubyGems trusted publishing exchanges this OIDC token
     env:
-      VERSION: ${{ needs.build.outputs.version }}
-      GEM_SHA256: ${{ needs.build.outputs.gem_sha256 }}
+      VERSION: ${{ needs.source.outputs.version }}
+      GEM_SHA: ${{ needs.package.outputs.gem_sha256 }}
     steps:
-      - name: Validate unprivileged build outputs against the release ref
-        env:
-          REF_NAME: ${{ github.ref_name }}
-        run: |
-          if [[ ! "$VERSION" =~ ^[0-9]+(\.[A-Za-z0-9]+)*$ ]]; then
-            echo "::error::Build output is not a plausible gem version"
-            exit 1
-          fi
-          if [ "v${VERSION}" != "$REF_NAME" ]; then
-            echo "::error::Build output version ${VERSION} does not match release ref ${REF_NAME}"
-            exit 1
-          fi
-          if [[ ! "$GEM_SHA256" =~ ^[0-9a-f]{64}$ ]]; then
-            echo "::error::Build output is not a lowercase SHA-256 digest"
-            exit 1
-          fi
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: rubygem
-      - name: Verify artifact identity (digest must match the build job's)
+      - name: Verify artifact identity
+        run: '[ "$(sha256sum "surfguard-${VERSION}.gem" | awk ''{print $1}'')" = "$GEM_SHA" ]'
+      - uses: rubygems/configure-rubygems-credentials@dc5a8d8553e6ee01fc26761a49e99e733d17954a # v2.1.0
+        if: needs.reconcile.outputs.decision == 'push'
+      - name: Push using only the hosted runner gem command
+        if: needs.reconcile.outputs.decision == 'push'
         run: |
-          actual="$(sha256sum "surfguard-${VERSION}.gem" | awk '{ print $1 }')"
-          if [ "$actual" != "$GEM_SHA256" ]; then
-            echo "::error::Artifact digest ${actual} does not match build output ${GEM_SHA256}"
-            exit 1
-          fi
-      - name: Reconcile with the registry (total state machine; fails closed)
-        id: reconcile
-        run: |
-          registry_url="https://rubygems.org/api/v2/rubygems/surfguard/versions/${VERSION}.json"
-          response_body="$(mktemp)"
-          trap 'rm -f "$response_body"' EXIT
-
-          attempt=1
-          while [ "$attempt" -le 5 ]; do
-            : > "$response_body"
-            status=""
-            retry_reason=""
-
-            if status="$(curl --disable --silent --show-error \
-              --connect-timeout 10 \
-              --max-time 40 \
-              --proto '=https' \
-              --output "$response_body" \
-              --write-out '%{http_code}' \
-              "$registry_url")"; then
-              case "$status" in
-                200)
-                  if ! published_version="$(jq --exit-status --raw-output \
-                    '.number | select(type == "string")' "$response_body")"; then
-                    echo "::error::RubyGems returned malformed version metadata"
-                    exit 1
-                  fi
-                  if ! published_sha="$(jq --exit-status --raw-output \
-                    '.sha | strings | select(test("^[0-9A-Fa-f]{64}$")) | ascii_downcase' \
-                    "$response_body")"; then
-                    echo "::error::RubyGems returned malformed digest metadata"
-                    exit 1
-                  fi
-                  if [ "$published_version" != "$VERSION" ]; then
-                    echo "::error::RubyGems returned metadata for a different version; expected ${VERSION}"
-                    exit 1
-                  fi
-                  if [ "$published_sha" != "$GEM_SHA256" ]; then
-                    echo "::error::surfguard ${VERSION} is already published with sha256 ${published_sha}; our artifact is ${GEM_SHA256}"
-                    exit 1
-                  fi
-                  decision="skip"
-                  break
-                  ;;
-                404)
-                  decision="push"
-                  break
-                  ;;
-                429|5??)
-                  retry_reason="HTTP ${status}"
-                  ;;
-                *)
-                  echo "::error::Unexpected HTTP ${status} from ${registry_url}"
-                  exit 1
-                  ;;
-              esac
-            else
-              retry_reason="network failure"
-            fi
-
-            if [ "$attempt" -ge 5 ]; then
-              echo "::error::RubyGems unavailable after ${attempt} attempts (${retry_reason})"
-              exit 1
-            fi
-            sleep "$((2 * attempt))"
-            attempt="$((attempt + 1))"
-          done
-
-          echo "decision=${decision}" >> "$GITHUB_OUTPUT"
-          echo "registry decision: ${decision}"
-      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
-        if: steps.reconcile.outputs.decision == 'push'
-        with:
-          ruby-version: ${{ env.RUBY_VERSION }}
-          bundler-cache: false
-      - name: Pin the packaging toolchain (same pins as build)
-        if: steps.reconcile.outputs.decision == 'push'
-        run: gem update --system "$RUBYGEMS_VERSION"
-      - name: Configure RubyGems trusted-publishing credentials (OIDC)
-        if: steps.reconcile.outputs.decision == 'push'
-        uses: rubygems/configure-rubygems-credentials@dc5a8d8553e6ee01fc26761a49e99e733d17954a # v2.1.0
-      - name: Re-verify artifact identity and push the gem
-        if: steps.reconcile.outputs.decision == 'push'
-        run: |
-          actual="$(sha256sum "surfguard-${VERSION}.gem" | awk '{ print $1 }')"
-          if [ "$actual" != "$GEM_SHA256" ]; then
-            echo "::error::Artifact digest ${actual} changed after reconciliation; expected ${GEM_SHA256}"
-            exit 1
-          fi
+          [ "$(sha256sum "surfguard-${VERSION}.gem" | awk '{print $1}')" = "$GEM_SHA" ]
           gem push "surfguard-${VERSION}.gem"
-      - name: Scrub credentials (runs even when the push fails)
-        if: always()
-        run: |
-          rm -f ~/.gem/credentials
-          {
-            echo "RUBYGEMS_API_KEY="
-            echo "BUNDLE_GEM__PUSH_KEY="
-            echo "GEM_HOST_API_KEY="
-          } >> "$GITHUB_ENV"
+      - name: Remove credentials created by the trusted-publishing action
+        if: always() && needs.reconcile.outputs.decision == 'push'
+        run: ruby -e 'path = File.expand_path("~/.gem/credentials"); File.delete(path) if File.file?(path) && !File.symlink?(path)'
 
-  # Registry confirmation deliberately lives OUTSIDE the credentialed job: no
-  # OIDC, no credentials, no checkout — just the public registry and math.
   confirm:
-    name: Confirm publication
+    name: Confirm and capture canonical registry bytes
     if: github.event_name == 'push'
-    needs: [ build, publish ]
+    needs: [ source, package, publish ]
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions: {}
-    env:
-      VERSION: ${{ needs.build.outputs.version }}
-      GEM_SHA256: ${{ needs.build.outputs.gem_sha256 }}
     steps:
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: rubygem
-      # Spanning lib/ and script/, the artifact is rooted at the repo root:
-      # extracting into the workspace restores both trees in place.
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-scripts
-      - name: Verify artifact identity (digest must match the build job's)
+      - name: Verify release scripts before execution
+        env:
+          REGISTRY_SHA: ${{ needs.source.outputs.registry_sha256 }}
+          CONFIRM_SHA: ${{ needs.source.outputs.confirm_sha256 }}
+          SURFGUARD_SHA: ${{ needs.source.outputs.surfguard_sha256 }}
+          VERSION_SHA: ${{ needs.source.outputs.version_sha256 }}
         run: |
-          actual="$(sha256sum "surfguard-${VERSION}.gem" | awk '{ print $1 }')"
-          if [ "$actual" != "$GEM_SHA256" ]; then
-            echo "::error::Artifact digest ${actual} does not match build output ${GEM_SHA256}"
-            exit 1
-          fi
+          [ "$(sha256sum script/release/registry.rb | awk '{print $1}')" = "$REGISTRY_SHA" ]
+          [ "$(sha256sum script/release/registry_confirm.rb | awk '{print $1}')" = "$CONFIRM_SHA" ]
+          [ "$(sha256sum lib/surfguard.rb | awk '{print $1}')" = "$SURFGUARD_SHA" ]
+          [ "$(sha256sum lib/surfguard/version.rb | awk '{print $1}')" = "$VERSION_SHA" ]
       - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           ruby-version: ${{ env.RUBY_VERSION }}
           bundler-cache: false
-      - name: Confirm the registry serves exactly our bytes
-        run: ruby script/release/registry_confirm.rb surfguard "$VERSION" "$GEM_SHA256" 300
+      - name: Save and verify canonical registry artifact
+        env:
+          VERSION: ${{ needs.source.outputs.version }}
+          GEM_SHA: ${{ needs.package.outputs.gem_sha256 }}
+        run: |
+          ruby script/release/registry_confirm.rb surfguard "$VERSION" "$GEM_SHA" "surfguard-${VERSION}.gem" 300
+          [ "$(sha256sum "surfguard-${VERSION}.gem" | awk '{print $1}')" = "$GEM_SHA" ]
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: canonical-gem
+          path: surfguard-${{ needs.source.outputs.version }}.gem
+          if-no-files-found: error
 
-  # Attestation happens only after the registry has confirmed publication, so
-  # only canonical bytes are ever attested. No checkout, no environment.
   attest:
-    name: Attest provenance
+    name: Attest canonical bytes
     if: github.event_name == 'push'
-    needs: [ build, confirm ]
+    needs: [ source, package, confirm ]
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
-      id-token: write # Sigstore signing needs the OIDC identity
-      attestations: write # the attestation is stored via the attestations API
-      contents: read # download-artifact reads this run's artifacts
-    env:
-      VERSION: ${{ needs.build.outputs.version }}
-      GEM_SHA256: ${{ needs.build.outputs.gem_sha256 }}
+      id-token: write # Sigstore signing uses the workflow OIDC identity
+      attestations: write # actions/attest stores the provenance attestation
+      artifact-metadata: write # actions/attest records the subject in artifact metadata
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: rubygem
-      - name: Verify artifact identity (digest must match the build job's)
-        run: |
-          actual="$(sha256sum "surfguard-${VERSION}.gem" | awk '{ print $1 }')"
-          if [ "$actual" != "$GEM_SHA256" ]; then
-            echo "::error::Artifact digest ${actual} does not match build output ${GEM_SHA256}"
-            exit 1
-          fi
-      - name: Attest build provenance (SLSA predicate)
+          name: canonical-gem
+      - name: Independently recheck the canonical digest
+        env:
+          VERSION: ${{ needs.source.outputs.version }}
+          GEM_SHA: ${{ needs.package.outputs.gem_sha256 }}
+        run: '[ "$(sha256sum "surfguard-${VERSION}.gem" | awk ''{print $1}'')" = "$GEM_SHA" ]'
+      - 
         uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
         with:
-          subject-path: surfguard-${{ needs.build.outputs.version }}.gem
+          subject-path: surfguard-${{ needs.source.outputs.version }}.gem
 
   github-release:
-    name: GitHub Release
+    name: GitHub Release from canonical bytes
     if: github.event_name == 'push'
-    needs: [ build, publish, confirm, attest ]
+    needs: [ source, package, confirm, attest ]
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: github-release
     permissions:
-      contents: write # creating the release and uploading its asset writes to the repo
-    env:
-      VERSION: ${{ needs.build.outputs.version }}
-      GEM_SHA256: ${{ needs.build.outputs.gem_sha256 }}
+      contents: write # softprops creates the release and uploads its canonical gem asset
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: rubygem
-      - name: Verify artifact identity (digest must match the build job's)
-        run: |
-          actual="$(sha256sum "surfguard-${VERSION}.gem" | awk '{ print $1 }')"
-          if [ "$actual" != "$GEM_SHA256" ]; then
-            echo "::error::Artifact digest ${actual} does not match build output ${GEM_SHA256}"
-            exit 1
-          fi
-      - name: Create the GitHub Release with the exact gem attached
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # zizmor: ignore[superfluous-actions,ref-version-mismatch] -- pinned at v3.0.2; deliberate: fail_on_unmatched_files + generate_release_notes + prerelease handling in one reviewed, pinned action beats reimplementing them in shell
+          name: canonical-gem
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          generate_release_notes: true
-          files: surfguard-${{ needs.build.outputs.version }}.gem
+          name: release-notes
+      - name: Recheck canonical digest and release tag immediately before creation
+        id: tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ github.ref_name }}
+          EXPECTED_COMMIT: ${{ needs.source.outputs.commit_sha }}
+          EXPECTED_DIGEST: ${{ needs.package.outputs.gem_sha256 }}
+          EXPECTED_NOTES_DIGEST: ${{ needs.source.outputs.notes_sha256 }}
+          VERSION: ${{ needs.source.outputs.version }}
+        run: |
+          [ "$(sha256sum "surfguard-${VERSION}.gem" | awk '{print $1}')" = "$EXPECTED_DIGEST" ]
+          [ "$(sha256sum "RELEASE_NOTES_${VERSION}.md" | awk '{print $1}')" = "$EXPECTED_NOTES_DIGEST" ]
+          object="$(gh api "repos/${REPO}/git/ref/tags/${TAG}" --jq '.object.type + " " + .object.sha')"
+          type="${object%% *}"; sha="${object#* }"
+          if [ "$type" = tag ]; then object="$(gh api "repos/${REPO}/git/tags/${sha}" --jq '.object.type + " " + .object.sha')"; type="${object%% *}"; sha="${object#* }"; fi
+          [ "$type" = commit ] && [ "$sha" = "$EXPECTED_COMMIT" ]
+          echo "sha=${sha}" >> "$GITHUB_OUTPUT"
+      - name: Create the GitHub Release from the canonical bytes # zizmor: ignore[superfluous-actions] -- the pinned action provides fail-on-unmatched-files, reviewed release-note handling, prerelease handling, target_commitish, and overwrite control as one operation
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
+        with:
+          tag_name: ${{ github.ref_name }}
+          target_commitish: ${{ steps.tag.outputs.sha }}
+          body_path: RELEASE_NOTES_${{ needs.source.outputs.version }}.md
+          files: surfguard-${{ needs.source.outputs.version }}.gem
           fail_on_unmatched_files: true
-          prerelease: ${{ needs.build.outputs.prerelease == 'true' }}
+          overwrite_files: false
+          prerelease: ${{ needs.source.outputs.prerelease == 'true' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -261,7 +261,16 @@ jobs:
         env:
           VERSION: ${{ needs.source.outputs.version }}
           GEM_SHA: ${{ needs.package.outputs.gem_sha256 }}
-        run: echo "decision=$(ruby script/release/registry_check.rb surfguard "$VERSION" "$GEM_SHA" 300)" >> "$GITHUB_OUTPUT"
+        # A standalone assignment so a nonzero helper exit fails the step
+        # (inside `echo "$(…)"` it would be swallowed), plus an explicit
+        # allowlist of the two valid decisions before anything is recorded.
+        run: |
+          decision="$(ruby script/release/registry_check.rb surfguard "$VERSION" "$GEM_SHA" 300)"
+          case "$decision" in
+            push|skip) ;;
+            *) echo "::error::Reconciliation produced no usable decision"; exit 1 ;;
+          esac
+          echo "decision=${decision}" >> "$GITHUB_OUTPUT"
 
   publish:
     name: Publish with hosted RubyGems
@@ -389,6 +398,32 @@ jobs:
           if [ "$type" = tag ]; then object="$(gh api "repos/${REPO}/git/tags/${sha}" --jq '.object.type + " " + .object.sha')"; type="${object%% *}"; sha="${object#* }"; fi
           [ "$type" = commit ] && [ "$sha" = "$EXPECTED_COMMIT" ]
           echo "sha=${sha}" >> "$GITHUB_OUTPUT"
+          # overwrite_files: false silently retains a same-named asset, so an
+          # asset left by a partial or manual run must be proven byte-identical
+          # to the canonical gem before this job can succeed. Only a missing
+          # release (HTTP 404) may skip the comparison; any other query failure
+          # fails closed.
+          set +e
+          asset_names="$(gh api "repos/${REPO}/releases/tags/${TAG}" --jq '[.assets[].name]' 2>release-query-error.txt)"
+          query_status=$?
+          set -e
+          if [ "$query_status" -ne 0 ]; then
+            if ! grep --quiet "HTTP 404" release-query-error.txt; then
+              cat release-query-error.txt
+              echo "::error::Could not determine whether a release asset already exists"
+              exit 1
+            fi
+            asset_names="[]"
+          fi
+          if jq --exit-status --arg name "surfguard-${VERSION}.gem" 'index($name) != null' <<<"$asset_names" >/dev/null; then
+            gh release download "$TAG" --repo "$REPO" --pattern "surfguard-${VERSION}.gem" --output existing-asset.gem
+            existing="$(sha256sum existing-asset.gem | awk '{print $1}')"
+            rm existing-asset.gem
+            if [ "$existing" != "$EXPECTED_DIGEST" ]; then
+              echo "::error::Existing release asset digest ${existing} does not match canonical ${EXPECTED_DIGEST}; refusing to finish a release that serves different bytes"
+              exit 1
+            fi
+          fi
       - name: Create the GitHub Release from the canonical bytes # zizmor: ignore[superfluous-actions] -- the pinned action provides fail-on-unmatched-files, reviewed release-note handling, prerelease handling, target_commitish, and overwrite control as one operation
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    surfguard (0.1.3)
+    surfguard (0.2.0)
 
 GEM
   remote: https://rubygems.org/
@@ -130,7 +130,7 @@ CHECKSUMS
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
   simplecov (1.1.1) sha256=25825ef13f0b2e74694d769817dad6ab8e90131dabdaa666e522fea105521e78
-  surfguard (0.1.3)
+  surfguard (0.2.0)
   tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b
   unicode-display_width (3.2.0) sha256=0cdd96b5681a5949cdbc2c55e7b420facae74c4aaf9a9815eee1087cb1853c42
   unicode-emoji (4.2.0) sha256=519e69150f75652e40bf736106cfbc8f0f73aa3fb6a65afe62fefa7f80b0f80f

--- a/README.md
+++ b/README.md
@@ -8,7 +8,24 @@ Surfguard resolves and classifies addresses for Ruby applications that fetch a U
 gem "surfguard"
 ```
 
-Surfguard requires Ruby 3.4.5 or newer and has zero runtime dependencies.
+Surfguard 0.2 requires Ruby 3.4.5 or newer and has zero runtime dependencies.
+
+To verify a downloaded release artifact against its repository, normal release
+workflow, and immutable tag:
+
+```sh
+gh attestation verify surfguard-X.Y.Z.gem \
+  --repo basecamp/surfguard \
+  --signer-workflow basecamp/surfguard/.github/workflows/release.yml \
+  --source-ref refs/tags/vX.Y.Z
+```
+
+If the release was completed through the documented recovery path, substitute
+`release-recovery.yml` as the signer workflow. Recovery dispatched on `main`
+has `refs/heads/main` provenance; confirm its logged tag/rebuild equality as
+described in the
+[release guide](https://github.com/basecamp/surfguard/blob/main/RELEASING.md)
+before accepting that residual case.
 
 ## APIs and policies
 

--- a/RELEASE_NOTES_0.2.0.md
+++ b/RELEASE_NOTES_0.2.0.md
@@ -1,0 +1,13 @@
+# Surfguard 0.2.0
+
+Surfguard 0.2.0 closes the reserved/unallocated IPv6 default-allow gap. The default policy now admits only reviewed IANA `Status=ALLOCATED` IPv6 unicast prefixes plus the documented transition and globally reachable service exceptions. The previously reported three-prefix v0.1.3 regression was stale; its boundaries are nevertheless locked down across every public API.
+
+The five public APIs now accept `policy:`. The default remains reachability-oriented; the new trusted-caller `:iana_special_use` policy blocks every checked-in RFC 6890/IANA special-purpose prefix, including AMT, AS112, and the complete NAT64 well-known prefix. Unknown policies raise `ArgumentError`.
+
+Input and resolver handling is now owned, bounded, and fail-closed: malformed encodings, zones, networks, unstable coercion, malformed mixed answers, and more than 256 answers are rejected. Results and policy data are deeply frozen, resolver order is preserved by the single-address API, and public error messages are fixed strings without attacker-controlled content.
+
+Caller guidance now includes a tested, proxy-disabled Net::HTTP recipe that preserves Host/SNI/certificate identity, pins the validated address, bounds response bytes, retries without resolving again, and revalidates every redirect. Surfguard remains an address policy rather than an HTTP client; callers still own schemes, userinfo, redirects, request deadlines, response handling, and egress controls.
+
+This release requires Ruby 3.4.5 or newer and keeps zero runtime dependencies. CI covers Ruby 3.4.5, current 3.4, 4.0, head, macOS, Windows, and pinned musl, and rejects vulnerable effective `resolv` versions. Explicitly downgrading `resolv` beneath the supported patched ranges is unsupported.
+
+Release assurance now includes exact raw gem-archive validation, immutable-source byte and mode comparison, isolated installed-byte tests, independent reproducible builds, bounded and pinned RubyGems access, canonical registry-byte confirmation, split attestation/release authority, stricter Dependabot lockfile validation, and hardened release helpers. The accepted High SG-02 residual remains: one authorized principal can initiate and self-approve a release until a second principal is available.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -3,36 +3,48 @@
 Releases are cut by tagging `main`. The tag triggers `.github/workflows/release.yml`:
 
 ```
-test -> build -> publish -> confirm -> attest -> github-release
+test -> source -> build -> package -> independent rebuild -> reconcile -> publish -> confirm -> attest -> github-release
 ```
 
 - **test** — RuboCop + the full suite (coverage thresholds enforced).
+- **source** — validates the version and annotated release tag without running
+  repository code, then emits immutable, SHA-256-addressed release helpers and
+  the reviewed release notes.
 - **build** — unprivileged job that builds the gem with an exactly pinned
   toolchain (Ruby + RubyGems versions in `release.yml`; `SOURCE_DATE_EPOCH`
-  from the commit, so identical source produces identical bytes), verifies the
-  package (`script/release/verify_package.rb`), and emits the artifact plus its
-  SHA-256. Artifact identity flows forward **by digest**: every later job
-  re-downloads the artifact and asserts that digest before acting.
+  from the commit, so identical source produces identical bytes) and uploads
+  the candidate. It does not supply its own verification result.
+- **package** — a fresh runner downloads the immutable build artifact, records
+  its digest before executing package code, verifies the raw archive, source
+  bytes/modes, isolated installation, and installed-byte suite, then rechecks
+  the original path. This job's digest is the identity every authority-bearing
+  job must consume.
+- **rebuild** — a second fresh runner must reproduce the verified package
+  digest and pass the same package verifier.
+- **reconcile** — an unprivileged, credential-free registry state machine; its
+  downloaded scripts are checked against the source-manifest digests before
+  execution.
 - **publish** — the only job that can mint RubyGems credentials, gated by the
   `release-rubygems` environment (required reviewer: Jeremy) and OIDC trusted
   publishing. No checkout and no artifact-delivered executable code: only the
-  `.gem` enters this job. Before pushing it reconciles with the registry using
-  workflow-owned `curl`/`jq` — a total state machine: version absent → push;
-  already published with exactly our bytes → skip (idempotent re-run);
-  anything else → fail closed. It verifies the gem digest again immediately
-  before `gem push`. Credentials are scrubbed unconditionally (`if: always()`),
-  even when the push fails.
+  `.gem` enters this job. It has no checkout, Ruby setup, installer, downloaded
+  script, or arbitrary executable download and uses the hosted `gem` command
+  only for `gem push`. If trusted-publishing credentials were configured, the
+  action-created credentials file is removed on success or failure; this is not
+  a claim that arbitrary process state can be scrubbed.
 - **confirm** — deliberately credential-free (`permissions: {}`): polls the
   registry until it reports exactly our version with exactly our digest, then
-  downloads the canonical bytes from RubyGems and asserts their digest equals
-  the artifact digest.
+  downloads and atomically saves the canonical bytes from RubyGems, asserts
+  their digest, and uploads them as `canonical-gem`.
 - **attest** — attests SLSA build provenance for the canonical,
   registry-confirmed bytes only.
-- **github-release** — creates the GitHub Release with the exact `.gem`
-  attached (`fail_on_unmatched_files: true`).
+- **github-release** — independently rechecks the canonical digest and tag SHA,
+  disables asset overwrite, uses the verified commit as `target_commitish`,
+  and publishes only the reviewed, digest-checked release notes.
 
 `workflow_dispatch` on `release.yml` is always a **no-publish rehearsal**:
-test → build only. No environment prompt, no credentials, no attestation.
+test → source → build → package → independent rebuild only. No environment
+prompt, credentials, registry reconciliation, attestation, or release creation.
 Rehearse before every first-of-its-kind release.
 
 ## Cutting a release
@@ -45,19 +57,34 @@ Rehearse before every first-of-its-kind release.
    publisher **immediately before tagging** (pending publishers expire after
    ~12 hours) — see one-time setup below.
 3. On an up-to-date `main` checkout: `rake tag`. Guards: clean tree, on
-   `main`, HEAD == `origin/main` after fetch, tag absent locally and remotely.
-   It pushes `main` first, then the tag.
+   `main`, HEAD == the fetched canonical push URL, and the remote tag absent.
+   Retry is allowed only for an exact annotated local tag that peels to HEAD.
 4. Approve the `release-rubygems` environment when the run pauses.
 5. Watch the run to completion. Verify afterwards:
    - digest equality across the RubyGems download, the GitHub Release asset,
      and the attestation subject;
-   - `gh attestation verify surfguard-X.Y.Z.gem --signer-workflow basecamp/surfguard/.github/workflows/release.yml --source-ref refs/tags/vX.Y.Z` —
-     constrain by signer workflow **and** source ref, not just `--repo`.
-     (A release finished by the recovery workflow is signed by it instead:
-     use `--signer-workflow basecamp/surfguard/.github/workflows/release-recovery.yml`,
-     with `--source-ref refs/tags/vX.Y.Z` when recovery was dispatched on the
-     tag — the preferred mode — or `--source-ref refs/heads/main` when it had
-     to be dispatched on `main`.)
+   - constrain attestation verification by repository, signer workflow,
+     **and** source ref:
+
+     ```sh
+     gh attestation verify surfguard-X.Y.Z.gem \
+       --repo basecamp/surfguard \
+       --signer-workflow basecamp/surfguard/.github/workflows/release.yml \
+       --source-ref refs/tags/vX.Y.Z
+     ```
+
+     A release finished by recovery is signed by that workflow instead:
+
+     ```sh
+     gh attestation verify surfguard-X.Y.Z.gem \
+       --repo basecamp/surfguard \
+       --signer-workflow basecamp/surfguard/.github/workflows/release-recovery.yml \
+       --source-ref refs/tags/vX.Y.Z
+     ```
+
+     Use `--source-ref refs/heads/main` only when recovery had to be dispatched
+     on `main`. The GitHub CLI requires `--repo` or `--owner`; the signer
+     constraints do not replace it.
 6. **First release only:** verify durable ownership on RubyGems — the gem
    sits under the RubyGems `basecamp` organization / the correct owner
    accounts with MFA enforced — before announcing.
@@ -78,7 +105,7 @@ any conflict. Recovery rules, by failure state:
 
 | State | Recovery |
 |---|---|
-| Failure before `gem push` ran (test/build/reconciliation) | Fix on `main`; delete the unpublished tag; re-tag. Allowed **only** because nothing was published. Tag deletion has **no standing bypass** — an admin must temporarily lift the `release-tags-immutable` ruleset, delete, and re-enable it. That friction is deliberate. |
+| Failure before `gem push` ran (test/source/build/package/rebuild/reconciliation) | Fix on `main`; delete the unpublished tag; re-tag. Allowed **only** because nothing was published. Tag deletion has **no standing bypass** — an admin must temporarily lift the `release-tags-immutable` ruleset, delete, and re-enable it. That friction is deliberate. |
 | Push succeeded; confirm/attest/release failed | Re-run the same run/tag. Reconciliation sees same-SHA → skips the push; downstream completes idempotently. |
 | **Ambiguous push result** (push errored/timed out; registry state unknown) | Never use a later 404 to justify deleting or moving the tag. Poll, then **download the canonical RubyGems bytes and compare digests**. Match → re-run the same tag to finish. Absent after bounded polling → re-run the same tag (reconciliation decides). Indeterminate/conflicting → **stop; contact RubyGems support**. |
 | Workflow defect embedded in a published tag | Re-runs use the tagged workflow; fixing `main` doesn't fix the tag. Never move/delete the tag. Run `release-recovery.yml` (dispatch with the version) to finish attestation + the GitHub Release from verified canonical registry bytes; ship the workflow fix in the next version. |
@@ -86,15 +113,17 @@ any conflict. Recovery rules, by failure state:
 
 `release-recovery.yml` never publishes and never mints RubyGems credentials.
 It mirrors the release pipeline's privilege separation: an **unprivileged
-`verify` job** proves the `vX.Y.Z` tag exists on `main` (so a typo can never
-attest an arbitrary registry version or mint a fresh tag at the
-default-branch tip), extracts the tagged source to the side with
-`git archive` (the recovery helpers keep running from the dispatch revision,
-not the possibly-defective tag), **rebuilds the gem with the tag's own
-toolchain pins**, and requires the rebuilt digest to equal the canonical
-RubyGems digest. Only then does the **reviewer-gated `finish` job**
-(`release-recovery` environment, same reviewer as publishing, no checkout)
-attest and create the GitHub Release from the canonical bytes. That digest
+`rebuild` job** proves the `vX.Y.Z` tag exists on `main` (so a typo can never
+attest an arbitrary registry version or mint a fresh tag at the default-branch
+tip), extracts the tagged source to the side with `git archive`, and rebuilds
+the gem with the tag's own toolchain pins. A separate fresh **`verify` job**
+revalidates the immutable tag, downloads and uploads the canonical RubyGems
+bytes before executing tagged package code, then verifies the immutable
+rebuild artifact against the tagged source and requires rebuilt == canonical.
+Only then do separate reviewer-gated jobs independently recheck the canonical
+digest: `attest` has only OIDC/attestation authority, and `github-release` has
+only `contents: write` and immediately re-reads the tag before creating the
+Release. That digest
 equality is what makes the recovery attestation honest: the attested bytes
 are demonstrably the product of the tagged source, not merely whatever the
 registry served. A mismatch stops the workflow for a human.
@@ -124,8 +153,9 @@ repository-owned workflow or ruleset.
 
 ## One-time setup
 
-Idempotent payloads, each **read back** to assert the declared invariant.
-Replace IDs where noted.
+Setup payloads, each **read back** to assert the declared invariant. Creation
+calls are one-time operations and can report an already-existing resource when
+repeated. Replace IDs where noted.
 
 1. **Workflow token defaults** — read-only token, bot approvals enabled
    (required for zero-touch Dependabot automation), and the repository's
@@ -171,8 +201,34 @@ Replace IDs where noted.
    `can_admins_bypass: false` as above, with deployment branch policies for
    both `main` (branch type) and `v*` (tag type): recovery is preferably
    dispatched on the release tag (binding provenance to it) and falls back
-   to `main`. Gates `release-recovery.yml`'s attestation + Release
-   permissions behind the same human as publishing.
+   to `main`. This environment gates only the recovery `attest` job's
+   OIDC/attestation authority.
+
+3b. **Environment `github-release`** — same reviewer,
+   `prevent_self_review: false`, and `can_admins_bypass: false`, also with
+   `main` (branch) and `v*` (tag) deployment policies. This distinct
+   environment gates the `contents: write` GitHub Release job in both normal
+   and recovery workflows. Configure and read back both environments before
+   either workflow references them:
+
+   ```sh
+   reviewer_id=$(gh api users/jeremy --jq .id)
+   for environment in release-recovery github-release; do
+     gh api -X PUT "repos/basecamp/surfguard/environments/${environment}" \
+       --input - <<JSON
+   { "reviewers": [{ "type": "User", "id": ${reviewer_id} }],
+     "prevent_self_review": false,
+     "can_admins_bypass": false,
+     "deployment_branch_policy": { "protected_branches": false, "custom_branch_policies": true } }
+   JSON
+     gh api -X POST "repos/basecamp/surfguard/environments/${environment}/deployment-branch-policies" \
+       -f name=main -f type=branch
+     gh api -X POST "repos/basecamp/surfguard/environments/${environment}/deployment-branch-policies" \
+       -f name='v*' -f type=tag
+     gh api "repos/basecamp/surfguard/environments/${environment}"
+     gh api "repos/basecamp/surfguard/environments/${environment}/deployment-branch-policies"
+   done
+   ```
 
 4. **Tag rulesets** — two separate rulesets on `refs/tags/v*`, enforcement
    `active`: (a) creation restricted, bypass_actors = the release team only
@@ -202,26 +258,48 @@ Replace IDs where noted.
 
 9. **Dependency graph** — confirm enabled (Settings → Security).
 
-10. **RubyGems trusted publisher** — **immediately before v0.1.0** (pending
+10. **RubyGems trusted publisher** — **immediately before a release** (pending
     publishers expire ~12h): create/verify the pending trusted publisher for
     gem `surfguard`: owner `basecamp`, repository `surfguard`, workflow
     `release.yml`, environment `release-rubygems`. A v1 API 404 for the gem
     name is **never** treated as proof the name is unclaimed. **After first
     publication**: move/verify ownership under the RubyGems `basecamp`
-    organization with MFA enforced, before announcing.
+    organization with MFA enforced, before announcing. Save the owner/MFA and
+    trusted-publisher readback with the release evidence. For 0.2.0 that
+    evidence remains pending because this implementation does not publish.
+
+## 0.2.0 control readback (2026-08-17)
+
+Before either workflow referenced it, `github-release` was created and read
+back with sole reviewer `jeremy` (numeric id 199), self-review allowed,
+`can_admins_bypass: false`, and deployment policies `v*` (tag) plus `main`
+(branch). The unused `copilot` environment was verified to have no protection
+rules and deleted; readback lists only `github-release`, `release-recovery`,
+and `release-rubygems`.
+
+Repository Actions were changed from unrestricted to selected repositories
+and read back with full-SHA pinning required, GitHub-owned/verified blanket
+allowances disabled, and only repositories referenced by checked-in workflows
+allowed. RubyGems owner/MFA and trusted-publisher evidence is still a mandatory
+manual pre-tag gate. No tag or publication was performed.
 
 ## Dependabot automation
 
-`dependabot-auto-merge.yml` auto-approves and auto-merges **Bundler
-patch/minor** updates only, via a constrained `pull_request_target` workflow
+`dependabot-auto-merge.yml` auto-approves and auto-merges **lockfile-only,
+single-direct-dependency Bundler patch/minor** updates, via a constrained `pull_request_target` workflow
 that never checks out or executes PR-controlled code. Everything else —
 bundler major, all github-actions updates — is human-gated. The approval is
-created through the API pinned to the validated head commit, the merge is
-pinned with `--match-head-commit`, and a human push to a Dependabot PR
-triggers a revoke job that disables any pending auto-merge (the
-dismiss-stale-reviews branch rule retracts the bot approval at the same
-time). CODEOWNERS pairs a blanket `* @jeremy` rule with an ownerless
-`/Gemfile.lock` override: every path requires code-owner review except the
-lockfile, so lockfile-only Dependabot PRs don't deadlock on code-owner
-review while any PR touching anything else stays human-gated; the required
+created through the API pinned to the validated head commit, and the merge is
+pinned with `--match-head-commit`. Automation requires an open, non-draft PR
+authored by Dependabot, a same-repository Dependabot head, and a base in this
+repository's protected `main`. The current base/head identity and every
+commit's Dependabot author, committer, and verified signature are checked
+again immediately before approval and immediately before merge enablement. A
+human push to a Dependabot PR triggers a revoke job that disables any pending
+auto-merge (the dismiss-stale-reviews branch rule retracts the bot approval at
+the same time). The trusted-base validator and base/head lockfiles are fetched
+through the API at exact SHAs; PR code is never checked out. Source, structure,
+prerelease, major, transitive, grouped, ambiguous, added, or removed changes
+require human review. CODEOWNERS uses an ownerless trailing `/Gemfile.lock` pattern to remove
+lockfile ownership while its catch-all protects every other path; the required
 `CI` check still gates every merge.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -128,6 +128,14 @@ equality is what makes the recovery attestation honest: the attested bytes
 are demonstrably the product of the tagged source, not merely whatever the
 registry served. A mismatch stops the workflow for a human.
 
+Recovery applies to **0.2.0+ tags only** — releases cut by the pipeline it
+mirrors, whose tags carry the toolchain digest pins, `RELEASE_NOTES_X.Y.Z.md`,
+and the package contract the verifier asserts. The 0.1.x releases are already
+complete (published, attested, released), so there is nothing for recovery to
+finish; a defective earlier release ships a new patch version per SECURITY.md.
+The workflow refuses pre-0.2.0 tags with an explicit error rather than
+carrying untestable legacy fallbacks.
+
 Dispatch recovery **on the release tag** when possible:
 
 ```sh

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -35,6 +35,21 @@ Synchronous name resolution has no independent cancellation deadline; callers ow
 worker deadlines. Public-addressed internal routes, custom DNS64, ISATAP/6rd, provider aliases,
 proxy configuration, and resolver/NSS divergence remain deployment risks requiring egress controls.
 
+## Accepted governance risk
+
+SG-02 is accepted as a **High residual risk**: one principal can initiate and approve a release,
+self-review remains enabled, and the current admin/write radius is external trust. Until a second
+authorized principal is available, the compensating controls are immutable release tags, no admin
+environment bypass, protected workflows, least-privilege jobs, reproducible package comparison,
+canonical-registry-byte confirmation, and read-only control-state checks. This decision is revisited
+only when a second authorized principal becomes available.
+
+Recovery dispatched from `main` retains `main`-bound provenance, and release tags remain unsigned;
+both are documented accepted residuals. GitHub-hosted runners, the Actions artifact service, and
+GitHub's control plane remain external trust; fresh-runner verification, reproducible rebuilding,
+and canonical-registry digest equality reduce but cannot eliminate that exposure. Explicitly
+overriding a supported Ruby with a vulnerable `resolv` gem is unsupported residual risk.
+
 Non-security bugs and questions belong in the
 [regular issue tracker](https://github.com/basecamp/surfguard/issues).
 

--- a/lib/surfguard/version.rb
+++ b/lib/surfguard/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Surfguard
-  VERSION = "0.1.3"
+  VERSION = "0.2.0"
 end

--- a/test/release/dependabot_validator_test.rb
+++ b/test/release/dependabot_validator_test.rb
@@ -236,7 +236,7 @@ class DependabotValidatorTest < Minitest::Test
     cases = {
       "top-level dependency" => valid.sub("  minitest\n", "  minitest (= 6.0.6)\n"),
       "platform structure" => valid.sub("  ruby\n", "  ruby\n  arm64-darwin\n"),
-      "local path source" => valid.sub("surfguard (0.1.3)", "surfguard (0.1.4)"),
+      "local path source" => valid.sub("surfguard (0.2.0)", "surfguard (0.2.1)"),
       "outside version/checksum" => valid.sub("      base64\n", "      base64 (>= 0)\n")
     }
 

--- a/test/release/publish_reconciliation_workflow_test.rb
+++ b/test/release/publish_reconciliation_workflow_test.rb
@@ -152,6 +152,31 @@ class WorkflowPolicyTest < Minitest::Test
     end
   end
 
+  def test_reconciliation_decision_fails_closed_and_is_allowlisted
+    check = workflow.fetch("jobs").fetch("reconcile").fetch("steps")
+      .find { |step| step["id"] == "check" }.fetch("run")
+
+    # A standalone assignment (never inside `echo "$(…)"`) so a nonzero helper
+    # exit fails the step, then an explicit push/skip allowlist before the
+    # decision is recorded.
+    assert_match(/^decision="\$\(ruby script\/release\/registry_check\.rb /, check)
+    assert_includes check, "push|skip"
+    refute_match(/echo "decision=\$\(/, check)
+  end
+
+  def test_release_creation_verifies_any_existing_asset_before_upload
+    [ [ RELEASE, "EXPECTED_DIGEST" ], [ RECOVERY, "GEM_SHA256" ] ].each do |path, digest_variable|
+      steps = workflow(path).fetch("jobs").fetch("github-release").fetch("steps")
+      preflight = steps.index { |step| step["run"]&.include?("existing-asset.gem") }
+      authority = steps.index { |step| step["uses"]&.start_with?("softprops/action-gh-release@") }
+
+      refute_nil preflight, path
+      assert_operator preflight, :<, authority, path
+      assert_includes steps.fetch(preflight).fetch("run"), digest_variable
+      assert_equal false, steps.fetch(authority).fetch("with").fetch("overwrite_files"), path
+    end
+  end
+
   def test_release_has_independent_rebuild_and_script_digest_verification
     jobs = workflow.fetch("jobs")
     assert jobs.key?("rebuild")
@@ -364,7 +389,8 @@ class WorkflowPolicyTest < Minitest::Test
     assert_includes boundary, '.base.sha == $base and .base.ref == "main"'
     assert_includes boundary, ".base.repo.full_name == $repo"
     assert_includes boundary, '.author.login == "dependabot[bot]"'
-    assert_includes boundary, '.committer.login == "dependabot[bot]"'
+    # Dependabot commits are committed and signed server-side by GitHub.
+    assert_includes boundary, '.committer.login == "web-flow"'
     assert_includes boundary, ".commit.verification.verified == true"
     assert_operator boundary.index('revalidate_current_pr "before approval"'), :<, boundary.index("-f event=APPROVE")
     assert_operator boundary.index("-f event=APPROVE"), :<, boundary.index('revalidate_current_pr "before merge"')

--- a/test/release/publish_reconciliation_workflow_test.rb
+++ b/test/release/publish_reconciliation_workflow_test.rb
@@ -1,280 +1,390 @@
 # frozen_string_literal: true
 
 require_relative "../test_helper"
-
-require "json"
-require "open3"
-require "rbconfig"
-require "tmpdir"
 require "yaml"
 
-# Executes the publish job's workflow-owned registry reconciliation verbatim.
-# A minimal PATH makes accidentally reaching the network impossible through the
-# named curl command, while scripted curl and sleep executables make every
-# state-machine transition deterministic and fast.
-class PublishReconciliationWorkflowTest < Minitest::Test
-  STEP_ID = "reconcile"
-  STEP_NAME = "Reconcile with the registry (total state machine; fails closed)"
-  WORKFLOW_PATH = File.expand_path("../../.github/workflows/release.yml", __dir__)
+class WorkflowPolicyTest < Minitest::Test
+  ROOT = File.expand_path("../..", __dir__)
+  RELEASE = File.join(ROOT, ".github/workflows/release.yml")
+  RECOVERY = File.join(ROOT, ".github/workflows/release-recovery.yml")
+  CI = File.join(ROOT, ".github/workflows/ci.yml")
+  DEPENDABOT = File.join(ROOT, ".github/workflows/dependabot-auto-merge.yml")
+  ALLOWED_ACTION_REPOSITORIES = %w[
+    actions/attest actions/checkout actions/dependency-review-action
+    actions/download-artifact actions/upload-artifact dependabot/fetch-metadata
+    github/codeql-action rubygems/configure-rubygems-credentials ruby/setup-ruby
+    softprops/action-gh-release zizmorcore/zizmor-action
+  ].freeze
 
-  VERSION = "0.1.0"
-  GEM_SHA256 = ("a" * 64).freeze
-  OTHER_SHA256 = ("b" * 64).freeze
-  REGISTRY_URL = "https://rubygems.org/api/v2/rubygems/surfguard/versions/0.1.0.json"
+  def workflow(path = RELEASE)
+    YAML.safe_load(File.read(path), aliases: false)
+  end
 
-  RunResult = Struct.new(:stdout, :stderr, :status, :github_output, :curl_calls, :sleeps,
-    keyword_init: true)
+  def scripts(job)
+    job.fetch("steps").filter_map { |step| step["run"] }.join("\n")
+  end
 
-  def self.load_reconciliation_script
-    workflow = YAML.safe_load(File.read(WORKFLOW_PATH), aliases: false)
-    steps = workflow.fetch("jobs").fetch("publish").fetch("steps")
-    matches = steps.select do |step|
-      step.is_a?(Hash) && step["id"] == STEP_ID && step["name"] == STEP_NAME
+  def action_steps(job, repository)
+    job.fetch("steps").select { |step| step["uses"]&.start_with?("#{repository}@") }
+  end
+
+  def test_oidc_publish_job_executes_no_checkout_setup_downloaded_script_or_installer
+    publish = workflow.fetch("jobs").fetch("publish")
+    assert_equal %w[name if needs runs-on timeout-minutes environment permissions env steps], publish.keys
+    assert_equal "ubuntu-latest", publish.fetch("runs-on")
+    assert_equal "release-rubygems", publish.fetch("environment")
+    assert_equal({ "id-token" => "write" }, publish.fetch("permissions"))
+    assert_operator publish.fetch("timeout-minutes"), :<=, 10
+
+    uses = publish.fetch("steps").filter_map { |step| step["uses"] }
+    assert_equal %w[actions/download-artifact rubygems/configure-rubygems-credentials],
+      uses.map { |entry| entry.split("@").first }
+    refute uses.any? { |entry| entry.start_with?("actions/checkout@", "ruby/setup-ruby@") }
+    assert uses.all? { |entry| entry.match?(/@[0-9a-f]{40}\z/) }
+    publish_scripts = scripts(publish)
+    refute_match(/gem update|gem install|curl|wget|script\/release|bundle|ruby\/setup|source |chmod|\beval\b/, publish_scripts)
+    assert_match(/gem push/, publish_scripts)
+    downloads = action_steps(publish, "actions/download-artifact")
+    assert_equal 1, downloads.length
+    download = downloads.first
+    assert_equal "rubygem", download.fetch("with").fetch("name")
+    refute download.fetch("with").key?("path")
+
+    scripts_by_name = publish.fetch("steps").filter_map do |step|
+      [ step.fetch("name"), step.fetch("run") ] if step.key?("run")
+    end.to_h
+    assert_equal [
+      "Verify artifact identity",
+      "Push using only the hosted runner gem command",
+      "Remove credentials created by the trusted-publishing action"
+    ], scripts_by_name.keys
+    assert_equal '[ "$(sha256sum "surfguard-${VERSION}.gem" | awk \'{print $1}\')" = "$GEM_SHA" ]',
+      scripts_by_name.fetch("Verify artifact identity")
+    assert_equal <<~'SHELL', scripts_by_name.fetch("Push using only the hosted runner gem command")
+      [ "$(sha256sum "surfguard-${VERSION}.gem" | awk '{print $1}')" = "$GEM_SHA" ]
+      gem push "surfguard-${VERSION}.gem"
+    SHELL
+    assert_equal <<~'SHELL'.chomp, scripts_by_name.fetch("Remove credentials created by the trusted-publishing action")
+      ruby -e 'path = File.expand_path("~/.gem/credentials"); File.delete(path) if File.file?(path) && !File.symlink?(path)'
+    SHELL
+  end
+
+
+  def test_dispatch_is_provably_no_publish_and_tag_authority_is_push_only
+    release = workflow
+    triggers = release.fetch(true)
+    assert_equal [ "v*" ], triggers.fetch("push").fetch("tags")
+    assert triggers.key?("workflow_dispatch")
+
+    jobs = release.fetch("jobs")
+    dispatch_jobs = %w[test source build package rebuild]
+    assert_equal dispatch_jobs, jobs.keys.reject { |name| jobs.fetch(name)["if"] }
+    %w[reconcile publish confirm attest github-release].each do |name|
+      assert_equal "github.event_name == 'push'", jobs.fetch(name).fetch("if"), name
+    end
+    expected_graph = {
+      "source" => %w[test],
+      "build" => %w[source],
+      "package" => %w[source build],
+      "rebuild" => %w[source package],
+      "reconcile" => %w[source package rebuild],
+      "publish" => %w[source package reconcile],
+      "confirm" => %w[source package publish],
+      "attest" => %w[source package confirm],
+      "github-release" => %w[source package confirm attest]
+    }
+    expected_graph.each do |name, needs|
+      assert_equal needs, Array(jobs.fetch(name).fetch("needs")), name
     end
 
-    raise "expected exactly one #{STEP_ID.inspect} / #{STEP_NAME.inspect} workflow step" unless matches.one?
-
-    matches.first.fetch("run").freeze
-  end
-  private_class_method :load_reconciliation_script
-
-  RECONCILIATION_SCRIPT = load_reconciliation_script
-
-  def test_404_means_push
-    result = run_reconciliation([ response(404) ])
-
-    assert_success(result)
-    assert_equal "decision=push\n", result.github_output
-    assert_equal 1, result.curl_calls
-    assert_empty result.sleeps
+    dispatch_jobs.each do |name|
+      assert_equal({ "contents" => "read" }, jobs.fetch(name).fetch("permissions"), name)
+      refute jobs.fetch(name).key?("environment"), name
+    end
   end
 
-  def test_matching_200_means_skip_and_normalizes_digest_case
-    result = run_reconciliation([
-      response(200, metadata(sha: GEM_SHA256.upcase))
-    ])
-
-    assert_success(result)
-    assert_equal "decision=skip\n", result.github_output
-    assert_equal 1, result.curl_calls
+  def test_canonical_registry_artifact_is_the_only_attestation_and_release_input
+    jobs = workflow.fetch("jobs")
+    assert_equal [ "source", "package", "publish" ], Array(jobs.fetch("confirm").fetch("needs"))
+    producers = jobs.flat_map do |name, job|
+      action_steps(job, "actions/upload-artifact").filter_map do |step|
+        name if step.fetch("with").fetch("name") == "canonical-gem"
+      end
+    end
+    assert_equal [ "confirm" ], producers
+    assert_equal [ "canonical-gem" ], action_steps(jobs.fetch("attest"), "actions/download-artifact").map {
+      |step| step.fetch("with").fetch("name")
+    }
+    assert_equal [ "canonical-gem", "release-notes" ],
+      action_steps(jobs.fetch("github-release"), "actions/download-artifact").map { |step| step.fetch("with").fetch("name") }
+    release_inputs = jobs.fetch("github-release").fetch("steps").last.fetch("with")
+    assert_equal false, release_inputs.fetch("overwrite_files")
+    assert release_inputs.key?("target_commitish")
+    assert_equal "RELEASE_NOTES_${{ needs.source.outputs.version }}.md", release_inputs.fetch("body_path")
+    refute release_inputs.key?("make_latest")
+    refute release_inputs.key?("generate_release_notes")
   end
 
-  def test_conflicting_digest_fails_closed
-    result = run_reconciliation([
-      response(200, metadata(sha: OTHER_SHA256))
-    ])
+  def test_canonical_artifact_producer_and_consumers_are_digest_gated_in_order
+    jobs = workflow.fetch("jobs")
+    confirm = jobs.fetch("confirm")
+    assert_equal [ "source", "package", "publish" ], Array(confirm.fetch("needs"))
+    confirm_steps = confirm.fetch("steps")
+    script_download = confirm_steps.index { |step| step["uses"]&.start_with?("actions/download-artifact@") }
+    script_check = confirm_steps.index { |step| step["name"] == "Verify release scripts before execution" }
+    execution = confirm_steps.index { |step| step["name"] == "Save and verify canonical registry artifact" }
+    upload = confirm_steps.index { |step| step["uses"]&.start_with?("actions/upload-artifact@") }
+    assert_operator script_download, :<, script_check
+    assert_operator script_check, :<, execution
+    assert_operator execution, :<, upload
+    assert_equal "canonical-gem", confirm_steps.fetch(upload).fetch("with").fetch("name")
+    assert_match(/registry_confirm\.rb.*surfguard-\$\{VERSION\}\.gem/m, confirm_steps.fetch(execution).fetch("run"))
 
-    assert_failure(result, /already published with sha256 #{OTHER_SHA256}/)
-    assert_equal 1, result.curl_calls
+    %w[attest github-release].each do |name|
+      job = jobs.fetch(name)
+      download_index = job.fetch("steps").index { |step| step["uses"]&.start_with?("actions/download-artifact@") }
+      digest_index = job.fetch("steps").index { |step| step["run"]&.include?("sha256sum") }
+      authority_index = job.fetch("steps").index do |step|
+        step["uses"]&.start_with?(name == "attest" ? "actions/attest@" : "softprops/action-gh-release@")
+      end
+      assert_operator download_index, :<, digest_index, name
+      assert_operator digest_index, :<, authority_index, name
+    end
   end
 
-  def test_malformed_json_fails_closed
-    result = run_reconciliation([ response(200, "not JSON") ])
-
-    assert_failure(result, /RubyGems returned malformed version metadata/)
-    assert_equal 1, result.curl_calls
+  def test_release_has_independent_rebuild_and_script_digest_verification
+    jobs = workflow.fetch("jobs")
+    assert jobs.key?("rebuild")
+    assert_includes Array(jobs.fetch("reconcile").fetch("needs")), "rebuild"
+    confirm_script = jobs.fetch("confirm").fetch("steps").filter_map { |step| step["run"] }.join("\n")
+    assert_includes confirm_script, "registry_confirm.rb"
+    assert_includes confirm_script, "sha256sum script/release/registry.rb"
   end
 
-  def test_malformed_json_shape_fails_closed
-    result = run_reconciliation([ response(200, JSON.generate([ VERSION, GEM_SHA256 ])) ])
+  def test_every_rubygems_installer_is_unprivileged_byte_pinned_and_version_checked
+    release = workflow.fetch("jobs")
+    recovery = workflow(RECOVERY).fetch("jobs")
+    installer_jobs = [ release.fetch("build"), release.fetch("rebuild"), recovery.fetch("rebuild") ]
 
-    assert_failure(result, /RubyGems returned malformed version metadata/)
-    assert_equal 1, result.curl_calls
+    installer_jobs.each do |job|
+      assert_equal({ "contents" => "read" }, job.fetch("permissions"))
+      script = scripts(job)
+      fetch = script.index("gem fetch rubygems-update")
+      digest = script.index("sha256sum --check")
+      install = script.index("gem install --local")
+      update = script.index("update_rubygems --no-document")
+      version = script.index('"$(gem --version)" = "$RUBYGEMS_VERSION"')
+      assert_operator fetch, :<, digest
+      assert_operator digest, :<, install
+      assert_operator install, :<, update
+      assert_operator update, :<, version
+      assert_includes script, "--clear-sources --source https://rubygems.org"
+      refute_includes script, "gem update --system"
+    end
   end
 
-  def test_metadata_for_a_different_version_fails_closed
-    result = run_reconciliation([
-      response(200, metadata(version: "9.9.9"))
-    ])
+  def test_package_identity_is_proved_on_fresh_runners_before_authority
+    jobs = workflow.fetch("jobs")
+    assert_equal [ "source", "build" ], Array(jobs.fetch("package").fetch("needs"))
+    assert_equal [ "source", "package" ], Array(jobs.fetch("rebuild").fetch("needs"))
 
-    assert_failure(result, /metadata for a different version; expected #{VERSION}/)
-    assert_equal 1, result.curl_calls
+    assert_equal [ "rubygem" ], action_steps(jobs.fetch("build"), "actions/upload-artifact").map {
+      |step| step.fetch("with").fetch("name")
+    }
+    rubygem_producers = jobs.flat_map do |name, job|
+      action_steps(job, "actions/upload-artifact").filter_map do |step|
+        name if step.fetch("with").fetch("name") == "rubygem"
+      end
+    end
+    assert_equal [ "build" ], rubygem_producers
+    package = jobs.fetch("package")
+    assert_equal [ "rubygem" ], action_steps(package, "actions/download-artifact").map {
+      |step| step.fetch("with").fetch("name")
+    }
+    capture = package.fetch("steps").index { |step| step["name"] == "Capture immutable artifact digest" }
+    verify = package.fetch("steps").index { |step| step["name"] == "Verify immutable candidate against source and installed bytes" }
+    assert_operator capture, :<, verify
+    verification_step = package.fetch("steps").fetch(verify)
+    assert_equal "${{ needs.source.outputs.commit_sha }}", verification_step.fetch("env").fetch("SOURCE_COMMIT")
+    assert_includes verification_step.fetch("run"), 'verify_package.rb "surfguard-${VERSION}.gem" surfguard "$VERSION" "$SOURCE_COMMIT"'
+    assert_includes package.fetch("steps").fetch(verify).fetch("run"), "sha256sum"
+
+    source = jobs.fetch("source")
+    manifest = source.fetch("steps").find { |step| step["name"] == "Validate tag and capture source manifest" }
+    assert_equal "${{ steps.manifest.outputs.commit_sha }}", source.fetch("outputs").fetch("commit_sha")
+    assert_includes manifest.fetch("run"), 'git rev-parse "refs/tags/${REF_NAME}^{commit}"'
+    assert_includes manifest.fetch("run"), 'git cat-file -t "$commit_sha"'
+    assert_includes manifest.fetch("run"), 'echo "commit_sha=${commit_sha}"'
+
+    publish = jobs.fetch("publish")
+    assert_equal [ "rubygem" ], action_steps(publish, "actions/download-artifact").map {
+      |step| step.fetch("with").fetch("name")
+    }
+    assert_equal "${{ needs.package.outputs.gem_sha256 }}", publish.fetch("env").fetch("GEM_SHA")
   end
 
-  def test_unexpected_status_fails_without_retrying
-    result = run_reconciliation([ response(403) ])
-
-    assert_failure(result, /Unexpected HTTP 403/)
-    assert_equal 1, result.curl_calls
-    assert_empty result.sleeps
+  def test_every_release_job_has_the_planned_timeout
+    workflow.fetch("jobs").each do |name, job|
+      limit = %w[test source build package rebuild].include?(name) ? 15 : 10
+      assert_operator job.fetch("timeout-minutes"), :<=, limit, name
+    end
   end
 
-  def test_retryable_statuses_back_off_then_succeed
-    result = run_reconciliation([
-      response(429),
-      response(503),
-      response(404)
-    ])
+  def test_ci_checks_bare_and_bundle_effective_resolv_versions
+    release_test = workflow.fetch("jobs").fetch("test")
+    assert_includes scripts(release_test), "ruby script/check_resolv_version.rb"
+    assert_includes scripts(release_test), "bundle exec ruby script/check_resolv_version.rb"
 
-    assert_success(result)
-    assert_equal "decision=push\n", result.github_output
-    assert_equal 3, result.curl_calls
-    assert_equal [ 2, 4 ], result.sleeps
+    ci = workflow(CI).fetch("jobs")
+    assert_includes scripts(ci.fetch("test")), "ruby script/check_resolv_version.rb"
+    assert_includes scripts(ci.fetch("lint")), "bundle exec ruby script/check_resolv_version.rb"
+    %w[platforms musl].each do |name|
+      assert_includes scripts(ci.fetch(name)), "ruby script/check_resolv_version.rb", name
+    end
   end
 
-  def test_persistent_retryable_status_fails_after_five_attempts
-    result = run_reconciliation(Array.new(5) { response(503) })
-
-    assert_failure(result, /RubyGems unavailable after 5 attempts \(HTTP 503\)/)
-    assert_equal 5, result.curl_calls
-    assert_equal [ 2, 4, 6, 8 ], result.sleeps
+  def test_every_workflow_action_is_sha_pinned_and_in_the_repository_allowlist
+    Dir[File.join(ROOT, ".github/workflows/*.yml")].each do |path|
+      File.read(path).scan(/^\s*-?\s*uses:\s*([^\s#]+)/).flatten.each do |use|
+        action, revision = use.split("@", 2)
+        repository = action.split("/").first(2).join("/")
+        assert_includes ALLOWED_ACTION_REPOSITORIES, repository, "#{path}: #{action}"
+        assert_match(/\A[0-9a-f]{40}\z/, revision, "#{path}: #{use}")
+      end
+    end
   end
 
-  def test_persistent_network_failure_fails_after_five_attempts
-    result = run_reconciliation(Array.new(5) { network_failure })
+  def test_recovery_splits_attestation_and_release_permissions
+    release_attest = workflow.fetch("jobs").fetch("attest")
+    assert_equal({
+      "id-token" => "write",
+      "attestations" => "write",
+      "artifact-metadata" => "write"
+    }, release_attest.fetch("permissions"))
+    assert_attestation_shape(release_attest, digest_name: "Independently recheck the canonical digest")
 
-    assert_failure(result, /RubyGems unavailable after 5 attempts \(network failure\)/)
-    assert_equal 5, result.curl_calls
-    assert_equal [ 2, 4, 6, 8 ], result.sleeps
+    recovery = workflow(RECOVERY).fetch("jobs")
+    assert_equal({
+      "id-token" => "write",
+      "attestations" => "write",
+      "artifact-metadata" => "write"
+    }, recovery.fetch("attest").fetch("permissions"))
+    assert_attestation_shape(recovery.fetch("attest"),
+      digest_name: "Verify artifact identity (digest must match the verify job's)")
+    assert_equal({ "contents" => "write" }, recovery.fetch("github-release").fetch("permissions"))
+    assert_equal "release-recovery", recovery.fetch("attest").fetch("environment")
+    assert_equal "github-release", recovery.fetch("github-release").fetch("environment")
+  end
+
+  def test_recovery_consumers_independently_verify_the_same_canonical_artifact
+    recovery = workflow(RECOVERY).fetch("jobs")
+    verify = recovery.fetch("verify")
+    canonical_download = verify.fetch("steps").index { |step| step["name"] == "Download canonical bytes before executing package code" }
+    canonical_upload = verify.fetch("steps").index do |step|
+      step["uses"]&.start_with?("actions/upload-artifact@") && step.dig("with", "name") == "canonical-gem"
+    end
+    package_verification = verify.fetch("steps").index {
+      |step| step["name"] == "Verify rebuilt package and prove rebuilt equals canonical"
+    }
+    assert_operator canonical_download, :<, canonical_upload
+    assert_operator canonical_upload, :<, package_verification
+
+    attest = recovery.fetch("attest")
+    assert_equal [ "canonical-gem" ], action_steps(attest, "actions/download-artifact").map {
+      |step| step.fetch("with").fetch("name")
+    }
+    assert_includes scripts(attest), "GEM_SHA256"
+
+    release = recovery.fetch("github-release")
+    assert_equal [ "canonical-gem", "release-notes" ], action_steps(release, "actions/download-artifact").map {
+      |step| step.fetch("with").fetch("name")
+    }
+    assert_includes scripts(release), "GEM_SHA256"
+    assert_includes scripts(release), "git/ref/tags/v${VERSION}"
+    assert_includes scripts(release), '"$sha" = "$TAG_SHA"'
+    inputs = release.fetch("steps").last.fetch("with")
+    assert_equal false, inputs.fetch("overwrite_files")
+    assert inputs.key?("target_commitish")
+    assert_equal "RELEASE_NOTES_${{ inputs.version }}.md", inputs.fetch("body_path")
+    refute inputs.key?("make_latest")
+  end
+
+  def test_ci_fan_in_has_an_explicit_closed_skip_policy
+    ci = workflow(CI).fetch("jobs")
+    fan_in = ci.fetch("ci")
+    expected = %w[test lint lint-actions dependency-review package-build package platforms musl iana-drift codeql]
+    assert_equal expected, fan_in.fetch("needs")
+    assert_equal "always()", fan_in.fetch("if")
+    fan_in_scripts = fan_in.fetch("steps").map { |step| [ step["if"], step["run"] ] }
+    assert fan_in_scripts.any? { |condition, run| condition&.include?("failure") && condition.include?("cancelled") && run == "exit 1" }
+    assert fan_in_scripts.any? { |condition, run| condition&.include?("needs.iana-drift.result == 'skipped'") && run == "exit 1" }
+    assert fan_in_scripts.any? { |condition, run| condition&.include?("needs.dependency-review.result == 'skipped'") && run == "exit 1" }
+    required = %w[test lint lint-actions package-build package platforms musl codeql]
+    skip_condition = fan_in_scripts.filter_map { |condition, run| condition if run == "exit 1" }.find do |condition|
+      required.all? { |name| condition.include?("needs.#{name}.result == 'skipped'") }
+    end
+    refute_nil skip_condition
+  end
+
+  def test_dependabot_never_checks_out_head_and_revalidates_protected_base_and_identity_at_both_boundaries
+    jobs = workflow(DEPENDABOT).fetch("jobs")
+    all_uses = jobs.values.flat_map { |job| job.fetch("steps").filter_map { |step| step["uses"] } }
+    refute all_uses.any? { |entry| entry.start_with?("actions/checkout@") }
+    assert_equal [ "dependabot/fetch-metadata" ], all_uses.map { |entry| entry.split("@").first }.uniq
+
+    metadata_condition = jobs.fetch("metadata").fetch("if")
+    assert_includes metadata_condition, "github.event.pull_request.state == 'open'"
+    assert_includes metadata_condition, "github.event.pull_request.draft == false"
+    assert_includes metadata_condition, "github.event.pull_request.base.repo.full_name == github.repository"
+    assert_includes metadata_condition, "github.event.pull_request.base.ref == 'main'"
+    assert_includes metadata_condition, "github.event.pull_request.head.repo.full_name == github.repository"
+
+    steps = jobs.fetch("automerge").fetch("steps")
+    initial = steps.fetch(0).fetch("run")
+    assert_includes initial, '[ "$state" = "open" ]'
+    assert_includes initial, '[ "$draft" = "false" ]'
+    assert_includes initial, '[ "$base_repo" = "$REPO" ]'
+    assert_includes initial, '[ "$base_ref" = "main" ]'
+    assert_includes initial, 'fetch_file .github/scripts/validate_dependabot_lockfile.rb "$base_sha" validator.rb'
+    assert_includes initial, 'fetch_file Gemfile.lock "$base_sha" base.lock'
+    assert_includes initial, 'fetch_file Gemfile.lock "$head_sha" head.lock'
+    assert_includes initial, '[[ "$base_sha" =~ ^[0-9a-f]{40}$ ]]'
+    assert_includes initial, 'echo "base_sha=${base_sha}" >> "$GITHUB_OUTPUT"'
+
+    assert_equal "${{ steps.validation.outputs.base_sha }}",
+      steps.fetch(1).fetch("env").fetch("VALIDATED_BASE_SHA")
+
+    boundary = steps.fetch(1).fetch("run")
+    assert_includes boundary, "revalidate_current_pr()"
+    assert_equal [ "before approval", "before merge" ],
+      boundary.scan(/^\s*revalidate_current_pr "([^"]+)"$/).flatten
+    assert_includes boundary, '.state == "open" and .draft == false'
+    assert_includes boundary, '.user.login == "dependabot[bot]"'
+    assert_includes boundary, ".head.sha == $head and .head.repo.full_name == $repo"
+    assert_includes boundary, '.base.sha == $base and .base.ref == "main"'
+    assert_includes boundary, ".base.repo.full_name == $repo"
+    assert_includes boundary, '.author.login == "dependabot[bot]"'
+    assert_includes boundary, '.committer.login == "dependabot[bot]"'
+    assert_includes boundary, ".commit.verification.verified == true"
+    assert_operator boundary.index('revalidate_current_pr "before approval"'), :<, boundary.index("-f event=APPROVE")
+    assert_operator boundary.index("-f event=APPROVE"), :<, boundary.index('revalidate_current_pr "before merge"')
+    assert_operator boundary.index('revalidate_current_pr "before merge"'), :<,
+      boundary.index('gh pr merge "$PR_URL"')
+    assert_includes boundary, '--match-head-commit "$EVENT_HEAD_SHA"'
   end
 
   private
-
-  def run_reconciliation(fixtures)
-    Dir.mktmpdir("surfguard-reconcile-test") do |directory|
-      bin_directory = File.join(directory, "bin")
-      Dir.mkdir(bin_directory)
-      install_real_commands(bin_directory)
-      install_fake_curl(bin_directory)
-      install_fake_sleep(bin_directory)
-
-      fixtures_path = File.join(directory, "curl-fixtures")
-      curl_index_path = File.join(directory, "curl-index")
-      sleep_log_path = File.join(directory, "sleep-log")
-      github_output_path = File.join(directory, "github-output")
-      File.binwrite(fixtures_path, Marshal.dump(fixtures))
-      File.write(curl_index_path, "0")
-      File.write(sleep_log_path, "")
-      File.write(github_output_path, "")
-
-      stdout, stderr, status = Open3.capture3(
-        isolated_environment(
-          directory: directory,
-          bin_directory: bin_directory,
-          fixtures_path: fixtures_path,
-          curl_index_path: curl_index_path,
-          sleep_log_path: sleep_log_path,
-          github_output_path: github_output_path
-        ),
-        executable("bash"), "--noprofile", "--norc", "-e", "-o", "pipefail", "-c",
-        RECONCILIATION_SCRIPT,
-        chdir: directory,
-        unsetenv_others: true
-      )
-
-      RunResult.new(
-        stdout: stdout,
-        stderr: stderr,
-        status: status,
-        github_output: File.read(github_output_path),
-        curl_calls: Integer(File.read(curl_index_path)),
-        sleeps: File.readlines(sleep_log_path, chomp: true).map(&:to_i)
-      )
+    def assert_attestation_shape(job, digest_name:)
+      steps = job.fetch("steps")
+      assert_equal 3, steps.length
+      assert_equal [ "actions/download-artifact", "actions/attest" ],
+        steps.filter_map { |step| step["uses"]&.split("@")&.first }
+      assert_equal [ digest_name ], steps.filter_map { |step| step["name"] if step.key?("run") }
+      assert_equal [ "canonical-gem" ], action_steps(job, "actions/download-artifact").map {
+        |step| step.fetch("with").fetch("name")
+      }
+      digest_script = steps.find { |step| step["name"] == digest_name }.fetch("run")
+      assert_includes digest_script, "sha256sum"
+      refute_match(/curl|wget|gem install|bundle|source |chmod|\beval\b/, digest_script)
     end
-  end
-
-  def isolated_environment(directory:, bin_directory:, fixtures_path:, curl_index_path:,
-    sleep_log_path:, github_output_path:)
-    {
-      "PATH" => bin_directory,
-      "HOME" => directory,
-      "TMPDIR" => directory,
-      "VERSION" => VERSION,
-      "GEM_SHA256" => GEM_SHA256,
-      "GITHUB_OUTPUT" => github_output_path,
-      "CURL_FIXTURES" => fixtures_path,
-      "CURL_INDEX" => curl_index_path,
-      "SLEEP_LOG" => sleep_log_path,
-      "EXPECTED_REGISTRY_URL" => REGISTRY_URL,
-      # Defense in depth if a future edit bypasses the fake curl by using an
-      # absolute path: external HTTP(S) still cannot leave through a proxy.
-      "HTTP_PROXY" => "http://127.0.0.1:1",
-      "HTTPS_PROXY" => "http://127.0.0.1:1",
-      "ALL_PROXY" => "http://127.0.0.1:1"
-    }
-  end
-
-  def install_real_commands(bin_directory)
-    %w[jq mktemp rm].each do |command|
-      File.symlink(executable(command), File.join(bin_directory, command))
-    end
-  end
-
-  def install_fake_curl(bin_directory)
-    write_executable(File.join(bin_directory, "curl"), <<~RUBY)
-      #!#{RbConfig.ruby}
-      fixtures = Marshal.load(File.binread(ENV.fetch("CURL_FIXTURES")))
-      index_path = ENV.fetch("CURL_INDEX")
-      index = Integer(File.read(index_path))
-      fixture = fixtures.fetch(index)
-      File.write(index_path, (index + 1).to_s)
-
-      output_index = ARGV.index("--output")
-      abort "fake curl requires --output" unless output_index
-      abort "unexpected registry URL" unless ARGV.last == ENV.fetch("EXPECTED_REGISTRY_URL")
-
-      File.binwrite(ARGV.fetch(output_index + 1), fixture.fetch(:body, ""))
-      $stderr.write(fixture.fetch(:stderr, ""))
-      $stdout.write(fixture.fetch(:status, "").to_s)
-      exit fixture.fetch(:exit_status, 0)
-    RUBY
-  end
-
-  def install_fake_sleep(bin_directory)
-    write_executable(File.join(bin_directory, "sleep"), <<~RUBY)
-      #!#{RbConfig.ruby}
-      abort "fake sleep requires one argument" unless ARGV.length == 1
-      File.open(ENV.fetch("SLEEP_LOG"), "a") { |file| file.puts(ARGV.first) }
-    RUBY
-  end
-
-  def write_executable(path, contents)
-    File.write(path, contents)
-    File.chmod(0o700, path)
-  end
-
-  def executable(command)
-    ENV.fetch("PATH").split(File::PATH_SEPARATOR).each do |directory|
-      path = File.join(directory, command)
-      return File.realpath(path) if File.file?(path) && File.executable?(path)
-    end
-
-    raise "required executable not found: #{command}"
-  end
-
-  def response(status, body = "")
-    { status: status.to_s, body: body }
-  end
-
-  def network_failure
-    {
-      status: "000",
-      stderr: "curl: simulated network failure\n",
-      exit_status: 7
-    }
-  end
-
-  def metadata(version: VERSION, sha: GEM_SHA256)
-    JSON.generate("number" => version, "sha" => sha)
-  end
-
-  def assert_success(result)
-    assert result.status.success?, failure_diagnostics(result)
-  end
-
-  def assert_failure(result, message_pattern)
-    refute result.status.success?, "expected workflow step to fail"
-    assert_empty result.github_output
-    assert_match message_pattern, result.stdout
-  end
-
-  def failure_diagnostics(result)
-    <<~MESSAGE
-      workflow step unexpectedly failed (#{result.status.exitstatus})
-      stdout:
-      #{result.stdout}
-      stderr:
-      #{result.stderr}
-    MESSAGE
-  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,13 +7,25 @@ if ENV["COVERAGE"]
   require "simplecov"
 
   SimpleCov.start do
-    enable_coverage :branch
-    add_filter "/test/"
-
-    # Measured actuals are 100/100 across lib/ and the release scripts the
-    # suite loads, so the thresholds pin them there: any change that leaves
-    # a line or branch untested fails loudly.
-    minimum_coverage line: 100, branch: 100
+    # Every owned runtime and release-critical Ruby implementation is included,
+    # including CLI entry points and live adapters. A new uncovered path must be
+    # tested or redesigned; it cannot disappear behind aggregate or per-file slack.
+    coverage(:line) do
+      minimum 100
+      minimum_per_file 100
+    end
+    coverage(:branch) do
+      minimum 100
+      minimum_per_file 100
+    end
+    # The default hidden-file filter would silently discard the owned
+    # Dependabot validator under `.github/scripts`. The explicit allowlist
+    # below is the complete coverage universe, so default skips add no safety
+    # and can only hide a newly tracked path.
+    no_default_skips
+    # `cover` is SimpleCov's non-deprecated track-files API: unloaded matching
+    # files remain in the report at zero rather than silently disappearing.
+    cover "lib/**/*.rb", "script/**/*.rb", ".github/scripts/**/*.rb", "Rakefile", "*.gemspec"
   end
 end
 


### PR DESCRIPTION
## Stack

5 of 5. Base: `security-hardening-04-dependabot`.

## Summary

- Separate source validation, candidate build, fresh package verification, independent rebuild, reconciliation, publication, confirmation, attestation, and GitHub Release authority.
- Keep the OIDC publication job to the hosted gem push command for the verified artifact; attest and release only independently rechecked registry-downloaded canonical bytes.
- Split recovery privileges, document accepted SG-02 High residual risk, enforce 100% per-file line and branch coverage, and prepare version and release notes for 0.2.0.

## Verification

- Local exact-head run: 382 tests / 90,656 assertions, 0 failures, 1 sandbox socket skip
- 1,846 / 1,846 lines and 841 / 841 branches covered
- RuboCop, actionlint, offline pedantic Zizmor, and IANA generator check
- Fresh-runner 0.2.0 gem verification passed raw archive, immutable source, isolated install, and installed-byte core suite checks: 138 tests / 87,957 assertions

No tag or publication was performed.
