### PR TITLE
Give the Go module a changelog and a release record

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -102,12 +102,17 @@ prohibited — cut one release, let its run finish, then cut the next.
 Everything above concerns the gem. The Go module at `go/` versions
 independently and has **no publish pipeline**: tagging is the release.
 
-1. On an up-to-date `main` whose CI is green, annotate a tag named
+1. Add the version's entry to `go/CHANGELOG.md` and merge it **before**
+   tagging. A new deny is a minor bump and the entry must name the range and
+   the `conformance/` case, per the promise in `go/README.md` and
+   `conformance/README.md`. Tagging first would ship a version whose only
+   description is the tag message, which nobody reads without a checkout.
+2. On an up-to-date `main` whose CI is green, annotate a tag named
    `go/vX.Y.Z` — the subdirectory prefix is required by Go's module rules, and
    the version applies to `go/` only, never to the gem.
-2. Push it. No workflow runs (see the tag ruleset note below); the module
+3. Push it. No workflow runs (see the tag ruleset note below); the module
    becomes fetchable the first time anyone requests it.
-3. Verify from outside the repository, not from the checkout — a working tree
+4. Verify from outside the repository, not from the checkout — a working tree
    proves nothing about what was published. Two things in your environment
    will otherwise answer the check for you:
 
@@ -136,6 +141,27 @@ independently and has **no publish pipeline**: tagging is the release.
    pattern overrides. That must report `module lookup disabled by
    GOPROXY=off`. If it succeeds, something answered locally — a warm cache, or
    a `GONOPROXY` pattern reaching VCS — and the positive run proved nothing.
+5. Only once step 4 passes, publish a GitHub Release on the tag whose body is
+   the entry from step 1. No pipeline does this — the gem's `github-release`
+   job is bound to `refs/tags/v*` and never sees a `go/` tag — so it is manual,
+   and skipping it leaves a Go consumer with nowhere to read what shipped:
+
+   ```sh
+   version=X.Y.Z
+   # The changelog file is the source; the Release body is a copy of one
+   # section. Read the extract before posting.
+   awk -v v="## v${version} " \
+     'index($0, v) == 1 { f = 1; next } f && /^## / { exit } f' \
+     go/CHANGELOG.md > /tmp/go-notes.md
+   gh release create "go/v${version}" --repo basecamp/surfguard \
+     --title "Surfguard for Go ${version}" --notes-file /tmp/go-notes.md
+   ```
+
+   It comes last because it is the announcement: publishing before step 4 would
+   advertise a version that may not resolve. Unlike the gem's Release, this one
+   carries no digest-verified asset — the module's bytes are whatever the tag
+   contains, and `sum.golang.org`, not this Release, is what attests them.
+   Attach nothing; the Release is the notes only.
 
 **Major version 2 and beyond.** Go requires the major suffix in the module
 path itself, so v2 is not just a different tag: `go/go.mod` must declare

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -43,3 +43,7 @@ whose expectation is the file's contract stated in its `description`.
 
 Policy changes land here and in every implementation in the same commit. A new
 deny is a minor version bump with a prominent changelog entry in each release.
+The implementations version independently, so "each release" means each one's
+own record: `../go/CHANGELOG.md` for the Go module, `../RELEASE_NOTES_X.Y.Z.md`
+for the gem. An entry names the range and the corpus case added here, because
+that is what tells a consumer which host stopped resolving on upgrade.

