### PR TITLE
Protect go/ tags and document how the Go module is released

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -128,16 +128,25 @@ record the tag's contents permanently on first fetch, so a mutated tag does
 not reach anyone who has already fetched it — and, worse, silently disagrees
 with the checksum database for everyone who has.
 
-That protection is not universal, and the exposed set is narrower than "anyone
-not using the proxy": it is consumers configured to fetch straight from
-version control, meaning `GOPROXY=direct` or a `GOPRIVATE`/`GONOPROXY` pattern
-matching this module. Those builds read the tag from the repository and are
-covered by neither the proxy nor the checksum database. (Vendoring is *not* in
-that set — a vendored build uses the checked-in `vendor/` tree without
-fetching, and `go mod vendor` itself downloads through `GOPROXY` like any
-other module command.) Protecting those consumers is what the
-`refs/tags/go/v*` immutability ruleset is for. A bad release ships as a new
-patch version, exactly as it does for the gem.
+That protection is not universal, but the uncovered set is much narrower than
+"anyone not using the proxy", and the two mechanisms have to be kept apart to
+see why. The go command validates downloaded modules against `sum.golang.org`
+**regardless of where they were fetched from**, so bypassing the proxy alone —
+`GOPROXY=direct`, or a `GONOPROXY` pattern — does not bypass verification: a
+moved tag fails the checksum check loudly rather than being accepted.
+
+A mutated tag can only actually reach a consumer whose checksum verification
+is off for this module too: a matching `GOPRIVATE` (which disables both the
+proxy and the database), a matching `GONOSUMDB`, or `GOSUMDB=off` — and even
+then only on a first fetch, since an existing `go.sum` entry pins the hash.
+Vendoring is not in that set either: a vendored build uses the checked-in
+`vendor/` tree without fetching, and `go mod vendor` downloads through
+`GOPROXY` like any other module command.
+
+That residue is small, and it is still the reason the `refs/tags/go/v*`
+immutability ruleset exists — a tag nobody can move is a stronger guarantee
+than one whose consequences depend on each consumer's configuration. A bad
+release ships as a new patch version, exactly as it does for the gem.
 
 ## Recovery
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -97,6 +97,33 @@ The release workflow uses a constant concurrency group
 middle run is silently dropped. Rapid successive release tags are therefore
 prohibited — cut one release, let its run finish, then cut the next.
 
+### Releasing the Go module
+
+Everything above concerns the gem. The Go module at `go/` versions
+independently and has **no publish pipeline**: tagging is the release.
+
+1. On an up-to-date `main` whose CI is green, annotate a tag named
+   `go/vX.Y.Z` — the subdirectory prefix is required by Go's module rules, and
+   the version applies to `go/` only, never to the gem.
+2. Push it. No workflow runs (see the tag ruleset note below); the module
+   becomes fetchable the first time anyone requests it.
+3. Verify from outside the repository, not from the checkout — a working tree
+   proves nothing about what was published:
+
+   ```sh
+   cd "$(mktemp -d)" && go mod init verify
+   go get github.com/basecamp/surfguard/go@vX.Y.Z
+   ```
+
+There is no yank and no re-point. `proxy.golang.org` and `sum.golang.org`
+record the tag's contents permanently on first fetch, so a mutated tag does
+not reach anyone who has already fetched it — and, worse, silently disagrees
+with the checksum database for everyone who has. **Direct-mode consumers
+(`GOFLAGS=-mod=mod GOPRIVATE=…`, vendoring, or any proxy bypass) read the tag
+straight from the repository and are not protected by that caching at all.**
+That is what the `refs/tags/go/v*` immutability ruleset is for. A bad release
+ships as a new patch version, exactly as it does for the gem.
+
 ## Recovery
 
 The registry reconciliation makes re-running a tag's workflow **idempotent**:
