### PR TITLE
Make the Go release verification actually depend on fetching

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -108,12 +108,25 @@ independently and has **no publish pipeline**: tagging is the release.
 2. Push it. No workflow runs (see the tag ruleset note below); the module
    becomes fetchable the first time anyone requests it.
 3. Verify from outside the repository, not from the checkout — a working tree
-   proves nothing about what was published:
+   proves nothing about what was published. A throwaway *directory* is not
+   enough either: the module cache is global, so once you have fetched the
+   version even once, `go get` is answered from that cache without contacting
+   anything. Give the check its own `GOMODCACHE`, and pin the public proxy and
+   checksum database so it exercises the path a stranger would take rather
+   than whatever `GOPRIVATE`/`GOPROXY` your shell happens to carry:
 
    ```sh
+   cache="$(mktemp -d)"
    cd "$(mktemp -d)" && go mod init verify
-   go get github.com/basecamp/surfguard/go@vX.Y.Z
+   GOMODCACHE="$cache" GOPROXY=https://proxy.golang.org GOSUMDB=sum.golang.org \
+     go get github.com/basecamp/surfguard/go@vX.Y.Z
+   GOMODCACHE="$cache" go clean -modcache   # cache entries are read-only
    ```
+
+   It must print `go: downloading …`. To confirm the check is honest rather
+   than cached, re-run it with `GOPROXY=off` and a fresh `cache`: that must
+   fail with `module lookup disabled by GOPROXY=off`. If it succeeds, the
+   cache is warm and the verification proved nothing.
 
 **Major version 2 and beyond.** Go requires the major suffix in the module
 path itself, so v2 is not just a different tag: `go/go.mod` must declare

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -108,25 +108,34 @@ independently and has **no publish pipeline**: tagging is the release.
 2. Push it. No workflow runs (see the tag ruleset note below); the module
    becomes fetchable the first time anyone requests it.
 3. Verify from outside the repository, not from the checkout — a working tree
-   proves nothing about what was published. A throwaway *directory* is not
-   enough either: the module cache is global, so once you have fetched the
-   version even once, `go get` is answered from that cache without contacting
-   anything. Give the check its own `GOMODCACHE`, and pin the public proxy and
-   checksum database so it exercises the path a stranger would take rather
-   than whatever `GOPRIVATE`/`GOPROXY` your shell happens to carry:
+   proves nothing about what was published. Two things in your environment
+   will otherwise answer the check for you:
+
+   - **The module cache is global.** A throwaway *directory* is not enough —
+     once you have fetched the version even once, which right after tagging
+     you have, `go get` is served from `GOMODCACHE` without contacting
+     anything. Give the check its own cache.
+   - **`GOPRIVATE` outranks a pinned `GOPROXY`.** It is the default for
+     `GONOPROXY` and `GONOSUMDB`, so a pattern matching this module sends the
+     fetch straight to VCS and skips the checksum database — even with the
+     public proxy named on the command line. Override all three patterns, not
+     just `GOPROXY`/`GOSUMDB`.
 
    ```sh
    cache="$(mktemp -d)"
    cd "$(mktemp -d)" && go mod init verify
-   GOMODCACHE="$cache" GOPROXY=https://proxy.golang.org GOSUMDB=sum.golang.org \
+   GOMODCACHE="$cache" GOPRIVATE= GONOPROXY=none GONOSUMDB=none \
+     GOPROXY=https://proxy.golang.org GOSUMDB=sum.golang.org \
      go get github.com/basecamp/surfguard/go@vX.Y.Z
-   GOMODCACHE="$cache" go clean -modcache   # cache entries are read-only
+   GOMODCACHE="$cache" go clean -modcache
    ```
 
-   It must print `go: downloading …`. To confirm the check is honest rather
-   than cached, re-run it with `GOPROXY=off` and a fresh `cache`: that must
-   fail with `module lookup disabled by GOPROXY=off`. If it succeeds, the
-   cache is warm and the verification proved nothing.
+   It must print `go: downloading …`. Then confirm the check can actually
+   fail, because a verification you have never seen fail is not evidence:
+   re-run it with a fresh `cache` and `GOPROXY=off`, keeping the same three
+   pattern overrides. That must report `module lookup disabled by
+   GOPROXY=off`. If it succeeds, something answered locally — a warm cache, or
+   a `GONOPROXY` pattern reaching VCS — and the positive run proved nothing.
 
 **Major version 2 and beyond.** Go requires the major suffix in the module
 path itself, so v2 is not just a different tag: `go/go.mod` must declare


### PR DESCRIPTION
Follow-up to a P2 that arrived on #18 just after it merged. The finding is correct and I reproduced it.

The documented check created a throwaway *directory* but reused the global module cache. `GOMODCACHE` is shared, so once the version has been fetched even once — which, immediately after tagging, it has — `go get` is answered from cache without contacting anything:

```
$ cd "$(mktemp -d)" && go mod init verify
$ GOPROXY=off go get github.com/basecamp/surfguard/go@v0.1.0
go: added github.com/basecamp/surfguard/go v0.1.0        # succeeded with NO proxy reachable
```

So the step could not have failed for a tag that was missing, unreadable, or never pushed — it was verifying the maintainer's cache, not the release.

The check now gets its own `GOMODCACHE` and pins the public proxy and checksum database, so it exercises the path a stranger takes rather than whatever `GOPRIVATE`/`GOPROXY` the maintainer's shell carries. I also added the falsification step, since a verification you cannot see fail is the thing that just went wrong here: re-run with `GOPROXY=off` and a fresh cache, and it must fail with `module lookup disabled by GOPROXY=off`.

Verified the documented commands verbatim:

```
temp cache + real proxy   -> go: downloading github.com/basecamp/surfguard/go v0.1.0   (succeeds)
temp cache + GOPROXY=off  -> module lookup disabled by GOPROXY=off                     (fails, as it must)
```

**`go/v0.1.0` itself is fine.** Re-verified from a genuinely cold cache: it downloads and records `h1:JMo+MZQEOBRqnUylzD0/jS9S42Fp+XKWMG+4LWfu/XE=`. Only the procedure was unsound, and no retagging is needed.

Docs only. Full Ruby suite green (391 runs, 90,964 assertions).