--- a/go/CHANGELOG.md
+++ b/go/CHANGELOG.md
@@ -1,0 +1,58 @@
+# Changelog — Surfguard for Go
+
+The Go module at `go/` versions independently of the gem. This file is the
+human-readable record for `go/vX.Y.Z` tags; the gem's record is its per-release
+`RELEASE_NOTES_X.Y.Z.md` and GitHub Release. A gem version number never applies
+to this module, and this file never describes gem changes.
+
+**A new deny is a minor version bump with its own entry under a "Policy" heading
+below.** That is the promise `README.md` and `../conformance/README.md` make to
+consumers, and it is what makes an upgrade reviewable: a policy change can turn
+a host that resolved yesterday into `ErrBlocked` today, and the entry is where a
+consumer finds out which one and why. Policy changes land in `conformance/` and
+in both implementations in the same commit, so the entry names the corpus case
+as well as the range.
+
+Each released tag also gets a GitHub Release whose body is the entry below, so
+the record is readable without a checkout — see `../RELEASING.md`.
+
+## v0.1.0 — 2026-08-19
+
+First release of the Go implementation. `github.com/basecamp/surfguard/go`,
+Go 1.23 or newer, zero dependencies (enforced in CI: no `go.sum`, no `require`).
+
+**Policy.** No change. The default policy and `IANASpecialUse()` are the Ruby
+policy of the same commit, generated from the same checked-in IANA snapshots
+under `script/iana/` and asserted against the shared corpus in `conformance/`.
+There is no prior Go release for a range to have been added to.
+
+**Added.**
+
+- Classification — `Blocked(netip.Addr)`, `BlockedHost(string)`. Pure verdicts;
+  invalid, zoned, and malformed input fails closed; never resolves.
+- Resolution — `ResolvePublicAddrs(ctx, host)`, `CheckURL(ctx, url)`. Every
+  answer judged, each address family looked up separately, legacy numeric
+  spellings classified without DNS.
+- Enforcement — `Control`, `ControlContext`, `DialContext`. The literal address
+  of every connect attempt is judged at the moment of connection, so there is no
+  check-to-use gap; legacy-numeric literals are canonicalized before the
+  resolver can see them.
+- Client — `Transport()`, `RoundTripper()`, `Client()`, `CheckRedirect(next)`.
+  Real `net/http` types, `Proxy: nil`, malformed hosts and non-http(s) schemes
+  refused before the transport on the initial request and every hop.
+- Derivations — `Allow`, `Deny`, `AllowLoopback`, `AllowPorts`, `AllowAllPorts`,
+  `MaxRedirects`, `WithResolver`, `IANASpecialUse`.
+- Errors — `ErrBlocked` (`*Violation`) means deactivate the target;
+  `ErrUnresolvable` (`*UnresolvableError`) means retry later. The two are
+  deliberately unrelated and both survive `net/http`'s `url.Error`/`net.OpError`
+  wrapping.
+
+**Divergences from the gem**, deliberate and documented in `README.md`: a
+malformed host in resolution is a `*Violation` rather than a silent empty
+result; legacy numeric parsing uses the module's own `inet_aton` grammar rather
+than the platform resolver; `BlockedHost` classifies a legacy spelling
+authoritatively; the dial layer unmaps IPv4-mapped addresses and judges the
+embedded IPv4, because that is what the kernel connects to.
+
+**Not provided.** No proxy support, no IDN conversion, no response-size limits,
+and no request deadlines beyond the client's 30s timeout.

--- a/go/README.md
+++ b/go/README.md
@@ -184,5 +184,6 @@ passes against a downloaded module zip that contains only files beneath
 `go/`.
 
 Module tags follow the Go subdirectory convention: `go/vX.Y.Z`. New denies
-are a minor bump with a prominent changelog entry; policy changes land in
+are a minor bump with a prominent entry in [`CHANGELOG.md`](CHANGELOG.md),
+which is also the body of the tag's GitHub Release; policy changes land in
 `conformance/` and both implementations in one commit.


### PR DESCRIPTION
`go/README.md` and `conformance/README.md` both promise that a new deny ships "with a prominent changelog entry". Nothing kept that promise, because no CHANGELOG existed anywhere and the Go module has no release-notes mechanism at all: `go/v0.1.0` has no GitHub Release and no notes file, so a Go consumer has nowhere to read what shipped. The gem at least gets a digest-verified `RELEASE_NOTES_X.Y.Z.md` and a Release per tag.

Keeping the promise as written rather than watering the docs down to match the gap.

## Changes

- **`go/CHANGELOG.md`** (new) — retroactive `v0.1.0` entry, plus the change protocol at the top. The entry records what actually shipped at `db0c095` and states plainly that the policy did not change (there is no prior Go release for a range to have been added to), so the first real policy entry has a baseline to be prominent against.
- **`go/README.md`, `conformance/README.md`** — the promise now points at where the entry lives. `conformance/README.md` said "a changelog entry in each release" without saying whose; the implementations version independently, so it now names both records.
- **`RELEASING.md`** — the Go section gains the two missing steps: write the entry *before* tagging, and publish a Release from it *after* the fetch verification passes.

## Two judgment calls

**The Release comes last, after the fetch verification.** It is the announcement; publishing it before the `go get` check would advertise a version that may not resolve. The existing verification step is unchanged and still runs where it did.

**The Go Release carries no asset.** Unlike the gem's, there is nothing to attach and nothing to digest-verify — the module's bytes are whatever the tag contains, and `sum.golang.org` is what attests them. Said outright in `RELEASING.md` so the asymmetry with the gem's Release doesn't read as an omission.

## Verification

- Documentation only. `spec.files` is an explicit allowlist, so nothing here enters a gem byte and the built gem is unchanged.
- The `awk` extraction in `RELEASING.md` was run against the new `go/CHANGELOG.md` (39 lines, correct section, heading excluded since `--title` supplies it).
- Full release `test` job mirrored locally on the pinned Ruby 3.4.10: RuboCop, `COVERAGE=1 rake test` (391 runs, 0 failures; 100.00% line and branch), `check_resolv_version`, `generate_iana_data --check`, and a live `check_iana_drift` — all green.

## Follow-up, not in this PR

The missing GitHub Release for `go/v0.1.0` gets created from this file once it merges.