@@ -238,10 +265,18 @@ repeated. Replace IDs where noted.
    done
    ```
 
-4. **Tag rulesets** — two separate rulesets on `refs/tags/v*`, enforcement
+4. **Tag rulesets** — two separate rulesets, each matching **both**
+   `refs/tags/v*` (the gem) and `refs/tags/go/v*` (the Go module), enforcement
    `active`: (a) creation restricted, bypass_actors = the release team only
    (`bypass_mode: always`); (b) update + deletion blocked with **no** bypass
-   actors. Read back both, asserting enforcement and bypass lists.
+   actors. Read back both, asserting enforcement, the full include list, and
+   bypass lists.
+
+   A ref-name pattern's `*` does not cross `/`, so `refs/tags/v*` alone matches
+   no `go/` tag at all: listing the Go pattern is what protects those tags, not
+   an extra precaution. The same rule is why a `go/vX.Y.Z` tag does not trigger
+   `release.yml` (`tags: [ "v*" ]`), which is deliberate — the Go module has no
+   publish pipeline to run.
 
 5. **Main branch ruleset** — require PRs (≥ 1 approving review, code-owner
    review, **dismiss stale approvals on push** — the Dependabot automation's

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -115,14 +115,29 @@ independently and has **no publish pipeline**: tagging is the release.
    go get github.com/basecamp/surfguard/go@vX.Y.Z
    ```
 
+**Major version 2 and beyond.** Go requires the major suffix in the module
+path itself, so v2 is not just a different tag: `go/go.mod` must declare
+`module github.com/basecamp/surfguard/go/v2`, the package's own imports and
+the README must use that path, and consumers `go get
+github.com/basecamp/surfguard/go/v2@v2.X.Y`. The repository tag stays
+`go/v2.X.Y` — the `/v2` belongs to the module path, not the tag. Tagging v2
+without moving the module path first produces a tag Go refuses to resolve.
+
 There is no yank and no re-point. `proxy.golang.org` and `sum.golang.org`
 record the tag's contents permanently on first fetch, so a mutated tag does
 not reach anyone who has already fetched it — and, worse, silently disagrees
-with the checksum database for everyone who has. **Direct-mode consumers
-(`GOFLAGS=-mod=mod GOPRIVATE=…`, vendoring, or any proxy bypass) read the tag
-straight from the repository and are not protected by that caching at all.**
-That is what the `refs/tags/go/v*` immutability ruleset is for. A bad release
-ships as a new patch version, exactly as it does for the gem.
+with the checksum database for everyone who has.
+
+That protection is not universal, and the exposed set is narrower than "anyone
+not using the proxy": it is consumers configured to fetch straight from
+version control, meaning `GOPROXY=direct` or a `GOPRIVATE`/`GONOPROXY` pattern
+matching this module. Those builds read the tag from the repository and are
+covered by neither the proxy nor the checksum database. (Vendoring is *not* in
+that set — a vendored build uses the checked-in `vendor/` tree without
+fetching, and `go mod vendor` itself downloads through `GOPROXY` like any
+other module command.) Protecting those consumers is what the
+`refs/tags/go/v*` immutability ruleset is for. A bad release ships as a new
+patch version, exactly as it does for the gem.
 
 ## Recovery
 


### PR DESCRIPTION
The tag rulesets matched `refs/tags/v*` only. A ref-name pattern's `*` does not cross `/`, so that pattern matched **no** `go/` tag — `go/v0.1.0` shipped with neither the creation restriction nor the immutability rule behind it.

Both rulesets now list `refs/tags/go/v*` explicitly (already applied to the live repository; this PR brings the documented one-time setup in line so a rebuild from `RELEASING.md` reproduces it):

```
release-tags-creation:  include=["refs/tags/v*","refs/tags/go/v*"] rules=[creation]        bypass=[always]
release-tags-immutable: include=["refs/tags/v*","refs/tags/go/v*"] rules=[update,deletion] bypass=[]
```

Proxy caching is not a substitute for the ruleset. It pins the contents for anyone who has already fetched, and a mutated tag would disagree with `sum.golang.org` for everyone else — but **direct-mode consumers read the tag straight from the repository and are not covered by it at all**.

`RELEASING.md` described only the gem, which is how the gap survived review in the first place: nothing recorded that the Go module releases by tagging alone — no pipeline, no yank, no re-point. Added a short section covering that, including verifying a release from outside the repository rather than from a working tree, and noting that the same `*`-does-not-cross-`/` rule is why a `go/` tag deliberately does not trigger `release.yml`.

Docs and repository configuration only; no library code changes. Full Ruby suite green (391 runs, 90,964 assertions), including the workflow-policy tests.